### PR TITLE
trim values when checking for empty strings

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -229,7 +229,7 @@ class Assert
     public static function stringNotEmpty($value, $message = '')
     {
         static::string($value, $message);
-        static::notEq($value, '', $message);
+        static::notEq(trim($value), '', $message);
     }
 
     /**

--- a/tests/AssertTest.php
+++ b/tests/AssertTest.php
@@ -54,6 +54,7 @@ class AssertTest extends BaseTestCase
             array('stringNotEmpty', array('value'), true),
             array('stringNotEmpty', array('0'), true),
             array('stringNotEmpty', array(''), false),
+            array('stringNotEmpty', array(' '), false),
             array('stringNotEmpty', array(1234), false),
             array('integer', array(123), true),
             array('integer', array('123'), false),


### PR DESCRIPTION
Before this PR

```php
Assert::stringNotEmpty(' ');

// returns TRUE
```

after this PR:
```php
Assert::stringNotEmpty(' ');

// returns FALSE
```


I am unsure, as this is from a technical POV correct, but like this it feels more comfortable for the enduser

Another option would be to add `trimmedStringNotEmpty()` or `stringNotBlank()`?

WDYT?
cc @localheinz 