### PR TITLE
Use syntax sugar when call static functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^5.3.3 || ^7.0",
+        "php": "^5.5 || ^7.0",
         "symfony/polyfill-ctype": "^1.8"
     },
     "require-dev": {

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -533,7 +533,7 @@ class Assert
         static::reportInvalidArgument(\sprintf(
             $message ?: 'Expected an instance of any of %2$s. Got: %s',
             static::typeToString($value),
-            \implode(', ', \array_map(array('static', 'valueToString'), $classes))
+            \implode(', ', \array_map(array(static::class, 'valueToString'), $classes))
         ));
     }
 
@@ -877,7 +877,7 @@ class Assert
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected one of: %2$s. Got: %s',
                 static::valueToString($value),
-                \implode(', ', \array_map(array('static', 'valueToString'), $values))
+                \implode(', ', \array_map(array(static::class, 'valueToString'), $values))
             ));
         }
     }
@@ -1599,7 +1599,7 @@ class Assert
         if ('nullOr' === \substr($name, 0, 6)) {
             if (null !== $arguments[0]) {
                 $method = \lcfirst(\substr($name, 6));
-                \call_user_func_array(array('static', $method), $arguments);
+                \call_user_func_array(array(static::class, $method), $arguments);
             }
 
             return;
@@ -1614,7 +1614,7 @@ class Assert
             foreach ($arguments[0] as $entry) {
                 $args[0] = $entry;
 
-                \call_user_func_array(array('static', $method), $args);
+                \call_user_func_array(array(static::class, $method), $args);
             }
 
             return;


### PR DESCRIPTION
Some times we can call this function in another context and 'static' for the callable argument can mean different. But with such syntax sugar, it will work properly.