### PR TITLE
Add flexibility to report problems in different ways

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -146,7 +146,7 @@ class Assert
     public static function string($value, $message = '')
     {
         if (!is_string($value)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a string. Got: %s',
                 static::typeToString($value)
             ));
@@ -162,7 +162,7 @@ class Assert
     public static function integer($value, $message = '')
     {
         if (!is_int($value)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected an integer. Got: %s',
                 static::typeToString($value)
             ));
@@ -172,7 +172,7 @@ class Assert
     public static function integerish($value, $message = '')
     {
         if (!is_numeric($value) || $value != (int) $value) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected an integerish value. Got: %s',
                 static::typeToString($value)
             ));
@@ -182,7 +182,7 @@ class Assert
     public static function float($value, $message = '')
     {
         if (!is_float($value)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a float. Got: %s',
                 static::typeToString($value)
             ));
@@ -192,7 +192,7 @@ class Assert
     public static function numeric($value, $message = '')
     {
         if (!is_numeric($value)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a numeric. Got: %s',
                 static::typeToString($value)
             ));
@@ -202,7 +202,7 @@ class Assert
     public static function boolean($value, $message = '')
     {
         if (!is_bool($value)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a boolean. Got: %s',
                 static::typeToString($value)
             ));
@@ -212,7 +212,7 @@ class Assert
     public static function scalar($value, $message = '')
     {
         if (!is_scalar($value)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a scalar. Got: %s',
                 static::typeToString($value)
             ));
@@ -222,7 +222,7 @@ class Assert
     public static function object($value, $message = '')
     {
         if (!is_object($value)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected an object. Got: %s',
                 static::typeToString($value)
             ));
@@ -232,14 +232,14 @@ class Assert
     public static function resource($value, $type = null, $message = '')
     {
         if (!is_resource($value)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a resource. Got: %s',
                 static::typeToString($value)
             ));
         }
 
         if ($type && $type !== get_resource_type($value)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a resource of type %2$s. Got: %s',
                 static::typeToString($value),
                 $type
@@ -250,7 +250,7 @@ class Assert
     public static function isCallable($value, $message = '')
     {
         if (!is_callable($value)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a callable. Got: %s',
                 static::typeToString($value)
             ));
@@ -260,7 +260,7 @@ class Assert
     public static function isArray($value, $message = '')
     {
         if (!is_array($value)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected an array. Got: %s',
                 static::typeToString($value)
             ));
@@ -270,7 +270,7 @@ class Assert
     public static function isTraversable($value, $message = '')
     {
         if (!is_array($value) && !($value instanceof Traversable)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a traversable. Got: %s',
                 static::typeToString($value)
             ));
@@ -280,7 +280,7 @@ class Assert
     public static function isInstanceOf($value, $class, $message = '')
     {
         if (!($value instanceof $class)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected an instance of %2$s. Got: %s',
                 static::typeToString($value),
                 $class
@@ -291,7 +291,7 @@ class Assert
     public static function notInstanceOf($value, $class, $message = '')
     {
         if ($value instanceof $class) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected an instance other than %2$s. Got: %s',
                 static::typeToString($value),
                 $class
@@ -302,7 +302,7 @@ class Assert
     public static function isEmpty($value, $message = '')
     {
         if (!empty($value)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected an empty value. Got: %s',
                 static::valueToString($value)
             ));
@@ -312,7 +312,7 @@ class Assert
     public static function notEmpty($value, $message = '')
     {
         if (empty($value)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a non-empty value. Got: %s',
                 static::valueToString($value)
             ));
@@ -322,7 +322,7 @@ class Assert
     public static function null($value, $message = '')
     {
         if (null !== $value) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected null. Got: %s',
                 static::valueToString($value)
             ));
@@ -332,7 +332,7 @@ class Assert
     public static function notNull($value, $message = '')
     {
         if (null === $value) {
-            throw static::createInvalidArgumentException(
+            static::reportInvalidArgument(
                 $message ?: 'Expected a value other than null.'
             );
         }
@@ -341,7 +341,7 @@ class Assert
     public static function true($value, $message = '')
     {
         if (true !== $value) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a value to be true. Got: %s',
                 static::valueToString($value)
             ));
@@ -351,7 +351,7 @@ class Assert
     public static function false($value, $message = '')
     {
         if (false !== $value) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a value to be false. Got: %s',
                 static::valueToString($value)
             ));
@@ -361,7 +361,7 @@ class Assert
     public static function eq($value, $value2, $message = '')
     {
         if ($value2 != $value) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a value equal to %2$s. Got: %s',
                 static::valueToString($value),
                 static::valueToString($value2)
@@ -372,7 +372,7 @@ class Assert
     public static function notEq($value, $value2, $message = '')
     {
         if ($value2 == $value) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a different value than %s.',
                 static::valueToString($value2)
             ));
@@ -382,7 +382,7 @@ class Assert
     public static function same($value, $value2, $message = '')
     {
         if ($value2 !== $value) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a value identical to %2$s. Got: %s',
                 static::valueToString($value),
                 static::valueToString($value2)
@@ -393,7 +393,7 @@ class Assert
     public static function notSame($value, $value2, $message = '')
     {
         if ($value2 === $value) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a value not identical to %s.',
                 static::valueToString($value2)
             ));
@@ -403,7 +403,7 @@ class Assert
     public static function greaterThan($value, $limit, $message = '')
     {
         if ($value <= $limit) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a value greater than %2$s. Got: %s',
                 static::valueToString($value),
                 static::valueToString($limit)
@@ -414,7 +414,7 @@ class Assert
     public static function greaterThanEq($value, $limit, $message = '')
     {
         if ($value < $limit) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a value greater than or equal to %2$s. Got: %s',
                 static::valueToString($value),
                 static::valueToString($limit)
@@ -425,7 +425,7 @@ class Assert
     public static function lessThan($value, $limit, $message = '')
     {
         if ($value >= $limit) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a value less than %2$s. Got: %s',
                 static::valueToString($value),
                 static::valueToString($limit)
@@ -436,7 +436,7 @@ class Assert
     public static function lessThanEq($value, $limit, $message = '')
     {
         if ($value > $limit) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a value less than or equal to %2$s. Got: %s',
                 static::valueToString($value),
                 static::valueToString($limit)
@@ -447,7 +447,7 @@ class Assert
     public static function range($value, $min, $max, $message = '')
     {
         if ($value < $min || $value > $max) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a value between %2$s and %3$s. Got: %s',
                 static::valueToString($value),
                 static::valueToString($min),
@@ -459,7 +459,7 @@ class Assert
     public static function oneOf($value, array $values, $message = '')
     {
         if (!in_array($value, $values, true)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected one of: %2$s. Got: %s',
                 static::valueToString($value),
                 implode(', ', array_map(array('static', 'valueToString'), $values))
@@ -470,7 +470,7 @@ class Assert
     public static function contains($value, $subString, $message = '')
     {
         if (false === strpos($value, $subString)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a value to contain %2$s. Got: %s',
                 static::valueToString($value),
                 static::valueToString($subString)
@@ -481,7 +481,7 @@ class Assert
     public static function startsWith($value, $prefix, $message = '')
     {
         if (0 !== strpos($value, $prefix)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a value to start with %2$s. Got: %s',
                 static::valueToString($value),
                 static::valueToString($prefix)
@@ -501,7 +501,7 @@ class Assert
         }
 
         if (!$valid) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a value to start with a letter. Got: %s',
                 static::valueToString($value)
             ));
@@ -511,7 +511,7 @@ class Assert
     public static function endsWith($value, $suffix, $message = '')
     {
         if ($suffix !== substr($value, -static::strlen($suffix))) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a value to end with %2$s. Got: %s',
                 static::valueToString($value),
                 static::valueToString($suffix)
@@ -522,7 +522,7 @@ class Assert
     public static function regex($value, $pattern, $message = '')
     {
         if (!preg_match($pattern, $value)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'The value %s does not match the expected pattern.',
                 static::valueToString($value)
             ));
@@ -537,7 +537,7 @@ class Assert
         setlocale(LC_CTYPE, $locale);
 
         if ($valid) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a value to contain only letters. Got: %s',
                 static::valueToString($value)
             ));
@@ -552,7 +552,7 @@ class Assert
         setlocale(LC_CTYPE, $locale);
 
         if ($valid) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a value to contain digits only. Got: %s',
                 static::valueToString($value)
             ));
@@ -567,7 +567,7 @@ class Assert
         setlocale(LC_CTYPE, $locale);
 
         if ($valid) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a value to contain letters and digits only. Got: %s',
                 static::valueToString($value)
             ));
@@ -582,7 +582,7 @@ class Assert
         setlocale(LC_CTYPE, $locale);
 
         if ($valid) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a value to contain lowercase characters only. Got: %s',
                 static::valueToString($value)
             ));
@@ -597,7 +597,7 @@ class Assert
         setlocale(LC_CTYPE, $locale);
 
         if ($valid) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a value to contain uppercase characters only. Got: %s',
                 static::valueToString($value)
             ));
@@ -607,7 +607,7 @@ class Assert
     public static function length($value, $length, $message = '')
     {
         if ($length !== static::strlen($value)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a value to contain %2$s characters. Got: %s',
                 static::valueToString($value),
                 $length
@@ -618,7 +618,7 @@ class Assert
     public static function minLength($value, $min, $message = '')
     {
         if (static::strlen($value) < $min) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a value to contain at least %2$s characters. Got: %s',
                 static::valueToString($value),
                 $min
@@ -629,7 +629,7 @@ class Assert
     public static function maxLength($value, $max, $message = '')
     {
         if (static::strlen($value) > $max) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a value to contain at most %2$s characters. Got: %s',
                 static::valueToString($value),
                 $max
@@ -642,7 +642,7 @@ class Assert
         $length = static::strlen($value);
 
         if ($length < $min || $length > $max) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a value to contain between %2$s and %3$s characters. Got: %s',
                 static::valueToString($value),
                 $min,
@@ -656,7 +656,7 @@ class Assert
         static::string($value);
 
         if (!file_exists($value)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'The file %s does not exist.',
                 static::valueToString($value)
             ));
@@ -668,7 +668,7 @@ class Assert
         static::fileExists($value, $message);
 
         if (!is_file($value)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'The path %s is not a file.',
                 static::valueToString($value)
             ));
@@ -680,7 +680,7 @@ class Assert
         static::fileExists($value, $message);
 
         if (!is_dir($value)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'The path %s is no directory.',
                 static::valueToString($value)
             ));
@@ -690,7 +690,7 @@ class Assert
     public static function readable($value, $message = '')
     {
         if (!is_readable($value)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'The path %s is not readable.',
                 static::valueToString($value)
             ));
@@ -700,7 +700,7 @@ class Assert
     public static function writable($value, $message = '')
     {
         if (!is_writable($value)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'The path %s is not writable.',
                 static::valueToString($value)
             ));
@@ -710,7 +710,7 @@ class Assert
     public static function classExists($value, $message = '')
     {
         if (!class_exists($value)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected an existing class name. Got: %s',
                 static::valueToString($value)
             ));
@@ -720,7 +720,7 @@ class Assert
     public static function subclassOf($value, $class, $message = '')
     {
         if (!is_subclass_of($value, $class)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a sub-class of %2$s. Got: %s',
                 static::valueToString($value),
                 static::valueToString($class)
@@ -731,7 +731,7 @@ class Assert
     public static function implementsInterface($value, $interface, $message = '')
     {
         if (!in_array($interface, class_implements($value))) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected an implementation of %2$s. Got: %s',
                 static::valueToString($value),
                 static::valueToString($interface)
@@ -742,7 +742,7 @@ class Assert
     public static function propertyExists($classOrObject, $property, $message = '')
     {
         if (!property_exists($classOrObject, $property)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected the property %s to exist.',
                 static::valueToString($property)
             ));
@@ -752,7 +752,7 @@ class Assert
     public static function propertyNotExists($classOrObject, $property, $message = '')
     {
         if (property_exists($classOrObject, $property)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected the property %s to not exist.',
                 static::valueToString($property)
             ));
@@ -762,7 +762,7 @@ class Assert
     public static function methodExists($classOrObject, $method, $message = '')
     {
         if (!method_exists($classOrObject, $method)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected the method %s to exist.',
                 static::valueToString($method)
             ));
@@ -772,7 +772,7 @@ class Assert
     public static function methodNotExists($classOrObject, $method, $message = '')
     {
         if (method_exists($classOrObject, $method)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected the method %s to not exist.',
                 static::valueToString($method)
             ));
@@ -782,7 +782,7 @@ class Assert
     public static function keyExists($array, $key, $message = '')
     {
         if (!array_key_exists($key, $array)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected the key %s to exist.',
                 static::valueToString($key)
             ));
@@ -792,7 +792,7 @@ class Assert
     public static function keyNotExists($array, $key, $message = '')
     {
         if (array_key_exists($key, $array)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected the key %s to not exist.',
                 static::valueToString($key)
             ));
@@ -810,7 +810,7 @@ class Assert
         }
 
         if (!preg_match('/^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/', $value)) {
-            throw static::createInvalidArgumentException(sprintf(
+            static::reportInvalidArgument(sprintf(
                 $message ?: 'Value %s is not a valid UUID.',
                 static::valueToString($value)
             ));
@@ -897,9 +897,9 @@ class Assert
         return mb_strwidth($value, $encoding);
     }
 
-    protected static function createInvalidArgumentException($message)
+    protected static function reportInvalidArgument($message)
     {
-        return new InvalidArgumentException($message);
+        throw new InvalidArgumentException($message);
     }
 
     private function __construct()


### PR DESCRIPTION
Hi !

Further extending of #19 to allow report a problem in different ways via extending the class, while default behaviour is not changed.

Use case - I have a library used with a lot of messy, invalid input from it's users that needs to be fixed by the users of library.
When I do the assertions that raising the exceptions - it will crash their app. So far even if their input is not perfect, it works somehow (not in the best way, but at least some functionality is working due to autoconverting).

The goal is to be strict and raise an exception when user of lib will pass invalid input. But as a middle step I want to make extra release which will just warn him (like triggering a warning instead of breaking the flow with exception).
Currently one can't override the library to do anything else than raising an exception. With this change it would become possible.

What do you think @webmozart ?