### PR TITLE
exclude lock files and tools folder from export to prevent scanning

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@
 /ci                   export-ignore
 /phpunit.xml.dist     export-ignore
 /tests                export-ignore
+/tools                export-ignore


### PR DESCRIPTION
I am creating this MR because I stumbled upon an issue that was apparently introduced in version 1.12.0 where the security scan is flagging vulnerability issues in the tools path.

To circumvent this, we are locking the dependency to the previous version `~1.11.0`.

We believe PR https://github.com/webmozarts/assert/pull/304 might be the culprit, as it added the `/tools` directory but didn't update `.gitattributes` to exclude it from distribution.
