### PR TITLE
Remove branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,6 @@
     "require-dev": {
         "phpunit/phpunit": "^4.8.36 || ^7.5.13"
     },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.3-dev"
-        }
-    },
     "autoload": {
         "psr-4": {
             "Webmozart\\Assert\\": "src/"


### PR DESCRIPTION
This was way outdated, so its probably better to just get rid of it.