### PR TITLE
Fix error in documentation about Collection Assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ All of the above assertions can be prefixed with `all*()` to test the contents
 of an array or a `\Traversable`:
 
 ```php
-Assert::allIsInstanceOf('Acme\Employee', $employees);
+Assert::allIsInstanceOf($employees, 'Acme\Employee');
 ```
 
 ### Nullable Assertions


### PR DESCRIPTION
In the example of `Collection Assertions` if I use the function like 

`
Assert::allIsInstanceOf('Acme\Employee', $employees);
`

it throws "Expected a traversable. Got: string".

I have to use like
`
Assert::allIsInstanceOf($employees, 'Acme\Employee');
`