### PR TITLE
Use of 'static' in callable is deprecated

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1111,7 +1111,7 @@ class Assert
             static::reportInvalidArgument(\sprintf(
                 $message ?: '%2$s was not expected to contain a value. Got: %s',
                 static::valueToString($value),
-                \implode(', ', \array_map(['static', 'valueToString'], $values))
+                \implode(', ', \array_map(static::valueToString(...), $values))
             ));
         }
 


### PR DESCRIPTION
See https://www.php.net/manual/en/migration82.deprecated.php