### PR TITLE
Added type assertions for multiple methods not covered by existing `@psalm-assert` functionality

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,5 +3,6 @@
 /.styleci.yml         export-ignore
 /.travis.yml          export-ignore
 /appveyor.yml         export-ignore
+/ci                   export-ignore
 /phpunit.xml.dist     export-ignore
 /tests                export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 vendor/
-composer.lock
+./composer.lock

--- a/ci/composer.json
+++ b/ci/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "vimeo/psalm": "^3.8.5"
+        "vimeo/psalm": "^3.9.1"
     }
 }

--- a/ci/composer.lock
+++ b/ci/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a8e5b61882b341e7b6630107f8762c10",
+    "content-hash": "4ce4d8df2974bae91c2617c88ccf797e",
     "packages": [
         {
             "name": "amphp/amp",
-            "version": "v2.4.0",
+            "version": "v2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/amp.git",
-                "reference": "13930a582947831bb66ff1aeac28672fd91c38ea"
+                "reference": "2ac3b550c4997f2ec304faa63c8b2885079a2dc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/amp/zipball/13930a582947831bb66ff1aeac28672fd91c38ea",
-                "reference": "13930a582947831bb66ff1aeac28672fd91c38ea",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/2ac3b550c4997f2ec304faa63c8b2885079a2dc4",
+                "reference": "2ac3b550c4997f2ec304faa63c8b2885079a2dc4",
                 "shasum": ""
             },
             "require": {
@@ -81,20 +81,20 @@
                 "non-blocking",
                 "promise"
             ],
-            "time": "2019-11-11T19:32:05+00:00"
+            "time": "2020-02-10T18:10:57+00:00"
         },
         {
             "name": "amphp/byte-stream",
-            "version": "v1.7.1",
+            "version": "v1.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/byte-stream.git",
-                "reference": "9d8205686a004948475dc43f8a88d2fa5e75a113"
+                "reference": "1e52f1752b2e20e2a7e464476ef887a2388e3832"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/9d8205686a004948475dc43f8a88d2fa5e75a113",
-                "reference": "9d8205686a004948475dc43f8a88d2fa5e75a113",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/1e52f1752b2e20e2a7e464476ef887a2388e3832",
+                "reference": "1e52f1752b2e20e2a7e464476ef887a2388e3832",
                 "shasum": ""
             },
             "require": {
@@ -140,7 +140,68 @@
                 "non-blocking",
                 "stream"
             ],
-            "time": "2019-10-27T14:33:41+00:00"
+            "time": "2020-01-29T18:22:23+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "c6bea70230ef4dd483e6bbcab6005f682ed3a8de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/c6bea70230ef4dd483e6bbcab6005f682ed3a8de",
+                "reference": "c6bea70230ef4dd483e6bbcab6005f682ed3a8de",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5 || ^5.0.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "time": "2020-01-13T12:06:48+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -188,22 +249,22 @@
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
-            "version": "v3.0.4",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
-                "reference": "23366dd0cab0a0f3fd3016bf3c0b36dec74348e7"
+                "reference": "a407a6cb0325cd489c6dff57afcba6baeccc0483"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/23366dd0cab0a0f3fd3016bf3c0b36dec74348e7",
-                "reference": "23366dd0cab0a0f3fd3016bf3c0b36dec74348e7",
+                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/a407a6cb0325cd489c6dff57afcba6baeccc0483",
+                "reference": "a407a6cb0325cd489c6dff57afcba6baeccc0483",
                 "shasum": ""
             },
             "require": {
                 "netresearch/jsonmapper": "^1.0",
                 "php": ">=7.0",
-                "phpdocumentor/reflection-docblock": "^4.0.0"
+                "phpdocumentor/reflection-docblock": "^4.0.0 || ^5.0.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^6.0.0"
@@ -225,7 +286,7 @@
                 }
             ],
             "description": "A more advanced JSONRPC implementation",
-            "time": "2019-09-12T22:41:08+00:00"
+            "time": "2020-02-11T20:48:40+00:00"
         },
         {
             "name": "felixfbecker/language-server-protocol",
@@ -526,40 +587,38 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.2",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "b83ff7cfcfee7827e1e78b637a5904fe6a96698e"
+                "reference": "a48807183a4b819072f26e347bbd0b5199a9d15f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/b83ff7cfcfee7827e1e78b637a5904fe6a96698e",
-                "reference": "b83ff7cfcfee7827e1e78b637a5904fe6a96698e",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/a48807183a4b819072f26e347bbd0b5199a9d15f",
+                "reference": "a48807183a4b819072f26e347bbd0b5199a9d15f",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0.0 || ^2.0.0",
-                "phpdocumentor/type-resolver": "~0.4 || ^1.0.0",
-                "webmozart/assert": "^1.0"
+                "ext-filter": "^7.1",
+                "php": "^7.2",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpdocumentor/type-resolver": "^1.0",
+                "webmozart/assert": "^1"
             },
             "require-dev": {
-                "doctrine/instantiator": "^1.0.5",
-                "mockery/mockery": "^1.0",
-                "phpunit/phpunit": "^6.4"
+                "doctrine/instantiator": "^1",
+                "mockery/mockery": "^1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.x-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -570,10 +629,14 @@
                 {
                     "name": "Mike van Riel",
                     "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "account@ijaap.nl"
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2019-09-12T14:27:41+00:00"
+            "time": "2020-02-09T09:16:15+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -720,29 +783,29 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "3.0.2",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
+                "reference": "c0c26c9188b538bfa985ae10c9f05d278f12060d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
-                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c0c26c9188b538bfa985ae10c9f05d278f12060d",
+                "reference": "c0c26c9188b538bfa985ae10c9f05d278f12060d",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5 || ^8.0",
-                "symfony/process": "^2 || ^3.3 || ^4"
+                "phpunit/phpunit": "^9.0",
+                "symfony/process": "^4 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -756,12 +819,12 @@
             ],
             "authors": [
                 {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
-                {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
                 }
             ],
             "description": "Diff implementation",
@@ -772,20 +835,20 @@
                 "unidiff",
                 "unified diff"
             ],
-            "time": "2019-02-04T06:01:07+00:00"
+            "time": "2020-02-07T06:09:38+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.0.1",
+            "version": "v5.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "dae5ef273d700771168ab889d9f8a19b2d206656"
+                "reference": "91c294166c38d8c0858a86fad76d8c14dc1144c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/dae5ef273d700771168ab889d9f8a19b2d206656",
-                "reference": "dae5ef273d700771168ab889d9f8a19b2d206656",
+                "url": "https://api.github.com/repos/symfony/console/zipball/91c294166c38d8c0858a86fad76d8c14dc1144c8",
+                "reference": "91c294166c38d8c0858a86fad76d8c14dc1144c8",
                 "shasum": ""
             },
             "require": {
@@ -848,20 +911,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2019-12-01T10:51:15+00:00"
+            "time": "2020-01-25T15:56:29+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.13.1",
+            "version": "v1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3"
+                "reference": "fbdeaec0df06cf3d51c93de80c7eb76e271f5a38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
-                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/fbdeaec0df06cf3d51c93de80c7eb76e271f5a38",
+                "reference": "fbdeaec0df06cf3d51c93de80c7eb76e271f5a38",
                 "shasum": ""
             },
             "require": {
@@ -873,7 +936,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.13-dev"
+                    "dev-master": "1.14-dev"
                 }
             },
             "autoload": {
@@ -906,20 +969,20 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-11-27T13:56:44+00:00"
+            "time": "2020-01-13T11:15:53+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.13.1",
+            "version": "v1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "7b4aab9743c30be783b73de055d24a39cf4b954f"
+                "reference": "34094cfa9abe1f0f14f48f490772db7a775559f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7b4aab9743c30be783b73de055d24a39cf4b954f",
-                "reference": "7b4aab9743c30be783b73de055d24a39cf4b954f",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/34094cfa9abe1f0f14f48f490772db7a775559f2",
+                "reference": "34094cfa9abe1f0f14f48f490772db7a775559f2",
                 "shasum": ""
             },
             "require": {
@@ -931,7 +994,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.13-dev"
+                    "dev-master": "1.14-dev"
                 }
             },
             "autoload": {
@@ -965,20 +1028,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-11-27T14:18:11+00:00"
+            "time": "2020-01-13T11:15:53+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.13.1",
+            "version": "v1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "4b0e2222c55a25b4541305a053013d5647d3a25f"
+                "reference": "5e66a0fa1070bf46bec4bea7962d285108edd675"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/4b0e2222c55a25b4541305a053013d5647d3a25f",
-                "reference": "4b0e2222c55a25b4541305a053013d5647d3a25f",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/5e66a0fa1070bf46bec4bea7962d285108edd675",
+                "reference": "5e66a0fa1070bf46bec4bea7962d285108edd675",
                 "shasum": ""
             },
             "require": {
@@ -987,7 +1050,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.13-dev"
+                    "dev-master": "1.14-dev"
                 }
             },
             "autoload": {
@@ -1023,7 +1086,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-11-27T16:25:15+00:00"
+            "time": "2020-01-13T11:15:53+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -1085,31 +1148,37 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "dev-master",
+            "version": "3.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "8494f02008264d1e9b217c63a820fd2e1762b2d1"
+                "reference": "201d54f23293bac70c9b8b75985114449b3b56eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/8494f02008264d1e9b217c63a820fd2e1762b2d1",
-                "reference": "8494f02008264d1e9b217c63a820fd2e1762b2d1",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/201d54f23293bac70c9b8b75985114449b3b56eb",
+                "reference": "201d54f23293bac70c9b8b75985114449b3b56eb",
                 "shasum": ""
             },
             "require": {
                 "amphp/amp": "^2.1",
                 "amphp/byte-stream": "^1.5",
+                "composer/semver": "^1.4",
                 "composer/xdebug-handler": "^1.1",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
                 "felixfbecker/advanced-json-rpc": "^3.0.3",
                 "felixfbecker/language-server-protocol": "^1.4",
                 "netresearch/jsonmapper": "^1.0",
                 "nikic/php-parser": "^4.3",
                 "ocramius/package-versions": "^1.2",
                 "openlss/lib-array2xml": "^1.0",
-                "php": "^7.1.3",
-                "sebastian/diff": "^3.0",
-                "symfony/console": "^3.3||^4.0||^5.0",
+                "php": "^7.1.3|^8",
+                "sebastian/diff": "^3.0 || ^4.0",
+                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0",
                 "webmozart/glob": "^4.1",
                 "webmozart/path-util": "^2.3"
             },
@@ -1119,10 +1188,10 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.2",
                 "ext-curl": "*",
-                "friendsofphp/php-cs-fixer": "^2.15",
-                "phpmyadmin/sql-parser": "^5.0",
-                "phpunit/phpunit": "^7.5 || ^8.0",
-                "psalm/plugin-phpunit": "^0.6",
+                "phpmyadmin/sql-parser": "5.1.0",
+                "phpspec/prophecy": ">=1.9.0",
+                "phpunit/phpunit": "^7.5.16 || ^8.0",
+                "psalm/plugin-phpunit": "^0.9",
                 "slevomat/coding-standard": "^5.0",
                 "squizlabs/php_codesniffer": "^3.5",
                 "symfony/process": "^4.3"
@@ -1132,10 +1201,10 @@
             },
             "bin": [
                 "psalm",
-                "psalter",
                 "psalm-language-server",
                 "psalm-plugin",
-                "psalm-refactor"
+                "psalm-refactor",
+                "psalter"
             ],
             "type": "library",
             "extra": {
@@ -1170,20 +1239,20 @@
                 "inspection",
                 "php"
             ],
-            "time": "2019-12-10T05:50:36+00:00"
+            "time": "2020-02-18T14:40:21+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.6.0",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925"
+                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/573381c0a64f155a0d9a23f4b0c797194805b925",
-                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/aed98a490f9a8f78468232db345ab9cf606cf598",
+                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598",
                 "shasum": ""
             },
             "require": {
@@ -1218,7 +1287,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2019-11-24T13:36:37+00:00"
+            "time": "2020-02-14T12:15:55+00:00"
         },
         {
             "name": "webmozart/glob",
@@ -1317,9 +1386,7 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "vimeo/psalm": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],

--- a/ci/composer.lock
+++ b/ci/composer.lock
@@ -1,0 +1,1327 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "a8e5b61882b341e7b6630107f8762c10",
+    "packages": [
+        {
+            "name": "amphp/amp",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/amp.git",
+                "reference": "13930a582947831bb66ff1aeac28672fd91c38ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/13930a582947831bb66ff1aeac28672fd91c38ea",
+                "reference": "13930a582947831bb66ff1aeac28672fd91c38ea",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1",
+                "ext-json": "*",
+                "phpstan/phpstan": "^0.8.5",
+                "phpunit/phpunit": "^6.0.9 | ^7",
+                "react/promise": "^2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Amp\\": "lib"
+                },
+                "files": [
+                    "lib/functions.php",
+                    "lib/Internal/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A non-blocking concurrency framework for PHP applications.",
+            "homepage": "http://amphp.org/amp",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "awaitable",
+                "concurrency",
+                "event",
+                "event-loop",
+                "future",
+                "non-blocking",
+                "promise"
+            ],
+            "time": "2019-11-11T19:32:05+00:00"
+        },
+        {
+            "name": "amphp/byte-stream",
+            "version": "v1.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/byte-stream.git",
+                "reference": "9d8205686a004948475dc43f8a88d2fa5e75a113"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/9d8205686a004948475dc43f8a88d2fa5e75a113",
+                "reference": "9d8205686a004948475dc43f8a88d2fa5e75a113",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1",
+                "friendsofphp/php-cs-fixer": "^2.3",
+                "infection/infection": "^0.9.3",
+                "phpunit/phpunit": "^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\ByteStream\\": "lib"
+                },
+                "files": [
+                    "lib/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A stream abstraction to make working with non-blocking I/O simple.",
+            "homepage": "http://amphp.org/byte-stream",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "non-blocking",
+                "stream"
+            ],
+            "time": "2019-10-27T14:33:41+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "cbe23383749496fe0f373345208b79568e4bc248"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/cbe23383749496fe0f373345208b79568e4bc248",
+                "reference": "cbe23383749496fe0f373345208b79568e4bc248",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "time": "2019-11-06T16:40:04+00:00"
+        },
+        {
+            "name": "felixfbecker/advanced-json-rpc",
+            "version": "v3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
+                "reference": "23366dd0cab0a0f3fd3016bf3c0b36dec74348e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/23366dd0cab0a0f3fd3016bf3c0b36dec74348e7",
+                "reference": "23366dd0cab0a0f3fd3016bf3c0b36dec74348e7",
+                "shasum": ""
+            },
+            "require": {
+                "netresearch/jsonmapper": "^1.0",
+                "php": ">=7.0",
+                "phpdocumentor/reflection-docblock": "^4.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AdvancedJsonRpc\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "A more advanced JSONRPC implementation",
+            "time": "2019-09-12T22:41:08+00:00"
+        },
+        {
+            "name": "felixfbecker/language-server-protocol",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-language-server-protocol.git",
+                "reference": "378801f6139bb74ac215d81cca1272af61df9a9f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/378801f6139bb74ac215d81cca1272af61df9a9f",
+                "reference": "378801f6139bb74ac215d81cca1272af61df9a9f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "*",
+                "phpunit/phpunit": "^6.3",
+                "squizlabs/php_codesniffer": "^3.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "LanguageServerProtocol\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "PHP classes for the Language Server Protocol",
+            "keywords": [
+                "language",
+                "microsoft",
+                "php",
+                "server"
+            ],
+            "time": "2019-06-23T21:03:50+00:00"
+        },
+        {
+            "name": "netresearch/jsonmapper",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweiske/jsonmapper.git",
+                "reference": "0d4d1b48d682a93b6bfedf60b88c7750e9cb0b06"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/0d4d1b48d682a93b6bfedf60b88c7750e9cb0b06",
+                "reference": "0d4d1b48d682a93b6bfedf60b88c7750e9cb0b06",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8.35 || ~5.7 || ~6.4",
+                "squizlabs/php_codesniffer": "~1.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JsonMapper": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "OSL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Weiske",
+                    "email": "cweiske@cweiske.de",
+                    "homepage": "http://github.com/cweiske/jsonmapper/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Map nested JSON structures onto PHP classes",
+            "time": "2019-08-15T19:41:25+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v4.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "9a9981c347c5c49d6dfe5cf826bb882b824080dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/9a9981c347c5c49d6dfe5cf826bb882b824080dc",
+                "reference": "9a9981c347c5c49d6dfe5cf826bb882b824080dc",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "0.0.5",
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "time": "2019-11-08T13:50:10+00:00"
+        },
+        {
+            "name": "ocramius/package-versions",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ocramius/PackageVersions.git",
+                "reference": "1d32342b8c1eb27353c8887c366147b4c2da673c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/1d32342b8c1eb27353c8887c366147b4c2da673c",
+                "reference": "1d32342b8c1eb27353c8887c366147b4c2da673c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0.0",
+                "php": "^7.3.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.8.6",
+                "doctrine/coding-standard": "^6.0.0",
+                "ext-zip": "*",
+                "infection/infection": "^0.13.4",
+                "phpunit/phpunit": "^8.2.5",
+                "vimeo/psalm": "^3.4.9"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "time": "2019-07-17T15:49:50+00:00"
+        },
+        {
+            "name": "openlss/lib-array2xml",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nullivex/lib-array2xml.git",
+                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nullivex/lib-array2xml/zipball/a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
+                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "LSS": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Bryan Tong",
+                    "email": "bryan@nullivex.com",
+                    "homepage": "https://www.nullivex.com"
+                },
+                {
+                    "name": "Tony Butler",
+                    "email": "spudz76@gmail.com",
+                    "homepage": "https://www.nullivex.com"
+                }
+            ],
+            "description": "Array2XML conversion library credit to lalit.org",
+            "homepage": "https://www.nullivex.com",
+            "keywords": [
+                "array",
+                "array conversion",
+                "xml",
+                "xml conversion"
+            ],
+            "time": "2019-03-29T20:06:56+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2018-08-07T13:53:10+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "4.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "b83ff7cfcfee7827e1e78b637a5904fe6a96698e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/b83ff7cfcfee7827e1e78b637a5904fe6a96698e",
+                "reference": "b83ff7cfcfee7827e1e78b637a5904fe6a96698e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "phpdocumentor/reflection-common": "^1.0.0 || ^2.0.0",
+                "phpdocumentor/type-resolver": "~0.4 || ^1.0.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "doctrine/instantiator": "^1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2019-09-12T14:27:41+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
+                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "phpdocumentor/reflection-common": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "^7.1",
+                "mockery/mockery": "~1",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "time": "2019-08-22T18:11:29+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/446d54b4cb6bf489fc9d75f55843658e6f25d801",
+                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2019-11-01T11:05:21+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "time": "2019-02-04T06:01:07+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "dae5ef273d700771168ab889d9f8a19b2d206656"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/dae5ef273d700771168ab889d9f8a19b2d206656",
+                "reference": "dae5ef273d700771168ab889d9f8a19b2d206656",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php73": "^1.8",
+                "symfony/service-contracts": "^1.1|^2"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<4.4",
+                "symfony/event-dispatcher": "<4.4",
+                "symfony/lock": "<4.4",
+                "symfony/process": "<4.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/event-dispatcher": "^4.4|^5.0",
+                "symfony/lock": "^4.4|^5.0",
+                "symfony/process": "^4.4|^5.0",
+                "symfony/var-dumper": "^4.4|^5.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-12-01T10:51:15+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.13.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
+                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.13-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2019-11-27T13:56:44+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.13.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "7b4aab9743c30be783b73de055d24a39cf4b954f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7b4aab9743c30be783b73de055d24a39cf4b954f",
+                "reference": "7b4aab9743c30be783b73de055d24a39cf4b954f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.13-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2019-11-27T14:18:11+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.13.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "4b0e2222c55a25b4541305a053013d5647d3a25f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/4b0e2222c55a25b4541305a053013d5647d3a25f",
+                "reference": "4b0e2222c55a25b4541305a053013d5647d3a25f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.13-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2019-11-27T16:25:15+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "144c5e51266b281231e947b51223ba14acf1a749"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/144c5e51266b281231e947b51223ba14acf1a749",
+                "reference": "144c5e51266b281231e947b51223ba14acf1a749",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "symfony/service-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-11-18T17:27:11+00:00"
+        },
+        {
+            "name": "vimeo/psalm",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vimeo/psalm.git",
+                "reference": "8494f02008264d1e9b217c63a820fd2e1762b2d1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/8494f02008264d1e9b217c63a820fd2e1762b2d1",
+                "reference": "8494f02008264d1e9b217c63a820fd2e1762b2d1",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2.1",
+                "amphp/byte-stream": "^1.5",
+                "composer/xdebug-handler": "^1.1",
+                "felixfbecker/advanced-json-rpc": "^3.0.3",
+                "felixfbecker/language-server-protocol": "^1.4",
+                "netresearch/jsonmapper": "^1.0",
+                "nikic/php-parser": "^4.3",
+                "ocramius/package-versions": "^1.2",
+                "openlss/lib-array2xml": "^1.0",
+                "php": "^7.1.3",
+                "sebastian/diff": "^3.0",
+                "symfony/console": "^3.3||^4.0||^5.0",
+                "webmozart/glob": "^4.1",
+                "webmozart/path-util": "^2.3"
+            },
+            "provide": {
+                "psalm/psalm": "self.version"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.2",
+                "ext-curl": "*",
+                "friendsofphp/php-cs-fixer": "^2.15",
+                "phpmyadmin/sql-parser": "^5.0",
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "psalm/plugin-phpunit": "^0.6",
+                "slevomat/coding-standard": "^5.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^4.3"
+            },
+            "suggest": {
+                "ext-igbinary": "^2.0.5"
+            },
+            "bin": [
+                "psalm",
+                "psalter",
+                "psalm-language-server",
+                "psalm-plugin",
+                "psalm-refactor"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev",
+                    "dev-2.x": "2.x-dev",
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\Plugin\\": "src/Psalm/Plugin",
+                    "Psalm\\": "src/Psalm"
+                },
+                "files": [
+                    "src/functions.php",
+                    "src/spl_object_id.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Brown"
+                }
+            ],
+            "description": "A static analysis tool for finding errors in PHP applications",
+            "keywords": [
+                "code",
+                "inspection",
+                "php"
+            ],
+            "time": "2019-12-10T05:50:36+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/573381c0a64f155a0d9a23f4b0c797194805b925",
+                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "vimeo/psalm": "<3.6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2019-11-24T13:36:37+00:00"
+        },
+        {
+            "name": "webmozart/glob",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/glob.git",
+                "reference": "3cbf63d4973cf9d780b93d2da8eec7e4a9e63bbe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/glob/zipball/3cbf63d4973cf9d780b93d2da8eec7e4a9e63bbe",
+                "reference": "3cbf63d4973cf9d780b93d2da8eec7e4a9e63bbe",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3|^7.0",
+                "webmozart/path-util": "^2.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1",
+                "symfony/filesystem": "^2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Glob\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A PHP implementation of Ant's glob.",
+            "time": "2015-12-29T11:14:33+00:00"
+        },
+        {
+            "name": "webmozart/path-util",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/path-util.git",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/path-util/zipball/d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "webmozart/assert": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\PathUtil\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A robust cross-platform utility for normalizing, comparing and modifying file paths.",
+            "time": "2015-12-17T08:42:14+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {
+        "vimeo/psalm": 20
+    },
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "phpunit/phpunit": "^4.8.36 || ^7.5.13"
     },
     "conflict": {
-        "vimeo/psalm": "<3.6.0"
+        "vimeo/psalm": "<3.7.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "phpunit/phpunit": "^4.8.36 || ^7.5.13"
     },
     "conflict": {
-        "vimeo/psalm": "<3.7.3"
+        "vimeo/psalm": "<3.9.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -832,8 +832,6 @@ class Assert
     }
 
     /**
-     * @psalm-assert !empty $value
-     *
      * @param mixed  $value
      * @param string $message
      *
@@ -850,8 +848,6 @@ class Assert
     }
 
     /**
-     * @psalm-assert !empty $value
-     *
      * @param mixed  $value
      * @param string $message
      *
@@ -868,8 +864,6 @@ class Assert
     }
 
     /**
-     * @psalm-assert !empty $value
-     *
      * @param mixed  $value
      * @param string $message
      *
@@ -886,8 +880,6 @@ class Assert
     }
 
     /**
-     * @psalm-assert !empty $value
-     *
      * @param mixed  $value
      * @param string $message
      *
@@ -931,9 +923,6 @@ class Assert
 
     /**
      * @psalm-pure
-     * @psalm-template ExpectedType
-     * @psalm-param ExpectedType $expect
-     * @psalm-assert ExpectedType $value
      *
      * @param mixed  $value
      * @param mixed  $expect
@@ -1216,8 +1205,6 @@ class Assert
 
     /**
      * @psalm-pure
-     * @psalm-assert string $value
-     * @psalm-assert !empty $value
      *
      * @param mixed  $value
      * @param string $message
@@ -1307,8 +1294,6 @@ class Assert
 
     /**
      * @psalm-pure
-     * @psalm-assert string $value
-     * @psalm-assert !empty $value
      *
      * @param mixed  $value
      * @param string $message
@@ -1329,7 +1314,6 @@ class Assert
 
     /**
      * @psalm-pure
-     * @psalm-assert string $value
      *
      * @param mixed  $value
      * @param string $message
@@ -1355,7 +1339,6 @@ class Assert
 
     /**
      * @psalm-pure
-     * @psalm-assert !empty $value
      *
      * @param string|int $value   can be an integer, since ctype_* functions accept ASCII integers -128 ~ +256
      * @param string     $message
@@ -1379,7 +1362,6 @@ class Assert
 
     /**
      * @psalm-pure
-     * @psalm-assert !empty $value
      *
      * @param string|int $value   can be an integer, since ctype_* functions accept ASCII integers -128 ~ +256
      * @param string     $message
@@ -1403,7 +1385,7 @@ class Assert
 
     /**
      * @psalm-pure
-     * @psalm-assert !empty $value
+     * @psalm-assert lowercase-string $value
      *
      * @param string|int $value   can be an integer, since ctype_* functions accept ASCII integers -128 ~ +256
      * @param string     $message
@@ -1427,7 +1409,7 @@ class Assert
 
     /**
      * @psalm-pure
-     * @psalm-assert !empty $value
+     * @psalm-assert !lowercase-string $value
      *
      * @param string|int $value   can be an integer, since ctype_* functions accept ASCII integers -128 ~ +256
      * @param string     $message
@@ -1542,8 +1524,6 @@ class Assert
     /**
      * Will also pass if $value is a directory, use Assert::file() instead if you need to be sure it is a file.
      *
-     * @psalm-assert string $value
-     *
      * @param mixed  $value
      * @param string $message
      *
@@ -1562,8 +1542,6 @@ class Assert
     }
 
     /**
-     * @psalm-assert string $value
-     *
      * @param mixed  $value
      * @param string $message
      *
@@ -1582,8 +1560,6 @@ class Assert
     }
 
     /**
-     * @psalm-assert string $value
-     *
      * @param mixed  $value
      * @param string $message
      *
@@ -1602,8 +1578,6 @@ class Assert
     }
 
     /**
-     * @psalm-assert !empty $value
-     *
      * @param string $value
      * @param string $message
      *
@@ -1620,8 +1594,6 @@ class Assert
     }
 
     /**
-     * @psalm-assert !empty $value
-     *
      * @param string $value
      * @param string $message
      *
@@ -1638,9 +1610,6 @@ class Assert
     }
 
     /**
-     * @psalm-pure
-     * @psalm-assert class-string $value
-     *
      * @param mixed  $value
      * @param string $message
      *
@@ -1680,9 +1649,6 @@ class Assert
     }
 
     /**
-     * @psalm-pure
-     * @psalm-assert class-string $value
-     *
      * @param mixed  $value
      * @param string $message
      *
@@ -1723,6 +1689,7 @@ class Assert
 
     /**
      * @psalm-pure
+     * @psalm-param class-string|object $classOrObject
      *
      * @param string|object $classOrObject
      * @param mixed         $property
@@ -1742,6 +1709,7 @@ class Assert
 
     /**
      * @psalm-pure
+     * @psalm-param class-string|object $classOrObject
      *
      * @param string|object $classOrObject
      * @param mixed         $property
@@ -1761,6 +1729,7 @@ class Assert
 
     /**
      * @psalm-pure
+     * @psalm-param class-string|object $classOrObject
      *
      * @param string|object $classOrObject
      * @param mixed         $method
@@ -1780,6 +1749,7 @@ class Assert
 
     /**
      * @psalm-pure
+     * @psalm-param class-string|object $classOrObject
      *
      * @param string|object $classOrObject
      * @param mixed         $method
@@ -2001,6 +1971,7 @@ class Assert
      * @psalm-template T
      * @psalm-param mixed|array<T> $array
      * @psalm-assert array<string, T> $array
+     * @psalm-assert !empty $array
      *
      * @param mixed  $array
      * @param string $message
@@ -2015,7 +1986,6 @@ class Assert
 
     /**
      * @psalm-pure
-     * @psalm-assert !empty $value
      *
      * @param string $value
      * @param string $message

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1091,7 +1091,7 @@ class Assert
     }
 
     /**
-     * @param mixed  $value
+     * @param string  $value
      * @param string $subString
      * @param string $message
      *

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1922,9 +1922,11 @@ class Assert
     }
 
     /**
-     * @param Closure       $expression
-     * @param string|object $class
-     * @param string        $message
+     * @psalm-param class-string<Throwable>
+     *
+     * @param Closure $expression
+     * @param string  $class
+     * @param string  $message
      *
      * @throws InvalidArgumentException
      */

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1363,8 +1363,8 @@ class Assert
     }
 
     /**
-     * @param mixed  $value
-     * @param mixed  $length
+     * @param string $value
+     * @param int    $length
      * @param string $message
      *
      * @throws InvalidArgumentException

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -623,6 +623,11 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     * @psalm-template ExpectedType of object
+     * @psalm-param class-string<ExpectedType> $class
+     * @psalm-assert ExpectedType|class-string<ExpectedType> $value
+     *
      * @param object|string $value
      * @param string        $class
      * @param string        $message

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -898,8 +898,6 @@ class Assert
     /**
      * Does non strict comparisons on the items, so ['3', 3] will not pass the assertion.
      *
-     * @psalm-pure
-     *
      * @param array  $values
      * @param string $message
      *
@@ -922,8 +920,6 @@ class Assert
     }
 
     /**
-     * @psalm-pure
-     *
      * @param mixed  $value
      * @param mixed  $expect
      * @param string $message
@@ -942,8 +938,6 @@ class Assert
     }
 
     /**
-     * @psalm-pure
-     *
      * @param mixed  $value
      * @param mixed  $expect
      * @param string $message

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -789,6 +789,8 @@ class Assert
     }
 
     /**
+     * @psalm-assert string $value
+     *
      * @param mixed  $value
      * @param string $message
      *

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1109,7 +1109,7 @@ class Assert
     }
 
     /**
-     * @param mixed  $value
+     * @param string  $value
      * @param string $message
      *
      * @throws InvalidArgumentException

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1896,7 +1896,9 @@ class Assert
     }
 
     /**
-     * @param mixed  $value
+     * @psalm-assert !empty $value
+     *
+     * @param string  $value
      * @param string $message
      *
      * @throws InvalidArgumentException

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1447,6 +1447,8 @@ class Assert
     /**
      * Will also pass if $value is a directory, use Assert::file() instead if you need to be sure it is a file.
      *
+     * @psalm-assert string $value
+     *
      * @param mixed  $value
      * @param string $message
      *

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -790,7 +790,6 @@ class Assert
     }
 
     /**
-     * @psalm-assert string|object $value note: can be an object implementing __toString
      * @psalm-assert !empty $value
      *
      * @param mixed  $value
@@ -809,7 +808,6 @@ class Assert
     }
 
     /**
-     * @psalm-assert string|object $value note: can be an object implementing __toString
      * @psalm-assert !empty $value
      *
      * @param mixed  $value
@@ -828,7 +826,6 @@ class Assert
     }
 
     /**
-     * @psalm-assert string|object $value note: can be an object implementing __toString
      * @psalm-assert !empty $value
      *
      * @param mixed  $value
@@ -847,7 +844,6 @@ class Assert
     }
 
     /**
-     * @psalm-assert string|object $value note: can be an object implementing __toString
      * @psalm-assert !empty $value
      *
      * @param mixed  $value

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -209,6 +209,7 @@ use Traversable;
 class Assert
 {
     /**
+     * @psalm-pure
      * @psalm-assert string $value
      *
      * @param mixed  $value
@@ -227,6 +228,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert string $value
      * @psalm-assert !empty $value
      *
@@ -242,6 +244,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert int $value
      *
      * @param mixed  $value
@@ -260,6 +263,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert numeric $value
      *
      * @param mixed  $value
@@ -278,6 +282,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert float $value
      *
      * @param mixed  $value
@@ -296,6 +301,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert numeric $value
      *
      * @param mixed  $value
@@ -314,6 +320,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert int $value
      *
      * @param mixed  $value
@@ -332,6 +339,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert bool $value
      *
      * @param mixed  $value
@@ -350,6 +358,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert scalar $value
      *
      * @param mixed  $value
@@ -368,6 +377,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert object $value
      *
      * @param mixed  $value
@@ -386,6 +396,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert resource $value
      *
      * @param mixed       $value
@@ -413,6 +424,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert callable $value
      *
      * @param mixed  $value
@@ -431,6 +443,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert array $value
      *
      * @param mixed  $value
@@ -449,6 +462,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert iterable $value
      *
      * @deprecated use "isIterable" or "isInstanceOf" instead
@@ -477,6 +491,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert array|ArrayAccess $value
      *
      * @param mixed  $value
@@ -495,6 +510,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert countable $value
      *
      * @param mixed  $value
@@ -518,6 +534,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert iterable $value
      *
      * @param mixed  $value
@@ -536,6 +553,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-template ExpectedType of object
      * @psalm-param class-string<ExpectedType> $class
      * @psalm-assert ExpectedType $value
@@ -558,6 +576,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-template ExpectedType of object
      * @psalm-param class-string<ExpectedType> $class
      * @psalm-assert !ExpectedType $value
@@ -580,6 +599,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param mixed                $value
      * @param array<object|string> $classes
      * @param string               $message
@@ -666,6 +687,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert empty $value
      *
      * @param mixed  $value
@@ -684,6 +706,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert !empty $value
      *
      * @param mixed  $value
@@ -702,6 +725,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert null $value
      *
      * @param mixed  $value
@@ -720,6 +744,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert !null $value
      *
      * @param mixed  $value
@@ -737,6 +762,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert true $value
      *
      * @param mixed  $value
@@ -755,6 +781,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert false $value
      *
      * @param mixed  $value
@@ -864,6 +891,8 @@ class Assert
     /**
      * Does non strict comparisons on the items, so ['3', 3] will not pass the assertion.
      *
+     * @psalm-pure
+     *
      * @param array  $values
      * @param string $message
      *
@@ -886,6 +915,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-template ExpectedType
      * @psalm-param ExpectedType $expect
      * @psalm-assert ExpectedType $value
@@ -908,6 +938,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param mixed  $value
      * @param mixed  $expect
      * @param string $message
@@ -925,6 +957,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param mixed  $value
      * @param mixed  $expect
      * @param string $message
@@ -943,6 +977,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param mixed  $value
      * @param mixed  $expect
      * @param string $message
@@ -960,6 +996,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param mixed  $value
      * @param mixed  $limit
      * @param string $message
@@ -978,6 +1016,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param mixed  $value
      * @param mixed  $limit
      * @param string $message
@@ -996,6 +1036,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param mixed  $value
      * @param mixed  $limit
      * @param string $message
@@ -1014,6 +1056,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param mixed  $value
      * @param mixed  $limit
      * @param string $message
@@ -1033,6 +1077,8 @@ class Assert
 
     /**
      * Inclusive range, so Assert::(3, 3, 5) passes.
+     *
+     * @psalm-pure
      *
      * @param mixed  $value
      * @param mixed  $min
@@ -1056,6 +1102,8 @@ class Assert
     /**
      * Does strict comparison, so Assert::oneOf(3, ['3']) does not pass the assertion.
      *
+     * @psalm-pure
+     *
      * @param mixed  $value
      * @param array  $values
      * @param string $message
@@ -1074,6 +1122,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string $value
      * @param string $subString
      * @param string $message
@@ -1092,6 +1142,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string $value
      * @param string $subString
      * @param string $message
@@ -1110,6 +1162,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string $value
      * @param string $message
      *
@@ -1126,6 +1180,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string $value
      * @param string $prefix
      * @param string $message
@@ -1144,6 +1200,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert string $value
      * @psalm-assert !empty $value
      *
@@ -1174,6 +1231,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string $value
      * @param string $suffix
      * @param string $message
@@ -1192,6 +1251,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string $value
      * @param string $pattern
      * @param string $message
@@ -1209,6 +1270,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string $value
      * @param string $pattern
      * @param string $message
@@ -1228,6 +1291,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert string $value
      * @psalm-assert !empty $value
      *
@@ -1249,6 +1313,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert string $value
      *
      * @param mixed  $value
@@ -1274,6 +1339,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert !empty $value
      *
      * @param string|int $value   can be an integer, since ctype_* functions accept ASCII integers -128 ~ +256
@@ -1297,6 +1363,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert !empty $value
      *
      * @param string|int $value   can be an integer, since ctype_* functions accept ASCII integers -128 ~ +256
@@ -1320,6 +1387,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert !empty $value
      *
      * @param string|int $value   can be an integer, since ctype_* functions accept ASCII integers -128 ~ +256
@@ -1343,6 +1411,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert !empty $value
      *
      * @param string|int $value   can be an integer, since ctype_* functions accept ASCII integers -128 ~ +256
@@ -1366,6 +1435,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string $value
      * @param int    $length
      * @param string $message
@@ -1385,6 +1456,8 @@ class Assert
 
     /**
      * Inclusive min.
+     *
+     * @psalm-pure
      *
      * @param string $value
      * @param int    $min
@@ -1406,6 +1479,8 @@ class Assert
     /**
      * Inclusive max.
      *
+     * @psalm-pure
+     *
      * @param string $value
      * @param int    $max
      * @param string $message
@@ -1425,6 +1500,8 @@ class Assert
 
     /**
      * Inclusive , so Assert::lengthBetween('asd', 3, 5); passes the assertion.
+     *
+     * @psalm-pure
      *
      * @param string $value
      * @param int    $min
@@ -1546,6 +1623,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert class-string $value
      *
      * @param mixed  $value
@@ -1564,6 +1642,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-template ExpectedType of object
      * @psalm-param class-string<ExpectedType> $class
      * @psalm-assert class-string<ExpectedType> $value
@@ -1586,6 +1665,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert class-string $value
      *
      * @param mixed  $value
@@ -1604,6 +1684,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-template ExpectedType of object
      * @psalm-param class-string<ExpectedType> $interface
      * @psalm-assert class-string<ExpectedType> $value
@@ -1626,6 +1707,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string|object $classOrObject
      * @param mixed         $property
      * @param string        $message
@@ -1643,6 +1726,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string|object $classOrObject
      * @param mixed         $property
      * @param string        $message
@@ -1660,6 +1745,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string|object $classOrObject
      * @param mixed         $method
      * @param string        $message
@@ -1677,6 +1764,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string|object $classOrObject
      * @param mixed         $method
      * @param string        $message
@@ -1694,6 +1783,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param array      $array
      * @param string|int $key
      * @param string     $message
@@ -1711,6 +1802,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param array      $array
      * @param string|int $key
      * @param string     $message
@@ -1730,6 +1823,7 @@ class Assert
     /**
      * Checks if a value is a valid array key (int or string).
      *
+     * @psalm-pure
      * @psalm-assert array-key $value
      *
      * @param mixed  $value
@@ -1830,6 +1924,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert list $array
      *
      * @param mixed  $array
@@ -1847,6 +1942,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert list $array
      * @psalm-assert !empty $array
      *
@@ -1862,6 +1958,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-template T
      * @psalm-param mixed|array<T> $array
      * @psalm-assert array<string, T> $array
@@ -1885,6 +1982,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-template T
      * @psalm-param mixed|array<T> $array
      * @psalm-assert array<string, T> $array
@@ -1901,6 +1999,7 @@ class Assert
     }
 
     /**
+     * @psalm-pure
      * @psalm-assert !empty $value
      *
      * @param string $value

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1073,7 +1073,7 @@ class Assert
     }
 
     /**
-     * @param mixed  $value
+     * @param string $value
      * @param string $subString
      * @param string $message
      *

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1190,8 +1190,8 @@ class Assert
     }
 
     /**
-     * @param mixed  $value
-     * @param mixed  $pattern
+     * @param string $value
+     * @param string $pattern
      * @param string $message
      *
      * @throws InvalidArgumentException

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1340,8 +1340,8 @@ class Assert
     /**
      * @psalm-pure
      *
-     * @param string|int $value   can be an integer, since ctype_* functions accept ASCII integers -128 ~ +256
-     * @param string     $message
+     * @param string $value
+     * @param string $message
      *
      * @throws InvalidArgumentException
      */
@@ -1363,8 +1363,8 @@ class Assert
     /**
      * @psalm-pure
      *
-     * @param string|int $value   can be an integer, since ctype_* functions accept ASCII integers -128 ~ +256
-     * @param string     $message
+     * @param string $value
+     * @param string $message
      *
      * @throws InvalidArgumentException
      */
@@ -1387,8 +1387,8 @@ class Assert
      * @psalm-pure
      * @psalm-assert lowercase-string $value
      *
-     * @param string|int $value   can be an integer, since ctype_* functions accept ASCII integers -128 ~ +256
-     * @param string     $message
+     * @param string $value
+     * @param string $message
      *
      * @throws InvalidArgumentException
      */
@@ -1411,8 +1411,8 @@ class Assert
      * @psalm-pure
      * @psalm-assert !lowercase-string $value
      *
-     * @param string|int $value   can be an integer, since ctype_* functions accept ASCII integers -128 ~ +256
-     * @param string     $message
+     * @param string $value
+     * @param string $message
      *
      * @throws InvalidArgumentException
      */

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1601,6 +1601,10 @@ class Assert
     }
 
     /**
+     * @psalm-template ExpectedType of object
+     * @psalm-param class-string<ExpectedType> $interface
+     * @psalm-assert class-string<ExpectedType> $value
+     *
      * @param mixed  $value
      * @param mixed  $interface
      * @param string $message

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1143,6 +1143,8 @@ class Assert
     }
 
     /**
+     * @psalm-assert string $value
+     *
      * @param mixed  $value
      * @param string $message
      *

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -843,6 +843,8 @@ class Assert
     }
 
     /**
+     * @psalm-assert string $value
+     *
      * @param mixed  $value
      * @param string $message
      *

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1880,6 +1880,10 @@ class Assert
     }
 
     /**
+     * @psalm-template T
+     * @psalm-param mixed|array<T> $array
+     * @psalm-assert array<string, T> $array
+     *
      * @param mixed  $array
      * @param string $message
      *

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1947,7 +1947,6 @@ class Assert
      * @psalm-template T
      * @psalm-param mixed|array<T> $array
      * @psalm-assert array<string, T> $array
-     * @psalm-assert !empty $array
      *
      * @param mixed  $array
      * @param string $message

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1525,7 +1525,9 @@ class Assert
     }
 
     /**
-     * @param mixed  $value
+     * @psalm-assert !empty $value
+     *
+     * @param string $value
      * @param string $message
      *
      * @throws InvalidArgumentException

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -600,6 +600,7 @@ class Assert
 
     /**
      * @psalm-pure
+     * @psalm-param array<class-string> $classes
      *
      * @param mixed                $value
      * @param array<object|string> $classes

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1125,7 +1125,7 @@ class Assert
     }
 
     /**
-     * @param mixed  $value
+     * @param string $value
      * @param string $prefix
      * @param string $message
      *

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1507,7 +1507,9 @@ class Assert
     }
 
     /**
-     * @param mixed  $value
+     * @psalm-assert !empty $value
+     *
+     * @param string $value
      * @param string $message
      *
      * @throws InvalidArgumentException

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -476,6 +476,8 @@ class Assert
     }
 
     /**
+     * @psalm-assert array|ArrayAccess $value
+     *
      * @param mixed  $value
      * @param string $message
      *

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1246,6 +1246,8 @@ class Assert
     }
 
     /**
+     * @psalm-assert string $value
+     *
      * @param mixed  $value
      * @param string $message
      *
@@ -1269,7 +1271,9 @@ class Assert
     }
 
     /**
-     * @param mixed  $value
+     * @psalm-assert !empty $value
+     *
+     * @param string $value
      * @param string $message
      *
      * @throws InvalidArgumentException
@@ -1290,7 +1294,9 @@ class Assert
     }
 
     /**
-     * @param mixed  $value
+     * @psalm-assert !empty $value
+     *
+     * @param string $value
      * @param string $message
      *
      * @throws InvalidArgumentException
@@ -1311,7 +1317,9 @@ class Assert
     }
 
     /**
-     * @param mixed  $value
+     * @psalm-assert !empty $value
+     *
+     * @param string $value
      * @param string $message
      *
      * @throws InvalidArgumentException
@@ -1332,7 +1340,9 @@ class Assert
     }
 
     /**
-     * @param mixed  $value
+     * @psalm-assert !empty $value
+     *
+     * @param string $value
      * @param string $message
      *
      * @throws InvalidArgumentException

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -790,7 +790,8 @@ class Assert
     }
 
     /**
-     * @psalm-assert string $value
+     * @psalm-assert string|object $value note: can be an object implementing __toString
+     * @psalm-assert !empty $value
      *
      * @param mixed  $value
      * @param string $message
@@ -808,7 +809,8 @@ class Assert
     }
 
     /**
-     * @psalm-assert string $value
+     * @psalm-assert string|object $value note: can be an object implementing __toString
+     * @psalm-assert !empty $value
      *
      * @param mixed  $value
      * @param string $message
@@ -826,7 +828,8 @@ class Assert
     }
 
     /**
-     * @psalm-assert string $value
+     * @psalm-assert string|object $value note: can be an object implementing __toString
+     * @psalm-assert !empty $value
      *
      * @param mixed  $value
      * @param string $message
@@ -844,7 +847,8 @@ class Assert
     }
 
     /**
-     * @psalm-assert string $value
+     * @psalm-assert string|object $value note: can be an object implementing __toString
+     * @psalm-assert !empty $value
      *
      * @param mixed  $value
      * @param string $message

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1091,7 +1091,7 @@ class Assert
     }
 
     /**
-     * @param string  $value
+     * @param string $value
      * @param string $subString
      * @param string $message
      *
@@ -1109,7 +1109,7 @@ class Assert
     }
 
     /**
-     * @param string  $value
+     * @param string $value
      * @param string $message
      *
      * @throws InvalidArgumentException
@@ -1898,7 +1898,7 @@ class Assert
     /**
      * @psalm-assert !empty $value
      *
-     * @param string  $value
+     * @param string $value
      * @param string $message
      *
      * @throws InvalidArgumentException

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1172,7 +1172,7 @@ class Assert
     }
 
     /**
-     * @param mixed  $value
+     * @param string $value
      * @param string $suffix
      * @param string $message
      *

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -227,6 +227,8 @@ class Assert
     }
 
     /**
+     * @psalm-assert string $value
+     *
      * @param mixed  $value
      * @param string $message
      *

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1467,6 +1467,8 @@ class Assert
     }
 
     /**
+     * @psalm-assert string $value
+     *
      * @param mixed  $value
      * @param string $message
      *
@@ -1485,6 +1487,8 @@ class Assert
     }
 
     /**
+     * @psalm-assert string $value
+     *
      * @param mixed  $value
      * @param string $message
      *

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -807,6 +807,8 @@ class Assert
     }
 
     /**
+     * @psalm-assert string $value
+     *
      * @param mixed  $value
      * @param string $message
      *
@@ -823,6 +825,8 @@ class Assert
     }
 
     /**
+     * @psalm-assert string $value
+     *
      * @param mixed  $value
      * @param string $message
      *

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1561,6 +1561,10 @@ class Assert
     }
 
     /**
+     * @psalm-template ExpectedType of object
+     * @psalm-param class-string<ExpectedType> $class
+     * @psalm-assert class-string<ExpectedType> $value
+     *
      * @param mixed         $value
      * @param string|object $class
      * @param string        $message

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1207,8 +1207,8 @@ class Assert
     }
 
     /**
-     * @param mixed  $value
-     * @param mixed  $pattern
+     * @param string $value
+     * @param string $pattern
      * @param string $message
      *
      * @throws InvalidArgumentException

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1748,8 +1748,8 @@ class Assert
      * Does not check if $array is countable, this can generate a warning on php versions after 7.2.
      *
      * @param Countable|array $array
-     * @param int            $number
-     * @param string         $message
+     * @param int             $number
+     * @param string          $message
      *
      * @throws InvalidArgumentException
      */
@@ -1765,9 +1765,9 @@ class Assert
     /**
      * Does not check if $array is countable, this can generate a warning on php versions after 7.2.
      *
-     * @param mixed  $array
-     * @param mixed  $min
-     * @param string $message
+     * @param Countable|array $array
+     * @param int             $min
+     * @param string          $message
      *
      * @throws InvalidArgumentException
      */
@@ -1785,9 +1785,9 @@ class Assert
     /**
      * Does not check if $array is countable, this can generate a warning on php versions after 7.2.
      *
-     * @param mixed  $array
-     * @param mixed  $max
-     * @param string $message
+     * @param Countable|array $array
+     * @param int             $max
+     * @param string          $message
      *
      * @throws InvalidArgumentException
      */
@@ -1805,10 +1805,10 @@ class Assert
     /**
      * Does not check if $array is countable, this can generate a warning on php versions after 7.2.
      *
-     * @param mixed  $array
-     * @param mixed  $min
-     * @param mixed  $max
-     * @param string $message
+     * @param Countable|array $array
+     * @param int             $min
+     * @param int             $max
+     * @param string          $message
      *
      * @throws InvalidArgumentException
      */

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1149,6 +1149,7 @@ class Assert
 
     /**
      * @psalm-assert string $value
+     * @psalm-assert !empty $value
      *
      * @param mixed  $value
      * @param string $message
@@ -1232,6 +1233,7 @@ class Assert
 
     /**
      * @psalm-assert string $value
+     * @psalm-assert !empty $value
      *
      * @param mixed  $value
      * @param string $message
@@ -1278,8 +1280,8 @@ class Assert
     /**
      * @psalm-assert !empty $value
      *
-     * @param string $value
-     * @param string $message
+     * @param string|int $value   can be an integer, since ctype_* functions accept ASCII integers -128 ~ +256
+     * @param string     $message
      *
      * @throws InvalidArgumentException
      */
@@ -1301,8 +1303,8 @@ class Assert
     /**
      * @psalm-assert !empty $value
      *
-     * @param string $value
-     * @param string $message
+     * @param string|int $value   can be an integer, since ctype_* functions accept ASCII integers -128 ~ +256
+     * @param string     $message
      *
      * @throws InvalidArgumentException
      */
@@ -1324,8 +1326,8 @@ class Assert
     /**
      * @psalm-assert !empty $value
      *
-     * @param string $value
-     * @param string $message
+     * @param string|int $value   can be an integer, since ctype_* functions accept ASCII integers -128 ~ +256
+     * @param string     $message
      *
      * @throws InvalidArgumentException
      */
@@ -1347,8 +1349,8 @@ class Assert
     /**
      * @psalm-assert !empty $value
      *
-     * @param string $value
-     * @param string $message
+     * @param string|int $value   can be an integer, since ctype_* functions accept ASCII integers -128 ~ +256
+     * @param string     $message
      *
      * @throws InvalidArgumentException
      */

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -2162,6 +2162,8 @@ class Assert
      * @param string $message
      *
      * @throws InvalidArgumentException
+     *
+     * @psalm-pure this method is not supposed to perform side-effects
      */
     protected static function reportInvalidArgument($message)
     {

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -674,6 +674,9 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     * @psalm-param array<class-string> $classes
+     *
      * @param object|string $value
      * @param string[]      $classes
      * @param string        $message

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1645,7 +1645,7 @@ class Assert
      * @psalm-pure
      * @psalm-template ExpectedType of object
      * @psalm-param class-string<ExpectedType> $class
-     * @psalm-assert class-string<ExpectedType> $value
+     * @psalm-assert class-string<ExpectedType>|ExpectedType $value
      *
      * @param mixed         $value
      * @param string|object $class

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1810,6 +1810,10 @@ class Assert
     }
 
     /**
+     * @psalm-template T
+     * @psalm-param mixed|array<T> $array
+     * @psalm-assert array<string, T> $array
+     *
      * @param mixed  $array
      * @param string $message
      *

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -228,6 +228,7 @@ class Assert
 
     /**
      * @psalm-assert string $value
+     * @psalm-assert !empty $value
      *
      * @param mixed  $value
      * @param string $message
@@ -1844,7 +1845,8 @@ class Assert
     }
 
     /**
-     * @psalm-assert non-empty-list $array
+     * @psalm-assert list $array
+     * @psalm-assert !empty $array
      *
      * @param mixed  $array
      * @param string $message
@@ -1861,6 +1863,7 @@ class Assert
      * @psalm-template T
      * @psalm-param mixed|array<T> $array
      * @psalm-assert array<string, T> $array
+     * @psalm-assert !empty $array
      *
      * @param mixed  $array
      * @param string $message

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1747,9 +1747,9 @@ class Assert
     /**
      * Does not check if $array is countable, this can generate a warning on php versions after 7.2.
      *
-     * @param mixed  $array
-     * @param mixed  $number
-     * @param string $message
+     * @param Countable|array $array
+     * @param int            $number
+     * @param string         $message
      *
      * @throws InvalidArgumentException
      */

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1456,9 +1456,9 @@ class Assert
      *
      * @psalm-pure
      *
-     * @param string $value
-     * @param int    $min
-     * @param string $message
+     * @param string    $value
+     * @param int|float $min
+     * @param string    $message
      *
      * @throws InvalidArgumentException
      */
@@ -1478,9 +1478,9 @@ class Assert
      *
      * @psalm-pure
      *
-     * @param string $value
-     * @param int    $max
-     * @param string $message
+     * @param string    $value
+     * @param int|float $max
+     * @param string    $message
      *
      * @throws InvalidArgumentException
      */
@@ -1500,10 +1500,10 @@ class Assert
      *
      * @psalm-pure
      *
-     * @param string $value
-     * @param int    $min
-     * @param int    $max
-     * @param string $message
+     * @param string    $value
+     * @param int|float $min
+     * @param int|float $max
+     * @param string    $message
      *
      * @throws InvalidArgumentException
      */
@@ -1848,7 +1848,7 @@ class Assert
      * Does not check if $array is countable, this can generate a warning on php versions after 7.2.
      *
      * @param Countable|array $array
-     * @param int             $min
+     * @param int|float       $min
      * @param string          $message
      *
      * @throws InvalidArgumentException
@@ -1868,7 +1868,7 @@ class Assert
      * Does not check if $array is countable, this can generate a warning on php versions after 7.2.
      *
      * @param Countable|array $array
-     * @param int             $max
+     * @param int|float       $max
      * @param string          $message
      *
      * @throws InvalidArgumentException
@@ -1888,8 +1888,8 @@ class Assert
      * Does not check if $array is countable, this can generate a warning on php versions after 7.2.
      *
      * @param Countable|array $array
-     * @param int             $min
-     * @param int             $max
+     * @param int|float       $min
+     * @param int|float       $max
      * @param string          $message
      *
      * @throws InvalidArgumentException

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1383,8 +1383,8 @@ class Assert
     /**
      * Inclusive min.
      *
-     * @param mixed  $value
-     * @param mixed  $min
+     * @param string $value
+     * @param int    $min
      * @param string $message
      *
      * @throws InvalidArgumentException
@@ -1403,8 +1403,8 @@ class Assert
     /**
      * Inclusive max.
      *
-     * @param mixed  $value
-     * @param mixed  $max
+     * @param string $value
+     * @param int    $max
      * @param string $message
      *
      * @throws InvalidArgumentException
@@ -1423,9 +1423,9 @@ class Assert
     /**
      * Inclusive , so Assert::lengthBetween('asd', 3, 5); passes the assertion.
      *
-     * @param mixed  $value
-     * @param mixed  $min
-     * @param mixed  $max
+     * @param string $value
+     * @param int    $min
+     * @param int    $max
      * @param string $message
      *
      * @throws InvalidArgumentException

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -885,6 +885,10 @@ class Assert
     }
 
     /**
+     * @psalm-template ExpectedType
+     * @psalm-param ExpectedType $expect
+     * @psalm-assert ExpectedType $value
+     *
      * @param mixed  $value
      * @param mixed  $expect
      * @param string $message

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -648,6 +648,12 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     * @psalm-template UnexpectedType of object
+     * @psalm-param class-string<UnexpectedType> $class
+     * @psalm-assert !UnexpectedType $value
+     * @psalm-assert !class-string<UnexpectedType> $value
+     *
      * @param object|string $value
      * @param string        $class
      * @param string        $message

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1226,6 +1226,8 @@ class Assert
     }
 
     /**
+     * @psalm-assert string $value
+     *
      * @param mixed  $value
      * @param string $message
      *

--- a/tests/ProjectCodeTest.php
+++ b/tests/ProjectCodeTest.php
@@ -116,9 +116,31 @@ class ProjectCodeTest extends BaseTestCase
     public function testHasCorrespondingStaticAnalysisFile($method)
     {
         $doc = $method->getDocComment();
+        $methodName = $method->getName();
+
         if($doc === false || strpos($doc, '@psalm-assert') === false) {
             $this->addToAssertionCount(1);
             return;
+        }
+
+        if (\in_array(
+            $methodName,
+            [
+                'alnum',
+                'digits',
+                'upper',
+                'lower',
+                'readable',
+                'writable',
+                'uuid',
+            ],
+            true
+        )) {
+            self::markTestIncomplete(\sprintf(
+                'Could not design assertions for "%s" due to missing !empty test scenario'
+                . "\n\nSee https://github.com/vimeo/psalm/issues/2450#issuecomment-563479630",
+                $methodName
+            ));
         }
 
         $this->assertFileExists(

--- a/tests/ProjectCodeTest.php
+++ b/tests/ProjectCodeTest.php
@@ -125,7 +125,7 @@ class ProjectCodeTest extends BaseTestCase
 
         if (\in_array(
             $methodName,
-            [
+            array(
                 'alnum',
                 'digits',
                 'upper',
@@ -133,7 +133,7 @@ class ProjectCodeTest extends BaseTestCase
                 'readable',
                 'writable',
                 'uuid',
-            ],
+            ),
             true
         )) {
             self::markTestIncomplete(\sprintf(

--- a/tests/ProjectCodeTest.php
+++ b/tests/ProjectCodeTest.php
@@ -116,31 +116,10 @@ class ProjectCodeTest extends BaseTestCase
     public function testHasCorrespondingStaticAnalysisFile($method)
     {
         $doc = $method->getDocComment();
-        $methodName = $method->getName();
 
         if($doc === false || strpos($doc, '@psalm-assert') === false) {
             $this->addToAssertionCount(1);
             return;
-        }
-
-        if (\in_array(
-            $methodName,
-            array(
-                'alnum',
-                'digits',
-                'upper',
-                'lower',
-                'readable',
-                'writable',
-                'uuid',
-            ),
-            true
-        )) {
-            self::markTestIncomplete(\sprintf(
-                'Could not design assertions for "%s" due to missing !empty test scenario'
-                . "\n\nSee https://github.com/vimeo/psalm/issues/2450#issuecomment-563479630",
-                $methodName
-            ));
         }
 
         $this->assertFileExists(

--- a/tests/static-analysis/assert-alnum.php
+++ b/tests/static-analysis/assert-alnum.php
@@ -5,13 +5,15 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
+ *
  * @psalm-param non-empty-string $value
  *
- * @return non-empty-string
+ * @psalm-return non-empty-string
  */
 function consume(string $value): string
 {
-    Assert::ipv6($value);
+    Assert::alnum($value);
 
     return $value;
 }

--- a/tests/static-analysis/assert-alpha.php
+++ b/tests/static-analysis/assert-alpha.php
@@ -13,3 +13,10 @@ function consume($value): string
 
     return $value;
 }
+
+function consumeNullableString(?string $value): string
+{
+    Assert::alpha($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-alpha.php
+++ b/tests/static-analysis/assert-alpha.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-param mixed $value
+ */
+function consume($value): string
+{
+    Assert::alpha($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-alpha.php
+++ b/tests/static-analysis/assert-alpha.php
@@ -5,6 +5,7 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param mixed $value
  */
 function consume($value): string
@@ -14,6 +15,9 @@ function consume($value): string
     return $value;
 }
 
+/**
+ * @psalm-pure
+ */
 function consumeNullableString(?string $value): string
 {
     Assert::alpha($value);

--- a/tests/static-analysis/assert-alpha.php
+++ b/tests/static-analysis/assert-alpha.php
@@ -6,19 +6,12 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- * @psalm-param mixed $value
+ *
+ * @psalm-param non-empty-string $value
+ *
+ * @psalm-return non-empty-string
  */
-function consume($value): string
-{
-    Assert::alpha($value);
-
-    return $value;
-}
-
-/**
- * @psalm-pure
- */
-function consumeNullableString(?string $value): string
+function consume(string $value): string
 {
     Assert::alpha($value);
 

--- a/tests/static-analysis/assert-boolean.php
+++ b/tests/static-analysis/assert-boolean.php
@@ -5,6 +5,7 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param mixed $value
  */
 function consume($value): bool

--- a/tests/static-analysis/assert-classExists.php
+++ b/tests/static-analysis/assert-classExists.php
@@ -6,10 +6,8 @@ use Webmozart\Assert\Assert;
 
 
 /**
- * @psalm-pure
- * @param mixed $value
+ * @psalm-param class-string $value
  *
- * @return string
  * @psalm-return class-string
  */
 function consume($value): string

--- a/tests/static-analysis/assert-classExists.php
+++ b/tests/static-analysis/assert-classExists.php
@@ -6,6 +6,7 @@ use Webmozart\Assert\Assert;
 
 
 /**
+ * @psalm-pure
  * @param mixed $value
  *
  * @return string

--- a/tests/static-analysis/assert-contains.php
+++ b/tests/static-analysis/assert-contains.php
@@ -5,13 +5,11 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
- * @psalm-param non-empty-string $value
- *
- * @return non-empty-string
+ * @psalm-pure
  */
 function consume(string $value): string
 {
-    Assert::ipv6($value);
+    Assert::contains($value, 'foo');
 
     return $value;
 }

--- a/tests/static-analysis/assert-count.php
+++ b/tests/static-analysis/assert-count.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Countable;
+use Webmozart\Assert\Assert;
+
+function consume(Countable $value): Countable
+{
+    Assert::count($value, 1);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-countBetween.php
+++ b/tests/static-analysis/assert-countBetween.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Countable;
+use Webmozart\Assert\Assert;
+
+function consume(Countable $value): Countable
+{
+    Assert::countBetween($value, 1, 10);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-countBetween.php
+++ b/tests/static-analysis/assert-countBetween.php
@@ -5,9 +5,13 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Countable;
 use Webmozart\Assert\Assert;
 
-function consume(Countable $value): Countable
+/**
+ * @param int|float $min
+ * @param int|float $max
+ */
+function consume(Countable $value, $min, $max): Countable
 {
-    Assert::countBetween($value, 1, 10);
+    Assert::countBetween($value, $min, $max);
 
     return $value;
 }

--- a/tests/static-analysis/assert-digits.php
+++ b/tests/static-analysis/assert-digits.php
@@ -5,13 +5,15 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
+ *
  * @psalm-param non-empty-string $value
  *
- * @return non-empty-string
+ * @psalm-return non-empty-string
  */
 function consume(string $value): string
 {
-    Assert::ipv6($value);
+    Assert::digits($value);
 
     return $value;
 }

--- a/tests/static-analysis/assert-directory.php
+++ b/tests/static-analysis/assert-directory.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-param mixed $value
+ */
+function consume($value): string
+{
+    Assert::directory($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-directory.php
+++ b/tests/static-analysis/assert-directory.php
@@ -5,9 +5,11 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
- * @psalm-param mixed $value
+ * @psalm-param non-empty-string $value
+ *
+ * @return non-empty-string
  */
-function consume($value): string
+function consume(string $value): string
 {
     Assert::directory($value);
 

--- a/tests/static-analysis/assert-email.php
+++ b/tests/static-analysis/assert-email.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-param mixed $value
+ */
+function consume($value): string
+{
+    Assert::email($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-email.php
+++ b/tests/static-analysis/assert-email.php
@@ -4,14 +4,12 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 
 use Webmozart\Assert\Assert;
 
-function consume(?string $value): string
-{
-    Assert::email($value);
-
-    return $value;
-}
-
-function consumeObject(?object $value): object
+/**
+ * @psalm-param non-empty-string $value
+ *
+ * @return non-empty-string
+ */
+function consume(string $value): string
 {
     Assert::email($value);
 

--- a/tests/static-analysis/assert-email.php
+++ b/tests/static-analysis/assert-email.php
@@ -4,10 +4,14 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 
 use Webmozart\Assert\Assert;
 
-/**
- * @psalm-param mixed $value
- */
-function consume($value): string
+function consume(?string $value): string
+{
+    Assert::email($value);
+
+    return $value;
+}
+
+function consumeObject(?object $value): object
 {
     Assert::email($value);
 

--- a/tests/static-analysis/assert-endsWith.php
+++ b/tests/static-analysis/assert-endsWith.php
@@ -5,13 +5,14 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param non-empty-string $value
  *
- * @return non-empty-string
+ * @psalm-return non-empty-string
  */
-function consume(string $value): string
+function consume($value): string
 {
-    Assert::ipv6($value);
+    Assert::endsWith($value, 'foo');
 
     return $value;
 }

--- a/tests/static-analysis/assert-eq.php
+++ b/tests/static-analysis/assert-eq.php
@@ -4,9 +4,6 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 
 use Webmozart\Assert\Assert;
 
-/**
- * @psalm-pure
- */
 function consume(string $value): string
 {
     Assert::eq($value, 'foo');

--- a/tests/static-analysis/assert-eq.php
+++ b/tests/static-analysis/assert-eq.php
@@ -5,13 +5,11 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
- * @psalm-param non-empty-string $value
- *
- * @return non-empty-string
+ * @psalm-pure
  */
 function consume(string $value): string
 {
-    Assert::ipv6($value);
+    Assert::eq($value, 'foo');
 
     return $value;
 }

--- a/tests/static-analysis/assert-false.php
+++ b/tests/static-analysis/assert-false.php
@@ -5,6 +5,7 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @param mixed $value
  */
 function consume($value): bool

--- a/tests/static-analysis/assert-file.php
+++ b/tests/static-analysis/assert-file.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-param mixed $value
+ */
+function consume($value): string
+{
+    Assert::file($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-file.php
+++ b/tests/static-analysis/assert-file.php
@@ -5,9 +5,11 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
- * @psalm-param mixed $value
+ * @psalm-param non-empty-string $value
+ *
+ * @return non-empty-string
  */
-function consume($value): string
+function consume(string $value): string
 {
     Assert::file($value);
 

--- a/tests/static-analysis/assert-fileExists.php
+++ b/tests/static-analysis/assert-fileExists.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-param mixed $value
+ */
+function consume($value): string
+{
+    Assert::fileExists($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-fileExists.php
+++ b/tests/static-analysis/assert-fileExists.php
@@ -5,9 +5,11 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
- * @psalm-param mixed $value
+ * @psalm-param non-empty-string $value
+ *
+ * @return non-empty-string
  */
-function consume($value): string
+function consume(string $value): string
 {
     Assert::fileExists($value);
 

--- a/tests/static-analysis/assert-float.php
+++ b/tests/static-analysis/assert-float.php
@@ -5,6 +5,7 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param mixed $value
  */
 function consume($value): float

--- a/tests/static-analysis/assert-greaterThan.php
+++ b/tests/static-analysis/assert-greaterThan.php
@@ -6,13 +6,10 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- * @psalm-param mixed $value
- *
- * @psalm-return array-key
  */
-function consume($value)
+function consume(int $value): int
 {
-    Assert::validArrayKey($value);
+    Assert::greaterThan($value, 1);
 
     return $value;
 }

--- a/tests/static-analysis/assert-greaterThanEq.php
+++ b/tests/static-analysis/assert-greaterThanEq.php
@@ -6,13 +6,10 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- * @psalm-param mixed $value
- *
- * @psalm-return array-key
  */
-function consume($value)
+function consume(int $value): int
 {
-    Assert::validArrayKey($value);
+    Assert::greaterThanEq($value, 1);
 
     return $value;
 }

--- a/tests/static-analysis/assert-implementsInterface.php
+++ b/tests/static-analysis/assert-implementsInterface.php
@@ -19,6 +19,8 @@ interface ImplementsInterfaceC
 /**
  * @param mixed $value
  *
+ * @psalm-pure
+ *
  * @psalm-return class-string<ImplementsInterfaceA> $value
  */
 function consumeMixed($value): string
@@ -29,6 +31,8 @@ function consumeMixed($value): string
 }
 
 /**
+ * @psalm-pure
+ *
  * @psalm-param class-string<ImplementsInterfaceB>|class-string<ImplementsInterfaceC> $value
  *
  * @psalm-return class-string<ImplementsInterfaceB> $value

--- a/tests/static-analysis/assert-implementsInterface.php
+++ b/tests/static-analysis/assert-implementsInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Webmozart\Assert\Assert;
+
+interface ImplementsInterfaceA
+{
+}
+
+interface ImplementsInterfaceB extends ImplementsInterfaceA
+{
+}
+
+interface ImplementsInterfaceC
+{
+}
+
+/**
+ * @param mixed $value
+ *
+ * @psalm-return class-string<ImplementsInterfaceA> $value
+ */
+function consumeMixed($value): string
+{
+    Assert::implementsInterface($value, ImplementsInterfaceA::class);
+
+    return $value;
+}
+
+/**
+ * @psalm-param class-string<ImplementsInterfaceB>|class-string<ImplementsInterfaceC> $value
+ *
+ * @psalm-return class-string<ImplementsInterfaceB> $value
+ */
+function consumeSubclass(string $value): string
+{
+    Assert::implementsInterface($value, ImplementsInterfaceB::class);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-integer.php
+++ b/tests/static-analysis/assert-integer.php
@@ -5,6 +5,7 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param mixed $value
  */
 function consume($value): int

--- a/tests/static-analysis/assert-integerish.php
+++ b/tests/static-analysis/assert-integerish.php
@@ -5,6 +5,7 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param string|numeric $value
  *
  * @psalm-return numeric

--- a/tests/static-analysis/assert-interfaceExists.php
+++ b/tests/static-analysis/assert-interfaceExists.php
@@ -6,11 +6,8 @@ use Webmozart\Assert\Assert;
 
 
 /**
- * @param mixed $value
+ * @param class-string $value
  *
- * @return string
- *
- * @psalm-pure
  * @psalm-return class-string
  */
 function consume($value): string

--- a/tests/static-analysis/assert-interfaceExists.php
+++ b/tests/static-analysis/assert-interfaceExists.php
@@ -9,6 +9,8 @@ use Webmozart\Assert\Assert;
  * @param mixed $value
  *
  * @return string
+ *
+ * @psalm-pure
  * @psalm-return class-string
  */
 function consume($value): string

--- a/tests/static-analysis/assert-ip.php
+++ b/tests/static-analysis/assert-ip.php
@@ -4,17 +4,14 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 
 use Webmozart\Assert\Assert;
 
-function consume(?string $value): string
+/**
+ * @psalm-param non-empty-string $value
+ *
+ * @return non-empty-string
+ */
+function consume(string $value): string
 {
     Assert::ip($value);
 
     return $value;
 }
-
-function consumeObject(?object $value): object
-{
-    Assert::ip($value);
-
-    return $value;
-}
-

--- a/tests/static-analysis/assert-ip.php
+++ b/tests/static-analysis/assert-ip.php
@@ -4,12 +4,17 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 
 use Webmozart\Assert\Assert;
 
-/**
- * @psalm-param mixed $value
- */
-function consume($value): string
+function consume(?string $value): string
 {
     Assert::ip($value);
 
     return $value;
 }
+
+function consumeObject(?object $value): object
+{
+    Assert::ip($value);
+
+    return $value;
+}
+

--- a/tests/static-analysis/assert-ip.php
+++ b/tests/static-analysis/assert-ip.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-param mixed $value
+ */
+function consume($value): string
+{
+    Assert::ip($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-ipv4.php
+++ b/tests/static-analysis/assert-ipv4.php
@@ -4,12 +4,17 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 
 use Webmozart\Assert\Assert;
 
-/**
- * @psalm-param mixed $value
- */
-function consume($value): string
+function consume(?string $value): string
 {
     Assert::ipv4($value);
 
     return $value;
 }
+
+function consumeObject(?object $value): object
+{
+    Assert::ipv4($value);
+
+    return $value;
+}
+

--- a/tests/static-analysis/assert-ipv4.php
+++ b/tests/static-analysis/assert-ipv4.php
@@ -4,17 +4,14 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 
 use Webmozart\Assert\Assert;
 
-function consume(?string $value): string
+/**
+ * @psalm-param non-empty-string $value
+ *
+ * @return non-empty-string
+ */
+function consume(string $value): string
 {
     Assert::ipv4($value);
 
     return $value;
 }
-
-function consumeObject(?object $value): object
-{
-    Assert::ipv4($value);
-
-    return $value;
-}
-

--- a/tests/static-analysis/assert-ipv4.php
+++ b/tests/static-analysis/assert-ipv4.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-param mixed $value
+ */
+function consume($value): string
+{
+    Assert::ipv4($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-ipv6.php
+++ b/tests/static-analysis/assert-ipv6.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-param mixed $value
+ */
+function consume($value): string
+{
+    Assert::ipv6($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-ipv6.php
+++ b/tests/static-analysis/assert-ipv6.php
@@ -4,12 +4,17 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 
 use Webmozart\Assert\Assert;
 
-/**
- * @psalm-param mixed $value
- */
-function consume($value): string
+function consume(?string $value): string
 {
     Assert::ipv6($value);
 
     return $value;
 }
+
+function consumeObject(?object $value): object
+{
+    Assert::ipv6($value);
+
+    return $value;
+}
+

--- a/tests/static-analysis/assert-isAOf.php
+++ b/tests/static-analysis/assert-isAOf.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Webmozart\Assert\Assert;
+
+interface IsAOfA
+{
+}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-param string|object $value
+ *
+ * @psalm-return class-string<IsAOfA>|IsAOfA
+ */
+function consume($value)
+{
+    Assert::isAOf($value, IsAOfA::class);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-isAnyOf.php
+++ b/tests/static-analysis/assert-isAnyOf.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Webmozart\Assert\Assert;
+
+final class IsAnyOfA {}
+final class IsAnyOfB {}
+
+/**
+ * @psalm-pure
+ */
+function consume(object $value): object
+{
+    Assert::isAnyOf($value, [IsAnyOfA::class, IsAnyOfB::class]);
+
+    return $value;
+}
+

--- a/tests/static-analysis/assert-isArray.php
+++ b/tests/static-analysis/assert-isArray.php
@@ -5,6 +5,7 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param mixed $value
  */
 function consume($value): array

--- a/tests/static-analysis/assert-isArrayAccessible.php
+++ b/tests/static-analysis/assert-isArrayAccessible.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-param mixed $value
+ *
+ * @return array|\ArrayAccess
+ */
+function consume($value)
+{
+    Assert::isArrayAccessible($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-isArrayAccessible.php
+++ b/tests/static-analysis/assert-isArrayAccessible.php
@@ -5,6 +5,7 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param mixed $value
  *
  * @return array|\ArrayAccess

--- a/tests/static-analysis/assert-isCallable.php
+++ b/tests/static-analysis/assert-isCallable.php
@@ -5,6 +5,7 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param mixed $value
  */
 function consume($value): callable

--- a/tests/static-analysis/assert-isCountable.php
+++ b/tests/static-analysis/assert-isCountable.php
@@ -6,6 +6,7 @@ use Countable;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param object $value
  */
 function consume($value): Countable

--- a/tests/static-analysis/assert-isEmpty.php
+++ b/tests/static-analysis/assert-isEmpty.php
@@ -6,7 +6,8 @@ use Webmozart\Assert\Assert;
 
 
 /**
-
+ * @psalm-pure
+ *
  * @return null
  */
 function consume(?object $value)

--- a/tests/static-analysis/assert-isInstanceOf.php
+++ b/tests/static-analysis/assert-isInstanceOf.php
@@ -6,6 +6,7 @@ use stdClass;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @param mixed $value
  */
 function consume($value) : stdClass

--- a/tests/static-analysis/assert-isInstanceOfAny.php
+++ b/tests/static-analysis/assert-isInstanceOfAny.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Webmozart\Assert\Assert;
+
+final class IsInstanceOfAnyA {}
+final class IsInstanceOfAnyB {}
+
+/**
+ * @psalm-pure
+ */
+function consume(object $value): object
+{
+    Assert::isInstanceOfAny($value, [IsInstanceOfAnyA::class, IsInstanceOfAnyB::class]);
+
+    return $value;
+}
+

--- a/tests/static-analysis/assert-isIterable.php
+++ b/tests/static-analysis/assert-isIterable.php
@@ -5,6 +5,7 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param mixed $value
  */
 function consume($value): iterable

--- a/tests/static-analysis/assert-isList.php
+++ b/tests/static-analysis/assert-isList.php
@@ -5,6 +5,8 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
+ *
  * @psalm-param mixed $value
  *
  * @psalm-return list<mixed>
@@ -17,6 +19,8 @@ function consume($value): array
 }
 
 /**
+ * @psalm-pure
+ *
  * @psalm-param array<\stdClass> $value
  *
  * @psalm-return list<\stdClass>

--- a/tests/static-analysis/assert-isList.php
+++ b/tests/static-analysis/assert-isList.php
@@ -15,3 +15,15 @@ function consume($value): array
 
     return $value;
 }
+
+/**
+ * @psalm-param array<\stdClass> $value
+ *
+ * @psalm-return list<\stdClass>
+ */
+function consumeWithPreciseItemType(array $value): array
+{
+    Assert::isList($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-isMap.php
+++ b/tests/static-analysis/assert-isMap.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @param mixed $value
+ *
+ * @return array<string, mixed>
+ */
+function consume($value): array
+{
+    Assert::isMap($value);
+
+    return $value;
+}
+
+/**
+ * Verifying that the type of the elements in the array is preserved by the assertion
+ *
+ * @param array<int|string, \stdClass> $value
+ *
+ * @return array<string, \stdClass>
+ */
+function consumeWithSpecificValueType(array $value): array
+{
+    Assert::isMap($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-isMap.php
+++ b/tests/static-analysis/assert-isMap.php
@@ -5,6 +5,8 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
+ *
  * @param mixed $value
  *
  * @return array<string, mixed>
@@ -18,6 +20,8 @@ function consume($value): array
 
 /**
  * Verifying that the type of the elements in the array is preserved by the assertion
+ *
+ * @psalm-pure
  *
  * @param array<int|string, \stdClass> $value
  *

--- a/tests/static-analysis/assert-isMap.php
+++ b/tests/static-analysis/assert-isMap.php
@@ -33,3 +33,18 @@ function consumeWithSpecificValueType(array $value): array
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param array<int|string, mixed> $value
+ *
+ * @return array<string, mixed>
+ */
+function consumeAllowsForEmptyArrays(array $value): array
+{
+    Assert::isMap($value);
+    Assert::isEmpty($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-isNonEmptyList.php
+++ b/tests/static-analysis/assert-isNonEmptyList.php
@@ -5,6 +5,8 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
+ *
  * @psalm-param mixed $value
  *
  * @psalm-return non-empty-list<mixed>

--- a/tests/static-analysis/assert-isNonEmptyMap.php
+++ b/tests/static-analysis/assert-isNonEmptyMap.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @param mixed $value
+ *
+ * @return array<string, mixed>
+ */
+function consume($value): array
+{
+    Assert::isNonEmptyMap($value);
+
+    return $value;
+}
+
+/**
+ * Verifying that the type of the elements in the array is preserved by the assertion
+ *
+ * @param array<int|string, \stdClass> $value
+ *
+ * @return array<string, \stdClass>
+ */
+function consumeWithSpecificValueType(array $value): array
+{
+    Assert::isNonEmptyMap($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-isNonEmptyMap.php
+++ b/tests/static-analysis/assert-isNonEmptyMap.php
@@ -5,6 +5,8 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
+ *
  * @param mixed $value
  *
  * @return array<string, mixed>
@@ -18,6 +20,8 @@ function consume($value): array
 
 /**
  * Verifying that the type of the elements in the array is preserved by the assertion
+ *
+ * @psalm-pure
  *
  * @param array<int|string, \stdClass> $value
  *

--- a/tests/static-analysis/assert-isNonEmptyMap.php
+++ b/tests/static-analysis/assert-isNonEmptyMap.php
@@ -33,3 +33,18 @@ function consumeWithSpecificValueType(array $value): array
 
     return $value;
 }
+
+
+/**
+ * @psalm-pure
+ *
+ * @param array<int|string, \stdClass> $value
+ *
+ * @return non-empty-array
+ */
+function consumeWillProduceNonEmptyArray(array $value): array
+{
+    Assert::isNonEmptyMap($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-isNotA.php
+++ b/tests/static-analysis/assert-isNotA.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Webmozart\Assert\Assert;
+
+final class IsNotAA
+{
+}
+
+final class IsNotAB
+{
+}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-param IsNotAA|IsNotAB $value
+ */
+function consume(object $value): IsNotAA
+{
+    Assert::isNotA($value, IsNotAB::class);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-isTraversable.php
+++ b/tests/static-analysis/assert-isTraversable.php
@@ -5,6 +5,7 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param mixed $value
  */
 function consume($value): iterable

--- a/tests/static-analysis/assert-keyExists.php
+++ b/tests/static-analysis/assert-keyExists.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ * @param non-empty-array $array
+ * @param array-key $key
+ *
+ * @return non-empty-array
+ */
+function consume(array $array, $key): array
+{
+    Assert::keyExists($array, 'key');
+
+    return $array;
+}

--- a/tests/static-analysis/assert-keyNotExists.php
+++ b/tests/static-analysis/assert-keyNotExists.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ * @param non-empty-array $array
+ * @param array-key $key
+ *
+ * @return non-empty-array
+ */
+function consume(array $array, $key): array
+{
+    Assert::keyNotExists($array, 'key');
+
+    return $array;
+}

--- a/tests/static-analysis/assert-length.php
+++ b/tests/static-analysis/assert-length.php
@@ -5,13 +5,14 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param non-empty-string $value
  *
- * @return non-empty-string
+ * @psalm-return non-empty-string
  */
 function consume(string $value): string
 {
-    Assert::ipv6($value);
+    Assert::length($value, 0);
 
     return $value;
 }

--- a/tests/static-analysis/assert-lengthBetween.php
+++ b/tests/static-analysis/assert-lengthBetween.php
@@ -5,13 +5,14 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param non-empty-string $value
  *
- * @return non-empty-string
+ * @psalm-return non-empty-string
  */
 function consume(string $value): string
 {
-    Assert::ipv6($value);
+    Assert::lengthBetween($value, 0, 2);
 
     return $value;
 }

--- a/tests/static-analysis/assert-lengthBetween.php
+++ b/tests/static-analysis/assert-lengthBetween.php
@@ -8,11 +8,14 @@ use Webmozart\Assert\Assert;
  * @psalm-pure
  * @psalm-param non-empty-string $value
  *
+ * @param int|float $min
+ * @param int|float $max
+ *
  * @psalm-return non-empty-string
  */
-function consume(string $value): string
+function consume(string $value, $min, $max): string
 {
-    Assert::lengthBetween($value, 0, 2);
+    Assert::lengthBetween($value, $min, $max);
 
     return $value;
 }

--- a/tests/static-analysis/assert-lessThan.php
+++ b/tests/static-analysis/assert-lessThan.php
@@ -6,13 +6,10 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- * @psalm-param mixed $value
- *
- * @psalm-return array-key
  */
-function consume($value)
+function consume(int $value): int
 {
-    Assert::validArrayKey($value);
+    Assert::lessThan($value, 1);
 
     return $value;
 }

--- a/tests/static-analysis/assert-lessThanEq.php
+++ b/tests/static-analysis/assert-lessThanEq.php
@@ -6,13 +6,10 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- * @psalm-param mixed $value
- *
- * @psalm-return array-key
  */
-function consume($value)
+function consume(int $value): int
 {
-    Assert::validArrayKey($value);
+    Assert::lessThanEq($value, 1);
 
     return $value;
 }

--- a/tests/static-analysis/assert-lower.php
+++ b/tests/static-analysis/assert-lower.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ * @psalm-param non-empty-string $value
+ *
+ * @psalm-return lowercase-string
+ */
+function consume(string $value): string
+{
+    Assert::lower($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ * @psalm-param non-empty-string $value
+ *
+ * @psalm-return non-empty-string
+ */
+function consumePreservesTypes(string $value): string
+{
+    Assert::lower($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-maxCount.php
+++ b/tests/static-analysis/assert-maxCount.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Countable;
+use Webmozart\Assert\Assert;
+
+function consume(Countable $value): Countable
+{
+    Assert::maxCount($value, 1);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-maxCount.php
+++ b/tests/static-analysis/assert-maxCount.php
@@ -5,9 +5,10 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Countable;
 use Webmozart\Assert\Assert;
 
-function consume(Countable $value): Countable
+/** @param int|float $max */
+function consume(Countable $value, $max): Countable
 {
-    Assert::maxCount($value, 1);
+    Assert::maxCount($value, $max);
 
     return $value;
 }

--- a/tests/static-analysis/assert-maxLength.php
+++ b/tests/static-analysis/assert-maxLength.php
@@ -8,11 +8,13 @@ use Webmozart\Assert\Assert;
  * @psalm-pure
  * @psalm-param non-empty-string $value
  *
+ * @param int|float $maxLength
+ *
  * @psalm-return non-empty-string
  */
-function consume(string $value): string
+function consume(string $value, $maxLength): string
 {
-    Assert::maxLength($value, 1);
+    Assert::maxLength($value, $maxLength);
 
     return $value;
 }

--- a/tests/static-analysis/assert-maxLength.php
+++ b/tests/static-analysis/assert-maxLength.php
@@ -5,13 +5,14 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param non-empty-string $value
  *
- * @return non-empty-string
+ * @psalm-return non-empty-string
  */
 function consume(string $value): string
 {
-    Assert::ipv6($value);
+    Assert::maxLength($value, 1);
 
     return $value;
 }

--- a/tests/static-analysis/assert-methodExists.php
+++ b/tests/static-analysis/assert-methodExists.php
@@ -6,13 +6,13 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- * @psalm-param mixed $value
+ * @psalm-param class-string|object $value
  *
- * @psalm-return array-key
+ * @return class-string|object
  */
 function consume($value)
 {
-    Assert::validArrayKey($value);
+    Assert::methodExists($value, 'foo');
 
     return $value;
 }

--- a/tests/static-analysis/assert-methodNotExists.php
+++ b/tests/static-analysis/assert-methodNotExists.php
@@ -6,13 +6,13 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- * @psalm-param mixed $value
+ * @psalm-param class-string|object $value
  *
- * @psalm-return array-key
+ * @return class-string|object
  */
 function consume($value)
 {
-    Assert::validArrayKey($value);
+    Assert::methodNotExists($value, 'foo');
 
     return $value;
 }

--- a/tests/static-analysis/assert-minCount.php
+++ b/tests/static-analysis/assert-minCount.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Countable;
+use Webmozart\Assert\Assert;
+
+function consume(Countable $value): Countable
+{
+    Assert::minCount($value, 1);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-minCount.php
+++ b/tests/static-analysis/assert-minCount.php
@@ -5,9 +5,10 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Countable;
 use Webmozart\Assert\Assert;
 
-function consume(Countable $value): Countable
+/** @param int|float $min */
+function consume(Countable $value, $min): Countable
 {
-    Assert::minCount($value, 1);
+    Assert::minCount($value, $min);
 
     return $value;
 }

--- a/tests/static-analysis/assert-minLength.php
+++ b/tests/static-analysis/assert-minLength.php
@@ -8,11 +8,13 @@ use Webmozart\Assert\Assert;
  * @psalm-pure
  * @psalm-param non-empty-string $value
  *
+ * @param int|float $minLength
+ *
  * @psalm-return non-empty-string
  */
-function consume(string $value): string
+function consume(string $value, $minLength): string
 {
-    Assert::minLength($value, 0);
+    Assert::minLength($value, $minLength);
 
     return $value;
 }

--- a/tests/static-analysis/assert-minLength.php
+++ b/tests/static-analysis/assert-minLength.php
@@ -5,13 +5,14 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param non-empty-string $value
  *
- * @return non-empty-string
+ * @psalm-return non-empty-string
  */
 function consume(string $value): string
 {
-    Assert::ipv6($value);
+    Assert::minLength($value, 0);
 
     return $value;
 }

--- a/tests/static-analysis/assert-natural.php
+++ b/tests/static-analysis/assert-natural.php
@@ -5,6 +5,7 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param mixed $value
  */
 function consume($value): int

--- a/tests/static-analysis/assert-notContains.php
+++ b/tests/static-analysis/assert-notContains.php
@@ -5,13 +5,11 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
- * @psalm-param non-empty-string $value
- *
- * @return non-empty-string
+ * @psalm-pure
  */
 function consume(string $value): string
 {
-    Assert::ipv6($value);
+    Assert::notContains($value, 'foo');
 
     return $value;
 }

--- a/tests/static-analysis/assert-notEmpty.php
+++ b/tests/static-analysis/assert-notEmpty.php
@@ -4,6 +4,9 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 
 use Webmozart\Assert\Assert;
 
+/**
+ * @psalm-pure
+ */
 function consume(?object $value): object
 {
     Assert::notEmpty($value);

--- a/tests/static-analysis/assert-notEq.php
+++ b/tests/static-analysis/assert-notEq.php
@@ -4,9 +4,6 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 
 use Webmozart\Assert\Assert;
 
-/**
- * @psalm-pure
- */
 function consume(string $value): string
 {
     Assert::notEq($value, 'foo');

--- a/tests/static-analysis/assert-notEq.php
+++ b/tests/static-analysis/assert-notEq.php
@@ -5,13 +5,11 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
- * @psalm-param non-empty-string $value
- *
- * @return non-empty-string
+ * @psalm-pure
  */
 function consume(string $value): string
 {
-    Assert::ipv6($value);
+    Assert::notEq($value, 'foo');
 
     return $value;
 }

--- a/tests/static-analysis/assert-notInstanceOf.php
+++ b/tests/static-analysis/assert-notInstanceOf.php
@@ -8,6 +8,7 @@ class NotA {}
 class NotB {}
 
 /**
+ * @psalm-pure
  * @param NotA|NotB $value
  */
 function consume($value): NotA

--- a/tests/static-analysis/assert-notNull.php
+++ b/tests/static-analysis/assert-notNull.php
@@ -4,6 +4,9 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 
 use Webmozart\Assert\Assert;
 
+/**
+ * @psalm-pure
+ */
 function consume(?object $value): object
 {
     Assert::notNull($value);

--- a/tests/static-analysis/assert-notRegex.php
+++ b/tests/static-analysis/assert-notRegex.php
@@ -5,13 +5,14 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param non-empty-string $value
  *
- * @return non-empty-string
+ * @psalm-return non-empty-string
  */
-function consume(string $value): string
+function consume($value): string
 {
-    Assert::ipv6($value);
+    Assert::notRegex($value, '/foo/');
 
     return $value;
 }

--- a/tests/static-analysis/assert-notSame.php
+++ b/tests/static-analysis/assert-notSame.php
@@ -5,13 +5,11 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
- * @psalm-param non-empty-string $value
- *
- * @return non-empty-string
+ * @psalm-pure
  */
 function consume(string $value): string
 {
-    Assert::ipv6($value);
+    Assert::notSame($value, 'foo');
 
     return $value;
 }

--- a/tests/static-analysis/assert-notWhitespaceOnly.php
+++ b/tests/static-analysis/assert-notWhitespaceOnly.php
@@ -5,13 +5,11 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
- * @psalm-param non-empty-string $value
- *
- * @return non-empty-string
+ * @psalm-pure
  */
 function consume(string $value): string
 {
-    Assert::ipv6($value);
+    Assert::notWhitespaceOnly($value);
 
     return $value;
 }

--- a/tests/static-analysis/assert-null.php
+++ b/tests/static-analysis/assert-null.php
@@ -5,6 +5,7 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @return null
  */
 function consume(?object $value)

--- a/tests/static-analysis/assert-numeric.php
+++ b/tests/static-analysis/assert-numeric.php
@@ -5,7 +5,8 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
- * @psalm-param string|numeric $value
+ * @psalm-pure
+ * @psalm-param mixed $value
  *
  * @psalm-return numeric
  */

--- a/tests/static-analysis/assert-object.php
+++ b/tests/static-analysis/assert-object.php
@@ -5,6 +5,7 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param mixed $value
  */
 function consume($value): object

--- a/tests/static-analysis/assert-oneOf.php
+++ b/tests/static-analysis/assert-oneOf.php
@@ -5,13 +5,11 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
- * @psalm-param non-empty-string $value
- *
- * @return non-empty-string
+ * @psalm-pure
  */
 function consume(string $value): string
 {
-    Assert::ipv6($value);
+    Assert::oneOf($value, ['foo', 'bar']);
 
     return $value;
 }

--- a/tests/static-analysis/assert-propertyExists.php
+++ b/tests/static-analysis/assert-propertyExists.php
@@ -6,13 +6,13 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- * @psalm-param mixed $value
+ * @psalm-param class-string|object $value
  *
- * @psalm-return array-key
+ * @return class-string|object
  */
 function consume($value)
 {
-    Assert::validArrayKey($value);
+    Assert::propertyExists($value, 'foo');
 
     return $value;
 }

--- a/tests/static-analysis/assert-propertyNotExists.php
+++ b/tests/static-analysis/assert-propertyNotExists.php
@@ -6,13 +6,13 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- * @psalm-param mixed $value
+ * @psalm-param class-string|object $value
  *
- * @psalm-return array-key
+ * @return class-string|object
  */
 function consume($value)
 {
-    Assert::validArrayKey($value);
+    Assert::propertyNotExists($value, 'foo');
 
     return $value;
 }

--- a/tests/static-analysis/assert-range.php
+++ b/tests/static-analysis/assert-range.php
@@ -6,13 +6,10 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- * @psalm-param mixed $value
- *
- * @psalm-return array-key
  */
-function consume($value)
+function consume(int $value): int
 {
-    Assert::validArrayKey($value);
+    Assert::range($value, 1, 10);
 
     return $value;
 }

--- a/tests/static-analysis/assert-readable.php
+++ b/tests/static-analysis/assert-readable.php
@@ -11,7 +11,7 @@ use Webmozart\Assert\Assert;
  */
 function consume(string $value): string
 {
-    Assert::ipv6($value);
+    Assert::readable($value);
 
     return $value;
 }

--- a/tests/static-analysis/assert-regex.php
+++ b/tests/static-analysis/assert-regex.php
@@ -5,13 +5,14 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param non-empty-string $value
  *
- * @return non-empty-string
+ * @psalm-return non-empty-string
  */
-function consume(string $value): string
+function consume($value): string
 {
-    Assert::ipv6($value);
+    Assert::regex($value, '/foo/');
 
     return $value;
 }

--- a/tests/static-analysis/assert-resource.php
+++ b/tests/static-analysis/assert-resource.php
@@ -5,6 +5,7 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param mixed $value
  *
  * @return resource

--- a/tests/static-analysis/assert-same.php
+++ b/tests/static-analysis/assert-same.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use stdClass;
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-param mixed $value
+ */
+function consume($value): string
+{
+    Assert::same($value, 'foo');
+
+    return $value;
+}
+
+/**
+ * @psalm-param mixed $value
+ */
+function consumeWillInferObject($value): stdClass
+{
+    Assert::same($value, new stdClass());
+
+    return $value;
+}
+
+/**
+ * @psalm-param mixed $value
+ */
+function consumeWillInferArray($value): array
+{
+    Assert::same($value, ['foo' => 123]);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-same.php
+++ b/tests/static-analysis/assert-same.php
@@ -2,38 +2,18 @@
 
 namespace Webmozart\Assert\Tests\StaticAnalysis;
 
-use stdClass;
 use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- * @psalm-param mixed $value
+ *
+ * @param mixed $value
+ *
+ * @return mixed
  */
-function consume($value): string
+function consume($value)
 {
     Assert::same($value, 'foo');
-
-    return $value;
-}
-
-/**
- * @psalm-pure
- * @psalm-param mixed $value
- */
-function consumeWillInferObject($value): stdClass
-{
-    Assert::same($value, new stdClass());
-
-    return $value;
-}
-
-/**
- * @psalm-pure
- * @psalm-param mixed $value
- */
-function consumeWillInferArray($value): array
-{
-    Assert::same($value, ['foo' => 123]);
 
     return $value;
 }

--- a/tests/static-analysis/assert-same.php
+++ b/tests/static-analysis/assert-same.php
@@ -6,6 +6,7 @@ use stdClass;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param mixed $value
  */
 function consume($value): string
@@ -16,6 +17,7 @@ function consume($value): string
 }
 
 /**
+ * @psalm-pure
  * @psalm-param mixed $value
  */
 function consumeWillInferObject($value): stdClass
@@ -26,6 +28,7 @@ function consumeWillInferObject($value): stdClass
 }
 
 /**
+ * @psalm-pure
  * @psalm-param mixed $value
  */
 function consumeWillInferArray($value): array

--- a/tests/static-analysis/assert-scalar.php
+++ b/tests/static-analysis/assert-scalar.php
@@ -5,6 +5,7 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param \Exception|bool $value
  */
 function consume($value): bool

--- a/tests/static-analysis/assert-startsWith.php
+++ b/tests/static-analysis/assert-startsWith.php
@@ -5,13 +5,14 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param non-empty-string $value
  *
- * @return non-empty-string
+ * @psalm-return non-empty-string
  */
 function consume(string $value): string
 {
-    Assert::ipv6($value);
+    Assert::startsWith($value, 'foo');
 
     return $value;
 }

--- a/tests/static-analysis/assert-startsWithLetter.php
+++ b/tests/static-analysis/assert-startsWithLetter.php
@@ -5,6 +5,7 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param mixed $value
  */
 function consume($value): string

--- a/tests/static-analysis/assert-startsWithLetter.php
+++ b/tests/static-analysis/assert-startsWithLetter.php
@@ -6,7 +6,9 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- * @psalm-param mixed $value
+ * @psalm-param non-empty-string $value
+ *
+ * @psalm-return non-empty-string
  */
 function consume($value): string
 {

--- a/tests/static-analysis/assert-startsWithLetter.php
+++ b/tests/static-analysis/assert-startsWithLetter.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-param mixed $value
+ */
+function consume($value): string
+{
+    Assert::startsWithLetter($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-string.php
+++ b/tests/static-analysis/assert-string.php
@@ -5,6 +5,7 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param mixed $value
  */
 function consume($value): string

--- a/tests/static-analysis/assert-string.php
+++ b/tests/static-analysis/assert-string.php
@@ -14,3 +14,18 @@ function consume($value): string
 
     return $value;
 }
+
+/**
+ * @psalm-pure
+ * @psalm-param mixed $value
+ *
+ * @see https://github.com/webmozart/assert/pull/160#issuecomment-564491986
+ * @see https://github.com/vimeo/psalm/commit/4b715cdbffea19a7eab6f72482027d2dd358aab2
+ * @see https://github.com/vimeo/psalm/issues/2456
+ */
+function consumeWillNotBeRedundantIfAssertingAndNotUsingEither($value): bool
+{
+    Assert::string($value);
+
+    return true;
+}

--- a/tests/static-analysis/assert-stringNotEmpty.php
+++ b/tests/static-analysis/assert-stringNotEmpty.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-param mixed $value
+ */
+function consume($value): string
+{
+    Assert::stringNotEmpty($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-stringNotEmpty.php
+++ b/tests/static-analysis/assert-stringNotEmpty.php
@@ -5,6 +5,7 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param mixed $value
  */
 function consume($value): string

--- a/tests/static-analysis/assert-subclassOf.php
+++ b/tests/static-analysis/assert-subclassOf.php
@@ -8,34 +8,13 @@ class SubclassOfA
 {
 }
 
-class SubclassOfB extends SubclassOfA
-{
-}
-
-class SubclassOfC
-{
-}
-
 /**
  * @param mixed $value
  *
  * @psalm-pure
- * @psalm-return class-string<SubclassOfA> $value
+ * @psalm-return class-string<SubclassOfA>|SubclassOfA
  */
-function consumeMixed($value): string
-{
-    Assert::subclassOf($value, SubclassOfA::class);
-
-    return $value;
-}
-
-/**
- * @psalm-pure
- * @psalm-param class-string<SubclassOfB>|class-string<SubclassOfC> $value
- *
- * @psalm-return class-string<SubclassOfB> $value
- */
-function consumeSubInterface(string $value): string
+function consumeMixed($value)
 {
     Assert::subclassOf($value, SubclassOfA::class);
 

--- a/tests/static-analysis/assert-subclassOf.php
+++ b/tests/static-analysis/assert-subclassOf.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Webmozart\Assert\Assert;
+
+class A
+{
+}
+
+class B extends A
+{
+}
+
+class C
+{
+}
+
+/**
+ * @param mixed $value
+ *
+ * @psalm-return class-string<A> $value
+ */
+function consumeMixed($value): string
+{
+    Assert::subclassOf($value, A::class);
+
+    return $value;
+}
+
+/**
+ * @psalm-param class-string<B>|class-string<C> $value
+ *
+ * @psalm-return class-string<B> $value
+ */
+function consumeSubclass(string $value): string
+{
+    Assert::subclassOf($value, A::class);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-subclassOf.php
+++ b/tests/static-analysis/assert-subclassOf.php
@@ -19,6 +19,7 @@ class SubclassOfC
 /**
  * @param mixed $value
  *
+ * @psalm-pure
  * @psalm-return class-string<SubclassOfA> $value
  */
 function consumeMixed($value): string
@@ -29,6 +30,7 @@ function consumeMixed($value): string
 }
 
 /**
+ * @psalm-pure
  * @psalm-param class-string<SubclassOfB>|class-string<SubclassOfC> $value
  *
  * @psalm-return class-string<SubclassOfB> $value

--- a/tests/static-analysis/assert-subclassOf.php
+++ b/tests/static-analysis/assert-subclassOf.php
@@ -4,38 +4,38 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 
 use Webmozart\Assert\Assert;
 
-class A
+class SubclassOfA
 {
 }
 
-class B extends A
+class SubclassOfB extends SubclassOfA
 {
 }
 
-class C
+class SubclassOfC
 {
 }
 
 /**
  * @param mixed $value
  *
- * @psalm-return class-string<A> $value
+ * @psalm-return class-string<SubclassOfA> $value
  */
 function consumeMixed($value): string
 {
-    Assert::subclassOf($value, A::class);
+    Assert::subclassOf($value, SubclassOfA::class);
 
     return $value;
 }
 
 /**
- * @psalm-param class-string<B>|class-string<C> $value
+ * @psalm-param class-string<SubclassOfB>|class-string<SubclassOfC> $value
  *
- * @psalm-return class-string<B> $value
+ * @psalm-return class-string<SubclassOfB> $value
  */
-function consumeSubclass(string $value): string
+function consumeSubInterface(string $value): string
 {
-    Assert::subclassOf($value, A::class);
+    Assert::subclassOf($value, SubclassOfA::class);
 
     return $value;
 }

--- a/tests/static-analysis/assert-throws.php
+++ b/tests/static-analysis/assert-throws.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Closure;
+use Webmozart\Assert\Assert;
+
+function consume(Closure $value): Closure
+{
+    Assert::throws($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-true.php
+++ b/tests/static-analysis/assert-true.php
@@ -5,6 +5,7 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @param mixed $value
  */
 function consume($value): bool

--- a/tests/static-analysis/assert-unicodeLetters.php
+++ b/tests/static-analysis/assert-unicodeLetters.php
@@ -6,9 +6,11 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- * @psalm-param mixed $value
+ * @psalm-param non-empty-string $value
+ *
+ * @psalm-return non-empty-string
  */
-function consume($value): string
+function consume(string $value): string
 {
     Assert::unicodeLetters($value);
 

--- a/tests/static-analysis/assert-unicodeLetters.php
+++ b/tests/static-analysis/assert-unicodeLetters.php
@@ -5,6 +5,7 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param mixed $value
  */
 function consume($value): string

--- a/tests/static-analysis/assert-unicodeLetters.php
+++ b/tests/static-analysis/assert-unicodeLetters.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-param mixed $value
+ */
+function consume($value): string
+{
+    Assert::unicodeLetters($value);
+
+    return $value;
+}

--- a/tests/static-analysis/assert-uniqueValues.php
+++ b/tests/static-analysis/assert-uniqueValues.php
@@ -4,9 +4,6 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 
 use Webmozart\Assert\Assert;
 
-/**
- * @psalm-pure
- */
 function consume(array $value): array
 {
     Assert::uniqueValues($value);

--- a/tests/static-analysis/assert-uniqueValues.php
+++ b/tests/static-analysis/assert-uniqueValues.php
@@ -6,13 +6,10 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- * @psalm-param mixed $value
- *
- * @psalm-return array-key
  */
-function consume($value)
+function consume(array $value): array
 {
-    Assert::validArrayKey($value);
+    Assert::uniqueValues($value);
 
     return $value;
 }

--- a/tests/static-analysis/assert-upper.php
+++ b/tests/static-analysis/assert-upper.php
@@ -5,13 +5,14 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param non-empty-string $value
  *
- * @return non-empty-string
+ * @psalm-return non-empty-string
  */
 function consume(string $value): string
 {
-    Assert::ipv6($value);
+    Assert::upper($value);
 
     return $value;
 }

--- a/tests/static-analysis/assert-uuid.php
+++ b/tests/static-analysis/assert-uuid.php
@@ -5,13 +5,14 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param non-empty-string $value
  *
- * @return non-empty-string
+ * @psalm-return non-empty-string
  */
 function consume(string $value): string
 {
-    Assert::ipv6($value);
+    Assert::uuid($value);
 
     return $value;
 }

--- a/tests/static-analysis/assert-validArrayKey.php
+++ b/tests/static-analysis/assert-validArrayKey.php
@@ -5,6 +5,7 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
+ * @psalm-pure
  * @psalm-param mixed $value
  * @param array<int> $array
  *

--- a/tests/static-analysis/assert-writable.php
+++ b/tests/static-analysis/assert-writable.php
@@ -11,7 +11,7 @@ use Webmozart\Assert\Assert;
  */
 function consume(string $value): string
 {
-    Assert::ipv6($value);
+    Assert::writable($value);
 
     return $value;
 }


### PR DESCRIPTION
Related:

 * [x] https://github.com/vimeo/psalm/issues/2449
 * [x] https://github.com/vimeo/psalm/issues/2450
 * [x] https://github.com/vimeo/psalm/issues/2451
 * [x] https://github.com/vimeo/psalm/issues/2452
 * [x] https://github.com/vimeo/psalm/issues/2456