### PR TITLE
Tweak "issue tracker" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ All contents of this package are licensed under the [MIT license].
 [Composer]: https://getcomposer.org
 [Bernhard Schussek]: http://webmozarts.com
 [The Community Contributors]: https://github.com/webmozart/assert/graphs/contributors
-[issue tracker]: https://github.com/webmozart/assert
+[issue tracker]: https://github.com/webmozart/assert/issues
 [Git repository]: https://github.com/webmozart/assert
 [@webmozart]: https://twitter.com/webmozart
 [MIT license]: LICENSE


### PR DESCRIPTION
The issue tracker link in the README.md file simply went to the GitHub repo, which (if you were already there) could be slightly confusing. Making the link go to the actual list of issues seems more useful.