### PR TITLE
Add deprecated tag to isTraversable

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -322,6 +322,9 @@ class Assert
         }
     }
 
+    /**
+     * @deprecated
+     */
     public static function isTraversable($value, $message = '')
     {
         @trigger_error(


### PR DESCRIPTION
This helps IDEs etc with telling users this method is deprecated.