### PR TITLE
Add phpstan conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "phpunit/phpunit": "^4.8.36 || ^7.5.13"
     },
     "conflict": {
-        "vimeo/psalm": "<3.9.1"
+        "vimeo/psalm": "<3.9.1",
+        "phpstan/phpstan": "<0.12.20"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Versions before 0.12.20 did not understand mixins.
The next release may break phpstan for users if they use any of the `all*` or `nullOr*` methods.