### PR TITLE
Require a polyfill for ctype

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         }
     ],
     "require": {
-        "php": "^5.3.3 || ^7.0"
+        "php": "^5.3.3 || ^7.0",
+        "symfony/polyfill-ctype": "^1.8"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.6",


### PR DESCRIPTION
`ctype_` functions are used multiple times in the project, if the extension is not available this may lead to hard to debug error messages.

Another option would be to require the ext-ctype, or refactor all ctype_ functions away, which is a bit of a hassle, and slower.