### PR TITLE
Remove psalm-assert for `oneOf`

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -964,10 +964,6 @@ class Assert
     /**
      * Does strict comparison, so Assert::oneOf(3, ['3']) does not pass the assertion.
      *
-     * @psalm-template ExpectedType
-     * @psalm-param array<ExpectedType> $values
-     * @psalm-assert ExpectedType $value
-     *
      * @param mixed  $value
      * @param array  $values
      * @param string $message


### PR DESCRIPTION
While running Psalm on the following code:
```php
    public function __construct(string $countryCode)
    {
        Assert::length($countryCode, 2);
        Assert::upper($countryCode);
        Assert::oneOf($countryCode, self::ALLOWED_COUNTRIES);

        $this->countryCode = $countryCode;
    }
```
I get this error:
```
INFO: RedundantCondition - src/Domain/Model/Country.php:310:17 - Found a redundant condition when evaluating $countryCode and trying to reconcile type 'string' to string
        Assert::oneOf($countryCode, self::ALLOWED_COUNTRIES);
```

I believe the `psalm-assert` on this function is wrong because the function does not assert the type at all... it just asserts that `$value` is in the `$values` array.

https://github.com/webmozart/assert/blob/4c2f50b6039364988a08f1f30401ba49e06751b6/src/Assert.php#L964-L977

