### PR TITLE
Fix parameter type for `Assert::isMap()`

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -2025,7 +2025,7 @@ class Assert
      *
      * @psalm-assert array<string, T> $array
      *
-     * @param array<string, T> $array
+     * @param mixed|array<array-key, T> $array
      *
      * @return array<string, T>
      *

--- a/src/Mixin.php
+++ b/src/Mixin.php
@@ -4896,7 +4896,7 @@ trait Mixin
      * @template T
      * @psalm-assert array<string, T>|null $array
      *
-     * @param array<string, T>|null $array
+     * @param mixed|array<array-key, T>|null $array
      *
      * @return array<string, T>|null
      *
@@ -4915,7 +4915,7 @@ trait Mixin
      * @template T
      * @psalm-assert iterable<array<string, T>> $array
      *
-     * @param iterable<array<string, T>> $array
+     * @param iterable<mixed|array<array-key, T>> $array
      *
      * @return iterable<array<string, T>>
      *
@@ -4938,7 +4938,7 @@ trait Mixin
      * @template T
      * @psalm-assert iterable<array<string, T>|null> $array
      *
-     * @param iterable<array<string, T>|null> $array
+     * @param iterable<mixed|array<array-key, T>|null> $array
      *
      * @return iterable<array<string, T>|null>
      *


### PR DESCRIPTION
`isMap` should accept `mixed` or `array<array-key, T>`, not `array<string, T>`. If the input was `array<string, T>`, we wouldn't need to use `Assert::isMap()`.