### PR TITLE
Use array_key_exists with isset for perfomance

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -888,7 +888,7 @@ class Assert
 
     public static function keyExists($array, $key, $message = '')
     {
-        if (!isset($search[$key]) && !array_key_exists($key, $array)) {
+        if (!isset($array[$key]) && !array_key_exists($key, $array)) {
             static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected the key %s to exist.',
                 static::valueToString($key)
@@ -898,7 +898,7 @@ class Assert
 
     public static function keyNotExists($array, $key, $message = '')
     {
-        if (isset($search[$key]) || array_key_exists($key, $array)) {
+        if (isset($array[$key]) || array_key_exists($key, $array)) {
             static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected the key %s to not exist.',
                 static::valueToString($key)

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -888,7 +888,7 @@ class Assert
 
     public static function keyExists($array, $key, $message = '')
     {
-        if (!array_key_exists($key, $array)) {
+        if (!(isset($array[$key]) || array_key_exists($key, $array))) {
             static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected the key %s to exist.',
                 static::valueToString($key)

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -888,7 +888,7 @@ class Assert
 
     public static function keyExists($array, $key, $message = '')
     {
-        if (!isset($array[$key]) || !array_key_exists($key, $array)) {
+        if (!array_key_exists($key, $array)) {
             static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected the key %s to exist.',
                 static::valueToString($key)

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -888,7 +888,7 @@ class Assert
 
     public static function keyExists($array, $key, $message = '')
     {
-        if (!isset($array[$key]) && !array_key_exists($key, $array)) {
+        if (!isset($array[$key]) || !array_key_exists($key, $array)) {
             static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected the key %s to exist.',
                 static::valueToString($key)

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -888,7 +888,7 @@ class Assert
 
     public static function keyExists($array, $key, $message = '')
     {
-        if (!array_key_exists($key, $array)) {
+        if (!isset($search[$key]) && !array_key_exists($key, $array)) {
             static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected the key %s to exist.',
                 static::valueToString($key)
@@ -898,7 +898,7 @@ class Assert
 
     public static function keyNotExists($array, $key, $message = '')
     {
-        if (array_key_exists($key, $array)) {
+        if (isset($search[$key]) || array_key_exists($key, $array)) {
             static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected the key %s to not exist.',
                 static::valueToString($key)


### PR DESCRIPTION
`isset` is much faster than `array_key_exists`, but isset doesnt detect NULL values correctly. So combination of both functions do the trick for perfomance. More info: http://php.net/manual/en/function.array-key-exists.php#107786