### PR TITLE
Introduces ability to disable assertions at runtime with `zend.assertions` PHP configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,6 @@
         "cs-check" : "./tools/php-cs-fixer/vendor/bin/php-cs-fixer check",
         "cs-fix": "./tools/php-cs-fixer/vendor/bin/php-cs-fixer fix",
         "static-analysis": "./tools/psalm/vendor/bin/psalm --threads=4 --root=$(pwd)",
-        "test": "./tools/phpunit/vendor/bin/phpunit"
+        "test": "php -d zend.assertions=1 ./tools/phpunit/vendor/bin/phpunit"
     }
 }

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -2141,6 +2141,13 @@ class Assert
      */
     protected static function reportInvalidArgument($message)
     {
+        if (\ini_get('zend.assertions') != '1') {
+            //  1 : Assert::* code is always executed (development mode)
+            //  0 : jump around Assert::* code at runtime
+            // -1 : (production mode)
+            // @see https://www.php.net/manual/en/function.assert.php
+            return;
+        }
         throw new InvalidArgumentException($message);
     }
 


### PR DESCRIPTION
With this PR I would like to introduces ability to disable `Assert::*` code at runtime.

Similar in behaviour to PHP [assert](https://www.php.net/manual/en/function.assert.php) function.

Learn more on assert options with https://php.watch/versions/8.3/assert-multiple-deprecations and especially recommended replacement.

This PR PASSED all dev tools runs (CS, Psalm, ...), and tests gave me : 

## Tests with `zend.assertions` = 1 -- (developement mode)  activated by default in `composer.json` scripts section

```text
OK (3247 tests, 3364 assertions)
```

## Tests with `zend.assertions` = 0 -- jump around Assert::* code at runtime

```shell
php -d zend.assertions=0 ./tools/phpunit/vendor/bin/phpunit
```

```text
OK, but incomplete, skipped, or risky tests!
Tests: 3247, Assertions: 651, Skipped: 2689.
```

## Tests with `zend.assertions` = -1 -- (production mode)

```shell
php -d zend.assertions=-1 ./tools/phpunit/vendor/bin/phpunit
```

```text
OK, but incomplete, skipped, or risky tests!
Tests: 3247, Assertions: 559, Skipped: 2781.
```
