### PR TITLE
Proposal: Drop support for PHP versions that are EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,6 @@ cache:
 
 matrix:
   include:
-    - php: 5.3
-      dist: precise
-    - php: 5.4
-      dist: trusty
-    - php: 5.5
-      dist: trusty
-    - php: 5.6
-    - php: 7.0
-    - php: 7.1
     - php: 7.2
     - php: 7.3
       env:

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^5.3.3 || ^7.0",
+        "php": "^7.2",
         "symfony/polyfill-ctype": "^1.8"
     },
     "require-dev": {


### PR DESCRIPTION
All PHP versions < 7.2  are end of life and should no longer be used. It is harmful to support these outdated versions in the future.

Why?

 - PHPUnit cannot be upgraded to 8 and above
 - Newer language features cannot be adopted resulting in bloated or less readable code
 - Users should not be encouraged to build technical debt