### PR TITLE
Add changelog entry for declare(strict_types=1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog
 
 - **BREAKING** Minimum PHP version is now 8.2 (was 7.2).
 - **BREAKING** Remove deprecated `isTraversable`, use `isIterable` or `isInstanceOf` instead.
+- **BREAKING** Added `declare(strict_types=1)` to all classes.
 - Updated CI/CD test matrix to test PHP 8.2, 8.3, 8.4, and 8.5.
 - Updated development tools (PHPUnit, Psalm, PHP-CS-Fixer) to supported versions.
 - Added explicit return types and parameter types to all methods in both source code and tests.


### PR DESCRIPTION
Not mention in the changelog but it was also added `declare(strict_types=1)`, why it may has not a lot of effects as most values are mixed. Stringables which may are used as `$message` are not longer auto converted to strings.