### PR TITLE
PHP 8: `method_exists()` fixes and composer.json version constraint update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^5.3.3 || ^7.0",
+        "php": "^5.3.3 || ^7.0 || ^8.0",
         "symfony/polyfill-ctype": "^1.8"
     },
     "require-dev": {

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1620,7 +1620,7 @@ class Assert
      */
     public static function methodExists($classOrObject, $method, $message = '')
     {
-        if (!\method_exists($classOrObject, $method)) {
+        if (!(\is_string($classOrObject) || \is_object($classOrObject)) || !\method_exists($classOrObject, $method)) {
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected the method %s to exist.',
                 static::valueToString($method)
@@ -1640,7 +1640,7 @@ class Assert
      */
     public static function methodNotExists($classOrObject, $method, $message = '')
     {
-        if (\method_exists($classOrObject, $method)) {
+        if ((\is_string($classOrObject) || \is_object($classOrObject)) && \method_exists($classOrObject, $method)) {
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected the method %s to not exist.',
                 static::valueToString($method)


### PR DESCRIPTION
Ref: sebastianbergmann/phpunit#4325

PHP 8 builds are currently failing because `method_exists()` calls throw exceptions if the argument is not `string|object`. This PR fixes these calls by making sure the arguments are `string|object` before calling `method_exists`. This is because [PHP 8 throws `\TypeError` and `\ValueError` exceptions from internal functions](https://php.watch/versions/8.0/internal-function-exceptions). 

In preparation for PHP 8, this PR also updates `composer.json` PHP version constraint to allow PHP 8.

All tests now pass on PHP 8 dev builds. 