### PR TITLE
Allow a custom exception class to be thrown.

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,26 @@ assertion only if it the value is not `null`:
 Assert::nullOrString($middleName, 'The middle name must be a string or null. Got: %s');
 ```
 
+
+Project-Specific Exception
+--------------------------
+
+Instead of the default SPL `\InvalidArgumentException` that is thrown when an exception fails, you can override that with a project-specific exception class. (Inspired by [beberlei/assert])
+
+```php
+<?php
+
+namespace MyProject\Namespace;
+
+use Webmozart\Assert\Assert as BaseAssert;
+
+class Assert extends BaseAssert
+{
+    protected static $exceptionClass = 'MyProject\Namespace\ProjectSpecificException';
+}
+```
+
+
 Authors
 -------
 

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -186,6 +186,15 @@ use Traversable;
  */
 class Assert
 {
+    /**
+     * Class name of the exception to throw when an assertion failed.
+     *
+     * The exception to be thrown, can be overwritten in a project-specific Assert class that extends from this class.
+     *
+     * @var string
+     */
+    protected static $exceptionClass = 'InvalidArgumentException';
+
     public static function string($value, $message = '')
     {
         if (!is_string($value)) {
@@ -1178,7 +1187,9 @@ class Assert
 
     protected static function reportInvalidArgument($message)
     {
-        throw new InvalidArgumentException($message);
+        $exceptionClass = static::$exceptionClass;
+
+        throw new $exceptionClass($message);
     }
 
     private function __construct()

--- a/tests/CustomExceptionClassTest.php
+++ b/tests/CustomExceptionClassTest.php
@@ -12,10 +12,10 @@
 
 namespace Webmozart\Assert\Tests {
 
-    use PHPUnit\Framework\TestCase;
+    use PHPUnit_Framework_TestCase;
     use Webmozart\Assert\MyProjectNamespace\Assert;
 
-    class CustomExceptionClassTest extends TestCase
+    class CustomExceptionClassTest extends PHPUnit_Framework_TestCase
     {
         public function testCustomException()
         {

--- a/tests/CustomExceptionClassTest.php
+++ b/tests/CustomExceptionClassTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the webmozart/assert package.
+ *
+ * (c) Bernhard Schussek <bschussek@gmail.com>
+ * (c) Thomas Nunninger <thomas.nunninger@saleupventures.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Webmozart\Assert\Tests {
+
+    use PHPUnit\Framework\TestCase;
+    use Webmozart\Assert\MyProjectNamespace\Assert;
+
+    class CustomExceptionClassTest extends TestCase
+    {
+        public function testCustomException()
+        {
+            // given a project-specific, custom extension of the Assert class as included via the use statement
+
+            // when an assertion fails
+            // then a custom exception is thrown
+            $this->setExpectedException(
+                'Webmozart\Assert\MyProjectNamespace\ProjectSpecificException',
+                'Custom exception message. Expected: "this is". Given: "not the same".'
+            );
+
+            Assert::same('this is', 'not the same', 'Custom exception message. Expected: %1$s. Given: %2$s.');
+        }
+    }
+
+}
+
+namespace Webmozart\Assert\MyProjectNamespace {
+
+    use Webmozart\Assert\Assert as BaseAssert;
+
+    class Assert extends BaseAssert
+    {
+        protected static $exceptionClass = 'Webmozart\Assert\MyProjectNamespace\ProjectSpecificException';
+    }
+
+    class ProjectSpecificException extends \InvalidArgumentException
+    {
+    }
+}


### PR DESCRIPTION
Inspired by beberlei/assert, I implemented a possibility to throw a project-specific exception class instead of `\InvalidArgumentException`.

Why is that useful:

* If you have a main project that uses several libraries, where the libraries override the default exception by a project-specific exception, in the main project you can differentiate the exceptions that are thrown from different libraries.

* Some static code style checkers criticize if you throw standard exceptions. By overriding the default exception you can comply with the project's coding style.

State:

* Tested with PHP 7.2 on Ubuntu 18.10, should hopefully work with PHP 5.3.3 as well.

* Test can be found in `tests/CustomExceptionClassTest.php`.

* Feel free to change it or ask for changes.