### PR TITLE
Use php 7.4 instead of the snapshot version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,10 @@ matrix:
       env:
        - COVERAGE=yes
        - ANALYSIS=yes
-    - php: 7.4snapshot
+    - php: 7.4
     - php: hhvm-3.30
     - php: nightly
   allow_failures:
-    - php: 7.4snapshot
     - php: hhvm-3.30
     - php: nightly
   fast_finish: true


### PR DESCRIPTION
Also remove php 7.4 from the allowed failures.

Lets see what travis does with this.