### PR TITLE
WIP: psalm-specific annotations for restricting post-assertion value types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
         "symfony/polyfill-ctype": "^1.8"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.6",
-        "sebastian/version": "^1.0.1"
+        "phpunit/phpunit": "^8.1.6",
+        "vimeo/psalm": "^3.4"
     },
     "extra": {
         "branch-alias": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="static-analysis" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+
+<!--    <issueHandlers>-->
+<!--        -->
+<!--        <LessSpecificReturnType errorLevel="info" />-->
+
+<!--        &lt;!&ndash; level 3 issues - slightly lazy code writing, but provably low false-negatives &ndash;&gt;-->
+
+<!--        <DeprecatedMethod errorLevel="info" />-->
+<!--        <DeprecatedProperty errorLevel="info" />-->
+<!--        <DeprecatedClass errorLevel="info" />-->
+<!--        <DeprecatedConstant errorLevel="info" />-->
+<!--        <DeprecatedInterface errorLevel="info" />-->
+<!--        <DeprecatedTrait errorLevel="info" />-->
+
+<!--        <InternalMethod errorLevel="info" />-->
+<!--        <InternalProperty errorLevel="info" />-->
+<!--        <InternalClass errorLevel="info" />-->
+
+<!--        <MissingClosureReturnType errorLevel="info" />-->
+<!--        <MissingReturnType errorLevel="info" />-->
+<!--        <MissingPropertyType errorLevel="info" />-->
+<!--        <InvalidDocblock errorLevel="info" />-->
+<!--        <MisplacedRequiredParam errorLevel="info" />-->
+
+<!--        <PropertyNotSetInConstructor errorLevel="info" />-->
+<!--        <MissingConstructor errorLevel="info" />-->
+<!--        <MissingClosureParamType errorLevel="info" />-->
+<!--        <MissingParamType errorLevel="info" />-->
+
+<!--        <RedundantCondition errorLevel="info" />-->
+
+<!--        <DocblockTypeContradiction errorLevel="info" />-->
+<!--        <RedundantConditionGivenDocblockType errorLevel="info" />-->
+
+<!--        <UnresolvableInclude errorLevel="info" />-->
+
+<!--        <RawObjectIteration errorLevel="info" />-->
+
+<!--        <InvalidStringClass errorLevel="info" />-->
+<!--    </issueHandlers>-->
+</psalm>

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -188,6 +188,9 @@ use Traversable;
  */
 class Assert
 {
+    /**
+     * @psalm-assert string $value
+     */
     public static function string($value, $message = '')
     {
         if (!is_string($value)) {
@@ -198,12 +201,18 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert string $value
+     */
     public static function stringNotEmpty($value, $message = '')
     {
         static::string($value, $message);
         static::notEq($value, '', $message);
     }
 
+    /**
+     * @psalm-assert int $value
+     */
     public static function integer($value, $message = '')
     {
         if (!is_int($value)) {
@@ -214,6 +223,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert numeric $value
+     */
     public static function integerish($value, $message = '')
     {
         if (!is_numeric($value) || $value != (int) $value) {
@@ -224,6 +236,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert float $value
+     */
     public static function float($value, $message = '')
     {
         if (!is_float($value)) {
@@ -234,6 +249,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert numeric $value
+     */
     public static function numeric($value, $message = '')
     {
         if (!is_numeric($value)) {
@@ -244,6 +262,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert int $value
+     */
     public static function natural($value, $message = '')
     {
         if (!is_int($value) || $value < 0) {
@@ -254,6 +275,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert bool $value
+     */
     public static function boolean($value, $message = '')
     {
         if (!is_bool($value)) {
@@ -264,6 +288,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert scalar $value
+     */
     public static function scalar($value, $message = '')
     {
         if (!is_scalar($value)) {
@@ -274,6 +301,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert object $value
+     */
     public static function object($value, $message = '')
     {
         if (!is_object($value)) {
@@ -284,6 +314,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert resource $value
+     */
     public static function resource($value, $type = null, $message = '')
     {
         if (!is_resource($value)) {
@@ -302,6 +335,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert callable $value
+     */
     public static function isCallable($value, $message = '')
     {
         if (!is_callable($value)) {
@@ -312,6 +348,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert array $value
+     */
     public static function isArray($value, $message = '')
     {
         if (!is_array($value)) {
@@ -322,6 +361,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert iterable $value
+     */
     public static function isTraversable($value, $message = '')
     {
         @trigger_error(
@@ -340,6 +382,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert (array|ArrayAccess) $value
+     */
     public static function isArrayAccessible($value, $message = '')
     {
         if (!is_array($value) && !($value instanceof ArrayAccess)) {
@@ -350,6 +395,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert (array|Countable) $value
+     */
     public static function isCountable($value, $message = '')
     {
         if (!is_array($value) && !($value instanceof Countable)) {
@@ -360,6 +408,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert iterable $value
+     */
     public static function isIterable($value, $message = '')
     {
         if (!is_array($value) && !($value instanceof Traversable)) {
@@ -370,6 +421,11 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-template ExpectedType of object
+     * @psalm-param class-string<ExpectedType> $class
+     * @psalm-assert ExpectedType $value
+     */
     public static function isInstanceOf($value, $class, $message = '')
     {
         if (!($value instanceof $class)) {
@@ -381,6 +437,11 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-template ExpectedType of object
+     * @psalm-param class-string<ExpectedType> $class
+     * @psalm-assert !ExpectedType $value
+     */
     public static function notInstanceOf($value, $class, $message = '')
     {
         if ($value instanceof $class) {
@@ -391,7 +452,11 @@ class Assert
             ));
         }
     }
-
+    /**
+     * @psalm-template ExpectedType
+     * @psalm-param array<class-string<ExpectedType>> $classes
+     * @psalm-assert ExpectedType $value
+     */
     public static function isInstanceOfAny($value, array $classes, $message = '')
     {
         foreach ($classes as $class) {
@@ -407,6 +472,9 @@ class Assert
         ));
     }
 
+    /**
+     * @psalm-assert empty $value
+     */
     public static function isEmpty($value, $message = '')
     {
         if (!empty($value)) {
@@ -417,6 +485,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert !empty $value
+     */
     public static function notEmpty($value, $message = '')
     {
         if (empty($value)) {
@@ -427,6 +498,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert null $value
+     */
     public static function null($value, $message = '')
     {
         if (null !== $value) {
@@ -437,6 +511,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert !null $value
+     */
     public static function notNull($value, $message = '')
     {
         if (null === $value) {
@@ -446,6 +523,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert true $value
+     */
     public static function true($value, $message = '')
     {
         if (true !== $value) {
@@ -456,6 +536,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert false $value
+     */
     public static function false($value, $message = '')
     {
         if (false !== $value) {
@@ -466,6 +549,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert string $value
+     */
     public static function ip($value, $message = '')
     {
         if (false === filter_var($value, FILTER_VALIDATE_IP)) {
@@ -476,6 +562,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert string $value
+     */
     public static function ipv4($value, $message = '')
     {
         if (false === filter_var($value, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
@@ -486,6 +575,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert string $value
+     */
     public static function ipv6($value, $message = '')
     {
         if (false === filter_var($value, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
@@ -533,6 +625,11 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-template ExpectedType
+     * @psalm-param ExpectedType $expect
+     * @psalm-assert =ExpectedType $value
+     */
     public static function same($value, $expect, $message = '')
     {
         if ($expect !== $value) {
@@ -610,6 +707,11 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-template ExpectedType
+     * @psalm-param array<ExpectedType> $values
+     * @psalm-assert ExpectedType $value
+     */
     public static function oneOf($value, array $values, $message = '')
     {
         if (!in_array($value, $values, true)) {
@@ -716,6 +818,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert !numeric $value
+     */
     public static function alpha($value, $message = '')
     {
         $locale = setlocale(LC_CTYPE, 0);
@@ -731,6 +836,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert numeric $value
+     */
     public static function digits($value, $message = '')
     {
         $locale = setlocale(LC_CTYPE, 0);
@@ -894,6 +1002,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert class-string $value
+     */
     public static function classExists($value, $message = '')
     {
         if (!class_exists($value)) {
@@ -904,6 +1015,11 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-template ExpectedType of object
+     * @psalm-param class-string<ExpectedType> $class
+     * @psalm-assert ExpectedType|class-string<ExpectedType> $value
+     */
     public static function subclassOf($value, $class, $message = '')
     {
         if (!is_subclass_of($value, $class)) {
@@ -915,6 +1031,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert class-string $value
+     */
     public static function interfaceExists($value, $message = '')
     {
         if (!interface_exists($value)) {
@@ -925,6 +1044,11 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-template ExpectedType of object
+     * @psalm-param class-string<ExpectedType> $class
+     * @psalm-assert ExpectedType|class-string<ExpectedType> $value
+     */
     public static function implementsInterface($value, $interface, $message = '')
     {
         if (!in_array($interface, class_implements($value))) {
@@ -996,6 +1120,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert array|\Countable $array
+     */
     public static function count($array, $number, $message = '')
     {
         static::eq(
@@ -1005,6 +1132,9 @@ class Assert
         );
     }
 
+    /**
+     * @psalm-assert array|\Countable $array
+     */
     public static function minCount($array, $min, $message = '')
     {
         if (count($array) < $min) {
@@ -1016,6 +1146,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert array|\Countable $array
+     */
     public static function maxCount($array, $max, $message = '')
     {
         if (count($array) > $max) {
@@ -1027,6 +1160,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert array|\Countable $array
+     */
     public static function countBetween($array, $min, $max, $message = '')
     {
         $count = count($array);
@@ -1041,6 +1177,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert array<int, mixed>&!empty $array
+     */
     public static function isList($array, $message = '')
     {
         if (!is_array($array) || !$array || array_keys($array) !== range(0, count($array) - 1)) {
@@ -1050,6 +1189,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert array<string, mixed>&!empty $array
+     */
     public static function isMap($array, $message = '')
     {
         if (
@@ -1083,6 +1225,9 @@ class Assert
         }
     }
 
+    /**
+     * @psalm-assert never-return
+     */
     public static function throws(Closure $expression, $class = 'Exception', $message = '')
     {
         static::string($class);

--- a/static-analysis/assert-alpha.php
+++ b/static-analysis/assert-alpha.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-param string|numeric $value
+ */
+function consume($value) : string
+{
+    Assert::alpha($value);
+
+    return $value;
+}

--- a/static-analysis/assert-boolean.php
+++ b/static-analysis/assert-boolean.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/** @param mixed $value */
+function consume($value) : bool
+{
+    Assert::boolean($value);
+
+    return $value;
+}

--- a/static-analysis/assert-class-exists.php
+++ b/static-analysis/assert-class-exists.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/** @return class-string */
+function consume(string $value)
+{
+    Assert::classExists($value);
+
+    return $value;
+}

--- a/static-analysis/assert-count-between.php.disabled
+++ b/static-analysis/assert-count-between.php.disabled
@@ -1,0 +1,17 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @param mixed $value
+ *
+ * @return array|\Countable
+ */
+function consume($value)
+{
+    Assert::countBetween($value, 1, 100);
+
+    return $value;
+}

--- a/static-analysis/assert-count.php.disabled
+++ b/static-analysis/assert-count.php.disabled
@@ -1,0 +1,17 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @param mixed $value
+ *
+ * @return array|\Countable
+ */
+function consume($value)
+{
+    Assert::count($value, 0);
+
+    return $value;
+}

--- a/static-analysis/assert-digits.php
+++ b/static-analysis/assert-digits.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-param mixed $value
+ *
+ * @return numeric
+ */
+function consume($value)
+{
+    Assert::digits($value);
+
+    return $value;
+}

--- a/static-analysis/assert-false.php
+++ b/static-analysis/assert-false.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @param mixed $value
+ *
+ * @return false
+ */
+function consume($value) : bool
+{
+    Assert::false($value);
+
+    return $value;
+}

--- a/static-analysis/assert-float.php
+++ b/static-analysis/assert-float.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/** @param mixed $value */
+function consume($value) : float
+{
+    Assert::float($value);
+
+    return $value;
+}

--- a/static-analysis/assert-implements-interface.php.disabled
+++ b/static-analysis/assert-implements-interface.php.disabled
@@ -1,0 +1,21 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertSubclassOf;
+
+use Webmozart\Assert\Assert;
+
+interface A
+{
+}
+
+/**
+ * @param mixed $value
+ *
+ * @psalm-return A|class-string<A>
+ */
+function consume($value)
+{
+    Assert::implementsInterface($value, A::class);
+
+    return $value;
+}

--- a/static-analysis/assert-int.php
+++ b/static-analysis/assert-int.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/** @param mixed $value */
+function consume($value) : int
+{
+    Assert::integer($value);
+
+    return $value;
+}

--- a/static-analysis/assert-integerish.php
+++ b/static-analysis/assert-integerish.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @param mixed $value
+ *
+ * @return numeric
+ */
+function consume($value)
+{
+    Assert::integerish($value);
+
+    return $value;
+}

--- a/static-analysis/assert-interface-exists.php
+++ b/static-analysis/assert-interface-exists.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @param mixed $value
+ *
+ * @return class-string
+ */
+function consume($value)
+{
+    Assert::interfaceExists($value);
+
+    return $value;
+}

--- a/static-analysis/assert-ip-v4.php
+++ b/static-analysis/assert-ip-v4.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/** @param mixed $value */
+function consume($value) : string
+{
+    Assert::ipv4($value);
+
+    return $value;
+}

--- a/static-analysis/assert-ip-v6.php
+++ b/static-analysis/assert-ip-v6.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/** @param mixed $value */
+function consume($value) : string
+{
+    Assert::ipv6($value);
+
+    return $value;
+}

--- a/static-analysis/assert-ip.php
+++ b/static-analysis/assert-ip.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/** @param mixed $value */
+function consume($value) : string
+{
+    Assert::ip($value);
+
+    return $value;
+}

--- a/static-analysis/assert-is-array-accessible.php.disabled
+++ b/static-analysis/assert-is-array-accessible.php.disabled
@@ -1,0 +1,17 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @param mixed $value
+ *
+ * @return array|\ArrayAccess
+ */
+function consume($value)
+{
+    Assert::isArrayAccessible($value);
+
+    return $value;
+}

--- a/static-analysis/assert-is-array.php
+++ b/static-analysis/assert-is-array.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/** @param mixed $value */
+function consume($value) : array
+{
+    Assert::isArray($value);
+
+    return $value;
+}

--- a/static-analysis/assert-is-callable.php
+++ b/static-analysis/assert-is-callable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/** @param mixed $value */
+function consume($value) : callable
+{
+    Assert::isCallable($value);
+
+    return $value;
+}

--- a/static-analysis/assert-is-coutable.php.disabled
+++ b/static-analysis/assert-is-coutable.php.disabled
@@ -1,0 +1,17 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @param mixed $value
+ *
+ * @return array|\Countable
+ */
+function consume($value)
+{
+    Assert::isCountable($value);
+
+    return $value;
+}

--- a/static-analysis/assert-is-empty.php
+++ b/static-analysis/assert-is-empty.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/** @return null */
+function consume(?object $value)
+{
+    Assert::isEmpty($value);
+
+    return $value;
+}

--- a/static-analysis/assert-is-instance-of-any.php.disabled
+++ b/static-analysis/assert-is-instance-of-any.php.disabled
@@ -1,0 +1,25 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertIsInstanceOfAny;
+
+use Webmozart\Assert\Assert;
+
+class A
+{
+}
+
+class B
+{
+}
+
+/**
+ * @param mixed $value
+ *
+ * @return A|B
+ */
+function consume($value)
+{
+    Assert::isInstanceOfAny($value, [A::class, B::class]);
+
+    return $value;
+}

--- a/static-analysis/assert-is-instance-of.php
+++ b/static-analysis/assert-is-instance-of.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/** @param mixed $value */
+function consume($value) : \stdClass
+{
+    Assert::isInstanceOf($value, \stdClass::class);
+
+    return $value;
+}

--- a/static-analysis/assert-is-iterable.php
+++ b/static-analysis/assert-is-iterable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/** @param mixed $value */
+function consume($value) : iterable
+{
+    Assert::isIterable($value);
+
+    return $value;
+}

--- a/static-analysis/assert-is-list.php.disabled
+++ b/static-analysis/assert-is-list.php.disabled
@@ -1,0 +1,17 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @param mixed $value
+ *
+ * @return array<int, mixed>
+ */
+function consume($value)
+{
+    Assert::isList($value);
+
+    return $value;
+}

--- a/static-analysis/assert-is-map.php.disabled
+++ b/static-analysis/assert-is-map.php.disabled
@@ -1,0 +1,17 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @param mixed $value
+ *
+ * @return array<string, mixed>
+ */
+function consume($value)
+{
+    Assert::isMap($value);
+
+    return $value;
+}

--- a/static-analysis/assert-is-traversable.php
+++ b/static-analysis/assert-is-traversable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/** @param mixed $value */
+function consume($value) : iterable
+{
+    Assert::isTraversable($value);
+
+    return $value;
+}

--- a/static-analysis/assert-max-count.php.disabled
+++ b/static-analysis/assert-max-count.php.disabled
@@ -1,0 +1,17 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @param mixed $value
+ *
+ * @return array|\Countable
+ */
+function consume($value)
+{
+    Assert::maxCount($value, 1);
+
+    return $value;
+}

--- a/static-analysis/assert-min-count.php.disabled
+++ b/static-analysis/assert-min-count.php.disabled
@@ -1,0 +1,17 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @param mixed $value
+ *
+ * @return array|\Countable
+ */
+function consume($value)
+{
+    Assert::minCount($value, 1);
+
+    return $value;
+}

--- a/static-analysis/assert-natural.php
+++ b/static-analysis/assert-natural.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/** @param mixed $value */
+function consume($value) : int
+{
+    Assert::natural($value);
+
+    return $value;
+}

--- a/static-analysis/assert-not-empty.php
+++ b/static-analysis/assert-not-empty.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/** @return object */
+function consume(?object $value)
+{
+    Assert::notEmpty($value);
+
+    return $value;
+}

--- a/static-analysis/assert-not-instance-of.php
+++ b/static-analysis/assert-not-instance-of.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertNotInstanceOf;
+
+use Webmozart\Assert\Assert;
+
+class A
+{
+}
+
+class B
+{
+}
+
+/** @param A|B $value */
+function consume($value) : A
+{
+    Assert::notInstanceOf($value, B::class);
+
+    return $value;
+}

--- a/static-analysis/assert-not-null.php
+++ b/static-analysis/assert-not-null.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/** @return object */
+function consume(?object $value)
+{
+    Assert::notNull($value);
+
+    return $value;
+}

--- a/static-analysis/assert-null.php
+++ b/static-analysis/assert-null.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/** @return null */
+function consume(?object $value)
+{
+    Assert::null($value);
+
+    return $value;
+}

--- a/static-analysis/assert-numeric.php
+++ b/static-analysis/assert-numeric.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @param mixed $value
+ *
+ * @return numeric
+ */
+function consume($value)
+{
+    Assert::numeric($value);
+
+    return $value;
+}

--- a/static-analysis/assert-object.php
+++ b/static-analysis/assert-object.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/** @param mixed $value */
+function consume($value) : object
+{
+    Assert::object($value);
+
+    return $value;
+}

--- a/static-analysis/assert-one-of.php.disabled
+++ b/static-analysis/assert-one-of.php.disabled
@@ -1,0 +1,25 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertIsInstanceOfAny;
+
+use Webmozart\Assert\Assert;
+
+class A
+{
+}
+
+class B
+{
+}
+
+/**
+ * @param mixed $value
+ *
+ * @return A|B
+ */
+function consume($value)
+{
+    Assert::isInstanceOfAny($value, [new A(), new B()]);
+
+    return $value;
+}

--- a/static-analysis/assert-resource.php
+++ b/static-analysis/assert-resource.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @param mixed $value
+ *
+ * @return resource
+ */
+function consume($value)
+{
+    Assert::resource($value);
+
+    return $value;
+}

--- a/static-analysis/assert-same.php
+++ b/static-analysis/assert-same.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertSame;
+
+use Webmozart\Assert\Assert;
+
+class A
+{
+
+}
+
+/** @param mixed $value */
+function consume($value) : A
+{
+    Assert::same($value, new A());
+
+    return $value;
+}

--- a/static-analysis/assert-scalar.php
+++ b/static-analysis/assert-scalar.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @param mixed $value
+ *
+ * @return scalar
+ */
+function consume($value)
+{
+    Assert::scalar($value);
+
+    return $value;
+}

--- a/static-analysis/assert-string-not-empty.php
+++ b/static-analysis/assert-string-not-empty.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/** @param mixed $value */
+function consume($value) : string
+{
+    Assert::stringNotEmpty($value);
+
+    return $value;
+}

--- a/static-analysis/assert-string.php
+++ b/static-analysis/assert-string.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/** @param mixed $value */
+function consume($value) : string
+{
+    Assert::string($value);
+
+    return $value;
+}

--- a/static-analysis/assert-subclass-of.php.disabled
+++ b/static-analysis/assert-subclass-of.php.disabled
@@ -1,0 +1,21 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertSubclassOf;
+
+use Webmozart\Assert\Assert;
+
+class A
+{
+}
+
+/**
+ * @param mixed $value
+ *
+ * @psalm-return A|class-string<A>
+ */
+function consume($value)
+{
+    Assert::subclassOf($value, A::class);
+
+    return $value;
+}

--- a/static-analysis/assert-throws.php.disabled
+++ b/static-analysis/assert-throws.php.disabled
@@ -1,0 +1,15 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-return callable() : never-returns
+ */
+function consume(callable $value) : callable
+{
+    Assert::throws($value);
+
+    return $value;
+}

--- a/static-analysis/assert-true.php
+++ b/static-analysis/assert-true.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Webmozart\Assert\StaticAnalysis\AssertString;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @param mixed $value
+ *
+ * @return true
+ */
+function consume($value) : bool
+{
+    Assert::true($value);
+
+    return $value;
+}


### PR DESCRIPTION
As discussed with @Nyholm, this is a WIP patch containing happy-path scenarios (some of which are marked as `.disabled`, will talk to @muglug about those) that ensure the added type declarations work as expected.

The idea is that after a `@psalm-assert int $value`, the caller of `Assert::integer($value)` can assume `$value` to be `int`.

This is equivalent to the behavior of https://github.com/phpstan/phpstan-webmozart-assert, but the declarations are now closer to the source, and that makes for easier usage from the ecosystem (support by phpstan and phpstorm may come soon ;-) )

As for the prefixed annotation format: that is required to not trip over tools like `doctrine/annotations`.

Other similar patches, for reference (since this is quite new stuff):

 * https://github.com/doctrine/collections/pull/177
 * https://github.com/Ocramius/ProxyManager/pull/465
 * https://github.com/sebastianbergmann/phpunit/pull/3708