### PR TITLE
Rename .php_cs to .php-cs-fixer.php in export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 /.gitattributes       export-ignore
 /.gitignore           export-ignore
 /.github              export-ignore
-/.php_cs              export-ignore
+/.php-cs-fixer.php    export-ignore
 /.editorconfig        export-ignore
 /psalm.xml            export-ignore
 /bin                  export-ignore


### PR DESCRIPTION
It seems to have been an oversight during the change
https://github.com/webmozarts/assert/commits/master/.php-cs-fixer.php