### PR TITLE
Use trusty dist for php 5.4 and 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ matrix:
     - php: 5.3
       dist: precise
     - php: 5.4
+      dist: trusty
     - php: 5.5
+      dist: trusty
     - php: 5.6
     - php: 7.0
     - php: 7.1


### PR DESCRIPTION
This should fix the broken builds for these php versions, and allow us to keep testing those versions.