### PR TITLE
Update CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 
-sudo: false
-
 branches:
   only:
     - master
@@ -14,28 +12,28 @@ matrix:
   include:
     - php: 5.3
       dist: precise
-    - php: 7.1
-      env: COVERAGE=yes
     - php: 5.4
     - php: 5.5
     - php: 5.6
     - php: 7.0
-    - php: hhvm
-    - php: nightly
     - php: 7.1
-      env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
     - php: 7.2
     - php: 7.3
+      env: COVERAGE=yes
+    - php: 7.4snapshot
+    - php: hhvm
+    - php: nightly
   allow_failures:
+    - php: 7.4snapshot
     - php: hhvm
     - php: nightly
   fast_finish: true
 
 before_install:
-  - if [[ $TRAVIS_PHP_VERSION != hhvm && $TRAVIS_PHP_VERSION != 7.3 && $COVERAGE != yes ]]; then phpenv config-rm xdebug.ini; fi;
+  - if [[ $COVERAGE != yes ]]; then phpenv config-rm xdebug.ini || true; fi;
 
 install:
-  - composer update $COMPOSER_FLAGS --prefer-dist --no-interaction
+  - composer update --prefer-dist --no-interaction
 
 script:
   - if [[ $COVERAGE = yes ]]; then vendor/bin/phpunit --verbose --coverage-clover=coverage.clover; else vendor/bin/phpunit --verbose; fi


### PR DESCRIPTION
* `sudo:false` is [deprecated](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)
* Gather coverage on php 7.3
* Move hhvm/nightly builds to bottom of matrix
* Test against php 7.4 snapshot, but allow it to fail
* Remove prefer lowest flags
* Simplify xdebug disabling

Nightly builds etc may not have xdebug, which makes disabling it not possible. There is no need to error on that, so we use `|| true` to make sure that always passes.

The `--prefer-lowest` flags only really test our compatibility with phpunit, which doesn't matter for end users

