### PR TITLE
[RFC] add throws assertion

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -14,6 +14,9 @@ namespace Webmozart\Assert;
 use BadMethodCallException;
 use InvalidArgumentException;
 use Traversable;
+use Exception;
+use Throwable;
+use Closure;
 
 /**
  * Efficient assertions to validate the input/output of your methods.
@@ -826,6 +829,32 @@ class Assert
                 static::valueToString($value)
             ));
         }
+    }
+
+    public static function throws(Closure $expression, $class = 'Exception', $message = '')
+    {
+        static::string($class);
+
+        $actual = 'none';
+        try {
+            $expression();
+        } catch (Exception $e) {
+            $actual = get_class($e);
+            if ($e instanceof $class) {
+                return;
+            }
+        } catch (Throwable $e) {
+            $actual = get_class($e);
+            if ($e instanceof $class) {
+                return;
+            }
+        }
+
+        static::reportInvalidArgument($message ?: sprintf(
+            'Expected to throw "%s", got "%s"',
+            $class,
+            $actual
+        ));
     }
 
     public static function __callStatic($name, $arguments)

--- a/tests/AssertTest.php
+++ b/tests/AssertTest.php
@@ -13,6 +13,8 @@ namespace Webmozart\Assert\Tests;
 
 use ArrayIterator;
 use Exception;
+use Error;
+use LogicException;
 use PHPUnit_Framework_TestCase;
 use RuntimeException;
 use stdClass;
@@ -289,7 +291,12 @@ class AssertTest extends PHPUnit_Framework_TestCase
             array('uuid', array('ff6f8cb0-c57da-51e1-9b21-0800200c9a66'), false),
             array('uuid', array('af6f8cb-c57d-11e1-9b21-0800200c9a66'), false),
             array('uuid', array('3f6f8cb0-c57d-11e1-9b21-0800200c9a6'), false),
-
+            array('throws', array(function() { throw new LogicException('test'); }, 'LogicException'), true),
+            array('throws', array(function() { throw new LogicException('test'); }, 'IllogicException'), false),
+            array('throws', array(function() { throw new Exception('test'); }), true),
+            array('throws', array(function() { trigger_error('test'); }, 'Throwable'), true, false, 70000),
+            array('throws', array(function() { trigger_error('test'); }, 'Unthrowable'), false, false, 70000),
+            array('throws', array(function() { throw new Error(); }, 'Throwable'), true, true, 70000),
         );
     }
 
@@ -307,8 +314,13 @@ class AssertTest extends PHPUnit_Framework_TestCase
     /**
      * @dataProvider getTests
      */
-    public function testAssert($method, $args, $success, $multibyte = false)
+    public function testAssert($method, $args, $success, $multibyte = false, $minVersion = null)
     {
+        if ($minVersion && PHP_VERSION_ID < $minVersion) {
+            $this->markTestSkipped(sprintf('This test requires php %s or upper.', $minVersion));
+
+            return;
+        }
         if ($multibyte && !function_exists('mb_strlen')) {
             $this->markTestSkipped('The function mb_strlen() is not available');
 
@@ -325,8 +337,13 @@ class AssertTest extends PHPUnit_Framework_TestCase
     /**
      * @dataProvider getTests
      */
-    public function testNullOr($method, $args, $success, $multibyte = false)
+    public function testNullOr($method, $args, $success, $multibyte = false, $minVersion = null)
     {
+        if ($minVersion && PHP_VERSION_ID < $minVersion) {
+            $this->markTestSkipped(sprintf('This test requires php %s or upper.', $minVersion));
+
+            return;
+        }
         if ($multibyte && !function_exists('mb_strlen')) {
             $this->markTestSkipped('The function mb_strlen() is not available');
 
@@ -351,8 +368,13 @@ class AssertTest extends PHPUnit_Framework_TestCase
     /**
      * @dataProvider getTests
      */
-    public function testAllArray($method, $args, $success, $multibyte = false)
+    public function testAllArray($method, $args, $success, $multibyte = false, $minVersion = null)
     {
+        if ($minVersion && PHP_VERSION_ID < $minVersion) {
+            $this->markTestSkipped(sprintf('This test requires php %s or upper.', $minVersion));
+
+            return;
+        }
         if ($multibyte && !function_exists('mb_strlen')) {
             $this->markTestSkipped('The function mb_strlen() is not available');
 
@@ -372,8 +394,13 @@ class AssertTest extends PHPUnit_Framework_TestCase
     /**
      * @dataProvider getTests
      */
-    public function testAllTraversable($method, $args, $success, $multibyte = false)
+    public function testAllTraversable($method, $args, $success, $multibyte = false, $minVersion = null)
     {
+        if ($minVersion && PHP_VERSION_ID < $minVersion) {
+            $this->markTestSkipped(sprintf('This test requires php %s or upper.', $minVersion));
+
+            return;
+        }
         if ($multibyte && !function_exists('mb_strlen')) {
             $this->markTestSkipped('The function mb_strlen() is not available');
 


### PR DESCRIPTION
hey there!

I was thinking about the simplest way to assert exceptions are thrown and thought it was currently missing.

Do you think it's a viable solution? If so, I'll add some tests.

current usage:

``` php
Assert::throws(function() {
    $this->products->findOrThrow('some-id'), new \LogicException);
}, \LogicException::class);
```

It will only check the exception type right now, not comparing the message.
