### PR TITLE
Convert DateTime to string value

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -2099,6 +2099,10 @@ class Assert
                 return \get_class($value).': '.self::valueToString($value->__toString());
             }
 
+            if ($value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
+                return \get_class($value).': '.self::valueToString($value->format('c'));
+            }
+
             return \get_class($value);
         }
 

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -15,6 +15,8 @@ use ArrayAccess;
 use BadMethodCallException;
 use Closure;
 use Countable;
+use DateTime;
+use DateTimeImmutable;
 use Exception;
 use InvalidArgumentException;
 use ResourceBundle;
@@ -2099,7 +2101,7 @@ class Assert
                 return \get_class($value).': '.self::valueToString($value->__toString());
             }
 
-            if ($value instanceof \DateTime || $value instanceof \DateTimeImmutable) {
+            if ($value instanceof DateTime || $value instanceof DateTimeImmutable) {
                 return \get_class($value).': '.self::valueToString($value->format('c'));
             }
 

--- a/tests/AssertTest.php
+++ b/tests/AssertTest.php
@@ -677,6 +677,8 @@ class AssertTest extends BaseTestCase
             array('eq', array(array(1), array(2)), 'Expected a value equal to array. Got: array'),
             array('eq', array(new ArrayIterator(array()), new stdClass()), 'Expected a value equal to stdClass. Got: ArrayIterator'),
             array('eq', array(1, self::getResource()), 'Expected a value equal to resource. Got: 1'),
+
+            array('lessThan', array(new \DateTime('2020-01-01 00:00:00'), new \DateTime('1999-01-01 00:00:00')), 'Expected a value less than DateTime: "1999-01-01T00:00:00+00:00". Got: DateTime: "2020-01-01T00:00:00+00:00"'),
         );
     }
 


### PR DESCRIPTION
Instead of showing `Expected a value less than DateTime. Got: DateTime` it will now show `Expected a value less than DateTime: "1999-01-01T00:00:00+00:00". Got: DateTime: "2020-01-01T00:00:00+00:00" ` which is much easier to understand.