### PR TITLE
Use notSame instead of notEq for stringNotEmpty

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -65,7 +65,7 @@ class Assert
     public static function stringNotEmpty(mixed $value, string $message = ''): string
     {
         static::string($value, $message);
-        static::notEq($value, '', $message);
+        static::notSame($value, '', $message);
 
         return $value;
     }


### PR DESCRIPTION
Optimization for stringNotEmpty - use strict comparator ($value === '') instead of $value == ''.