### PR TITLE
Assert::uniqueValues($values, $message = '')

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Method                                                   | Description
 `isInstanceOfAny($value, array $classes, $message = '')` | Check that a value is an `instanceof` a at least one class on the array of classes
 `notInstanceOf($value, $class, $message = '')`           | Check that a value is not an `instanceof` a class
 `isArrayAccessible($value, $message = '')`               | Check that a value can be accessed as an array
+`uniqueValues($values, $message = '')`                   | Check that the given array contains unique values
 
 ### Comparison Assertions
 
@@ -155,7 +156,6 @@ Method                                              | Description
 `ip($value, $message = '')`                         | Check that a string is a valid IP (either IPv4 or IPv6)
 `ipv4($value, $message = '')`                       | Check that a string is a valid IPv4
 `ipv6($value, $message = '')`                       | Check that a string is a valid IPv6
-`uniqueValues($values, $message = '')`              | Check that the given array contains unique values
 `notWhitespaceOnly($value, $message = '')`          | Check that a string contains at least one non-whitespace character
 
 ### File Assertions

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Method                                              | Description
 `ip($value, $message = '')`                         | Check that a string is a valid IP (either IPv4 or IPv6)
 `ipv4($value, $message = '')`                       | Check that a string is a valid IPv4
 `ipv6($value, $message = '')`                       | Check that a string is a valid IPv6
+`uniqueValues($values, $message = '')`              | Check that the given array contains unique values
 `notWhitespaceOnly($value, $message = '')`          | Check that a string contains at least one non-whitespace character
 
 ### File Assertions

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -509,10 +509,12 @@ class Assert
         }
 
         if (!empty($nonUniqueValues)) {
+            $countNonUniqueValues = count($nonUniqueValues);
+
             static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected an array of unique values, but %s %s duplicated: %s',
-                count($nonUniqueValues),
-                (1 === count($nonUniqueValues) ? 'is' : 'are'),
+                $countNonUniqueValues,
+                (1 === $countNonUniqueValues ? 'is' : 'are'),
                 implode(', ', $nonUniqueValues)
             ));
         }

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -50,6 +50,7 @@ use Traversable;
  * @method static void nullOrIp($value, $message = '')
  * @method static void nullOrIpv4($value, $message = '')
  * @method static void nullOrIpv6($value, $message = '')
+ * @method static void nullOrUniqueValues($values, $message = '')
  * @method static void nullOrEq($value, $value2, $message = '')
  * @method static void nullOrNotEq($value,$value2,  $message = '')
  * @method static void nullOrSame($value, $value2, $message = '')
@@ -129,6 +130,7 @@ use Traversable;
  * @method static void allIp($values, $message = '')
  * @method static void allIpv4($values, $message = '')
  * @method static void allIpv6($values, $message = '')
+ * @method static void allUniqueValues($values, $message = '')
  * @method static void allEq($values, $value2, $message = '')
  * @method static void allNotEq($values,$value2,  $message = '')
  * @method static void allSame($values, $value2, $message = '')
@@ -490,6 +492,28 @@ class Assert
             static::reportInvalidArgument(sprintf(
                 $message ?: 'Expected a value to be an IPv6. Got %s',
                 static::valueToString($value)
+            ));
+        }
+    }
+
+    public static function uniqueValues(array $values, $message = '')
+    {
+        $countValues = array_count_values($values);
+
+        $nonUniqueValues = array();
+
+        foreach ($countValues as $value => $count) {
+            if ($count > 1) {
+                array_push($nonUniqueValues, $nonUniqueValues);
+            }
+        }
+
+        if (!empty($nonUniqueValues)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected an array of unique values, but %s %s duplicated: %s',
+                count($nonUniqueValues),
+                (1 === count($nonUniqueValues) ? 'is' : 'are'),
+                implode(', ', $nonUniqueValues)
             ));
         }
     }

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -498,24 +498,16 @@ class Assert
 
     public static function uniqueValues(array $values, $message = '')
     {
-        $countValues = array_count_values($values);
+        $allValues = count($values);
+        $uniqueValues = count(array_unique($values));
 
-        $nonUniqueValues = array();
-
-        foreach ($countValues as $value => $count) {
-            if ($count > 1) {
-                array_push($nonUniqueValues, $value);
-            }
-        }
-
-        if (!empty($nonUniqueValues)) {
-            $countNonUniqueValues = count($nonUniqueValues);
+        if ($allValues !== $uniqueValues) {
+            $difference = $allValues - $uniqueValues;
 
             static::reportInvalidArgument(sprintf(
-                $message ?: 'Expected an array of unique values, but %s %s duplicated: %s',
-                $countNonUniqueValues,
-                (1 === $countNonUniqueValues ? 'is' : 'are'),
-                implode(', ', $nonUniqueValues)
+                $message ?: 'Expected an array of unique values, but %s of them %s duplicated',
+                $difference,
+                (1 === $difference ? 'is' : 'are')
             ));
         }
     }

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -504,7 +504,7 @@ class Assert
 
         foreach ($countValues as $value => $count) {
             if ($count > 1) {
-                array_push($nonUniqueValues, $nonUniqueValues);
+                array_push($nonUniqueValues, $value);
             }
         }
 

--- a/tests/AssertTest.php
+++ b/tests/AssertTest.php
@@ -401,6 +401,7 @@ class AssertTest extends PHPUnit_Framework_TestCase
             array('ipv6', array(false), false),
             array('uniqueValues', array(array('qwerty', 'qwerty')), false),
             array('uniqueValues', array(array('asdfg', 'qwerty')), true),
+            array('uniqueValues', array(array(123, '123')), false),
         );
     }
 

--- a/tests/AssertTest.php
+++ b/tests/AssertTest.php
@@ -399,6 +399,8 @@ class AssertTest extends PHPUnit_Framework_TestCase
             array('ipv6', array(array()), false),
             array('ipv6', array(null), false),
             array('ipv6', array(false), false),
+            array('uniqueValues', array(array('qwerty', 'qwerty')), false),
+            array('uniqueValues', array(array('asdfg', 'qwerty')), true),
         );
     }
 


### PR DESCRIPTION
This should fix https://github.com/webmozart/assert/issues/50

----

https://secure.php.net/manual/en/language.types.iterable.php
```
Iterable is a pseudo-type introduced in PHP 7.1
```
Given this repo needs to keep compatibility with previous PHP versions, then we can't use `iterable` but `array`