### PR TITLE
introduce isIterable, deprecate isTraversable

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -274,9 +274,27 @@ class Assert
 
     public static function isTraversable($value, $message = '')
     {
+        @trigger_error(
+            sprintf(
+                'The "%s" assertion is deprecated. You should stop using it, as it will soon be removed in 2.0 version. Use "isIterable" or "isInstanceOf" instead.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
         if (!is_array($value) && !($value instanceof Traversable)) {
             static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a traversable. Got: %s',
+                static::typeToString($value)
+            ));
+        }
+    }
+
+    public static function isIterable($value, $message = '')
+    {
+        if (!is_array($value) && !($value instanceof Traversable)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected an iterable. Got: %s',
                 static::typeToString($value)
             ));
         }
@@ -869,7 +887,7 @@ class Assert
         }
 
         if ('all' === substr($name, 0, 3)) {
-            static::isTraversable($arguments[0]);
+            static::isIterable($arguments[0]);
 
             $method = lcfirst(substr($name, 3));
             $args = $arguments;

--- a/tests/AssertTest.php
+++ b/tests/AssertTest.php
@@ -106,6 +106,11 @@ class AssertTest extends PHPUnit_Framework_TestCase
             array('isTraversable', array(new ArrayIterator(array())), true),
             array('isTraversable', array(123), false),
             array('isTraversable', array(new stdClass()), false),
+            array('isIterable', array(array()), true),
+            array('isIterable', array(array(1, 2, 3)), true),
+            array('isIterable', array(new ArrayIterator(array())), true),
+            array('isIterable', array(123), false),
+            array('isIterable', array(new stdClass()), false),
             array('isInstanceOf', array(new stdClass(), 'stdClass'), true),
             array('isInstanceOf', array(new Exception(), 'stdClass'), false),
             array('isInstanceOf', array(123, 'stdClass'), false),
@@ -323,8 +328,6 @@ class AssertTest extends PHPUnit_Framework_TestCase
         }
         if ($multibyte && !function_exists('mb_strlen')) {
             $this->markTestSkipped('The function mb_strlen() is not available');
-
-            return;
         }
 
         if (!$success) {
@@ -346,8 +349,6 @@ class AssertTest extends PHPUnit_Framework_TestCase
         }
         if ($multibyte && !function_exists('mb_strlen')) {
             $this->markTestSkipped('The function mb_strlen() is not available');
-
-            return;
         }
 
         if (!$success && null !== reset($args)) {
@@ -377,8 +378,6 @@ class AssertTest extends PHPUnit_Framework_TestCase
         }
         if ($multibyte && !function_exists('mb_strlen')) {
             $this->markTestSkipped('The function mb_strlen() is not available');
-
-            return;
         }
 
         if (!$success) {
@@ -403,8 +402,6 @@ class AssertTest extends PHPUnit_Framework_TestCase
         }
         if ($multibyte && !function_exists('mb_strlen')) {
             $this->markTestSkipped('The function mb_strlen() is not available');
-
-            return;
         }
 
         if (!$success) {


### PR DESCRIPTION
`isTraversable` accepts `array`, while it should not. Currently, it acts like `isIterable` from PHP 7.1.
it is very misleading
