### PR TITLE
Extend array assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,8 @@ Method                                                | Description
 Method                                      | Description
 ------------------------------------------- | --------------------------------------------------
 `keyExists($array, $key, $message = '')`    | Check that a key exists in an array
-`keyNotExists($array, $key, $message = '')` | Check that a key does not exist in an 
-`count($array, $number, $message = '')`     | Check that an array contains specific number of elements
+`keyNotExists($array, $key, $message = '')` | Check that a key does not exist in an array
+`count($array, $number, $message = '')`     | Check that an array contains a specific number of elements
 
 ### Collection Assertions
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ Method                                                | Description
 Method                                      | Description
 ------------------------------------------- | --------------------------------------------------
 `keyExists($array, $key, $message = '')`    | Check that a key exists in an array
-`keyNotExists($array, $key, $message = '')` | Check that a key does not exist in an array
+`keyNotExists($array, $key, $message = '')` | Check that a key does not exist in an 
+`count($array, $number, $message = '')`     | Check that an array contains specific number of elements
 
 ### Collection Assertions
 

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -75,6 +75,7 @@ use Traversable;
  * @method static void nullOrMethodNotExists($value, $method, $message = '')
  * @method static void nullOrKeyExists($value, $key, $message = '')
  * @method static void nullOrKeyNotExists($value, $key, $message = '')
+ * @method static void nullOrCount($value, $key, $message = '')
  * @method static void nullOrUuid($values, $message = '')
  * @method static void allString($values, $message = '')
  * @method static void allStringNotEmpty($values, $message = '')
@@ -135,6 +136,7 @@ use Traversable;
  * @method static void allMethodNotExists($values, $method, $message = '')
  * @method static void allKeyExists($values, $key, $message = '')
  * @method static void allKeyNotExists($values, $key, $message = '')
+ * @method static void allCount($values, $key, $message = '')
  * @method static void allUuid($values, $message = '')
  *
  * @since  1.0
@@ -804,7 +806,7 @@ class Assert
         static::eq(
             count($array),
             $number,
-            $message ?: sprintf('Array should have %d elements, but has %d.', $number, count($array))
+            $message ?: sprintf('Expected an array to contain %d elements. Got: %d.', $number, count($array))
         );
     }
 

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -799,6 +799,15 @@ class Assert
         }
     }
 
+    public static function count($array, $number, $message = '')
+    {
+        static::eq(
+            count($array),
+            $number,
+            $message ?: sprintf('Array should have %d elements, but has %d.', $number, count($array))
+        );
+    }
+
     public static function uuid($value, $message = '')
     {
         $value = str_replace(array('urn:', 'uuid:', '{', '}'), '', $value);

--- a/tests/AssertTest.php
+++ b/tests/AssertTest.php
@@ -275,6 +275,8 @@ class AssertTest extends PHPUnit_Framework_TestCase
             array('keyNotExists', array(array('key' => 0), 'key'), false),
             array('keyNotExists', array(array('key' => null), 'key'), false),
             array('keyNotExists', array(array('key' => null), 'foo'), true),
+            array('count', array(array(0, 1, 2), 3), true),
+            array('count', array(array(0, 1, 2), 2), false),
             array('uuid', array('00000000-0000-0000-0000-000000000000'), true),
             array('uuid', array('ff6f8cb0-c57d-21e1-9b21-0800200c9a66'), true),
             array('uuid', array('ff6f8cb0-c57d-11e1-9b21-0800200c9a66'), true),


### PR DESCRIPTION
Hello everybody!

First of all, I'd like to thank you for the amazing job with this library, it really fits my needs, I get used to use it and don't think I would like to change it at all 😄 

As my contribution for this library development, I would propose introducing some more assertions associated with arrays. Starting from the simple ``Assert::count(...)`` -> from my experience it would be pretty useful, as now to check array length, you must ``eq`` with ``count($array)`` which just looks bad 🐃 

Let me know is it something that could be useful for this library. Thank you for feedback and see ya in code ;)