### PR TITLE
Add array accessible assertion

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -11,6 +11,7 @@
 
 namespace Webmozart\Assert;
 
+use ArrayAccess;
 use BadMethodCallException;
 use InvalidArgumentException;
 use Traversable;
@@ -34,6 +35,7 @@ use Closure;
  * @method static void nullOrIsCallable($value, $message = '')
  * @method static void nullOrIsArray($value, $message = '')
  * @method static void nullOrIsTraversable($value, $message = '')
+ * @method static void nullOrIsArrayAccessible($value, $message = '')
  * @method static void nullOrIsInstanceOf($value, $class, $message = '')
  * @method static void nullOrNotInstanceOf($value, $class, $message = '')
  * @method static void nullOrIsEmpty($value, $message = '')
@@ -93,6 +95,7 @@ use Closure;
  * @method static void allIsCallable($values, $message = '')
  * @method static void allIsArray($values, $message = '')
  * @method static void allIsTraversable($values, $message = '')
+ * @method static void allIsArrayAccessible($values, $message = '')
  * @method static void allIsInstanceOf($values, $class, $message = '')
  * @method static void allNotInstanceOf($values, $class, $message = '')
  * @method static void allNull($values, $message = '')
@@ -277,6 +280,16 @@ class Assert
         if (!is_array($value) && !($value instanceof Traversable)) {
             static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a traversable. Got: %s',
+                static::typeToString($value)
+            ));
+        }
+    }
+
+    public static function isArrayAccessible($value, $message = '')
+    {
+        if (!is_array($value) && !($value instanceof ArrayAccess)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected an array accessible. Got: %s',
                 static::typeToString($value)
             ));
         }

--- a/tests/AssertTest.php
+++ b/tests/AssertTest.php
@@ -12,6 +12,7 @@
 namespace Webmozart\Assert\Tests;
 
 use ArrayIterator;
+use ArrayObject;
 use Exception;
 use Error;
 use LogicException;
@@ -106,6 +107,11 @@ class AssertTest extends PHPUnit_Framework_TestCase
             array('isTraversable', array(new ArrayIterator(array())), true),
             array('isTraversable', array(123), false),
             array('isTraversable', array(new stdClass()), false),
+            array('isArrayAccessible', array(array()), true),
+            array('isArrayAccessible', array(array(1, 2, 3)), true),
+            array('isArrayAccessible', array(new ArrayObject(array())), true),
+            array('isArrayAccessible', array(123), false),
+            array('isArrayAccessible', array(new stdClass()), false),
             array('isInstanceOf', array(new stdClass(), 'stdClass'), true),
             array('isInstanceOf', array(new Exception(), 'stdClass'), false),
             array('isInstanceOf', array(123, 'stdClass'), false),


### PR DESCRIPTION
This would allow simpler check of whether an argument can be accessed like an array.

This PR is very close to `isTraversable` implementation as it comes from the very same root.