### PR TITLE
Add support for lazy assertion messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,16 @@ Assert::nullOrString($middleName, 'The middle name must be a string or null. Got
 The `Assert` class comes with a few methods, which can be overridden to change the class behaviour. You can also extend it to
 add your own assertions.
 
+### Lazy assertion messages
+
+Assertion messages can be provided as callables to avoid unnecessary computation when the assertion passes:
+
+```php
+Assert::string($value, fn() => expensiveMessage());
+```
+
+The callable will only be executed if the assertion fails.
+
 #### Overriding methods
 
 Overriding the following methods in your assertion class allows you to change the behaviour of the assertions:

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -38,12 +38,15 @@ class Assert
      * @psalm-pure
      *
      * @psalm-assert string $value
+     * @param string|callable():string $message
      *
      * @throws InvalidArgumentException
      */
-    public static function string(mixed $value, string $message = ''): string
+    public static function string(mixed $value, string|callable $message = ''): string
     {
         if (!\is_string($value)) {
+            $message = static::resolveMessage($message);
+
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a string. Got: %s',
                 static::typeToString($value)
@@ -57,12 +60,13 @@ class Assert
      * @psalm-pure
      *
      * @psalm-assert non-empty-string $value
+     * @param string|callable():string $message
      *
      * @psalm-return non-empty-string
      *
      * @throws InvalidArgumentException
      */
-    public static function stringNotEmpty(mixed $value, string $message = ''): string
+    public static function stringNotEmpty(mixed $value, string|callable $message = ''): string
     {
         static::string($value, $message);
         static::notSame($value, '', $message);
@@ -75,11 +79,14 @@ class Assert
      *
      * @psalm-assert int $value
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function integer(mixed $value, string $message = ''): int
+    public static function integer(mixed $value, string|callable $message = ''): int
     {
         if (!\is_int($value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected an integer. Got: %s',
                 static::typeToString($value)
@@ -93,12 +100,14 @@ class Assert
      * @psalm-pure
      *
      * @psalm-assert numeric $value
+     * @param string|callable():string $message
      *
      * @throws InvalidArgumentException
      */
-    public static function integerish(mixed $value, string $message = ''): int|float|string
+    public static function integerish(mixed $value, string|callable $message = ''): int|float|string
     {
         if (!\is_numeric($value) || $value != (int) $value) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected an integerish value. Got: %s',
                 static::typeToString($value)
@@ -113,15 +122,18 @@ class Assert
      *
      * @psalm-assert positive-int $value
      *
+     * @param string|callable():string $message
+     *
      * @psalm-return positive-int
      *
      * @throws InvalidArgumentException
      */
-    public static function positiveInteger(mixed $value, string $message = ''): int
+    public static function positiveInteger(mixed $value, string|callable $message = ''): int
     {
         static::integer($value, $message);
 
         if ($value < 1) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a positive integer. Got: %s',
                 static::valueToString($value)
@@ -134,16 +146,18 @@ class Assert
     /**
      * @psalm-pure
      * @psalm-assert non-negative-int $value
+     * @param string|callable():string $message
      *
      * @psalm-return non-negative-int
      *
      * @throws InvalidArgumentException
      */
-    public static function notNegativeInteger(mixed $value, string $message = ''): int
+    public static function notNegativeInteger(mixed $value, string|callable $message = ''): int
     {
         static::integer($value, $message);
 
         if ($value < 0) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a non negative integer. Got: %s',
                 static::valueToString($value)
@@ -156,16 +170,18 @@ class Assert
     /**
      * @psalm-pure
      * @psalm-assert negative-int $value
+     * @param string|callable():string $message
      *
      * @psalm-return negative-int
      *
      * @throws InvalidArgumentException
      */
-    public static function negativeInteger(mixed $value, string $message = ''): int
+    public static function negativeInteger(mixed $value, string|callable $message = ''): int
     {
         static::integer($value, $message);
 
         if ($value >= 0) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a negative integer. Got: %s',
                 static::valueToString($value)
@@ -180,11 +196,14 @@ class Assert
      *
      * @psalm-assert float $value
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function float(mixed $value, string $message = ''): float
+    public static function float(mixed $value, string|callable $message = ''): float
     {
         if (!\is_float($value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a float. Got: %s',
                 static::typeToString($value)
@@ -199,11 +218,14 @@ class Assert
      *
      * @psalm-assert numeric $value
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function numeric(mixed $value, string $message = ''): int|float|string
+    public static function numeric(mixed $value, string|callable $message = ''): int|float|string
     {
         if (!\is_numeric($value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a numeric. Got: %s',
                 static::typeToString($value)
@@ -218,13 +240,16 @@ class Assert
      *
      * @psalm-assert positive-int|0 $value
      *
+     * @param string|callable():string $message
+     *
      * @psalm-return positive-int|0
      *
      * @throws InvalidArgumentException
      */
-    public static function natural(mixed $value, string $message = ''): int
+    public static function natural(mixed $value, string|callable $message = ''): int
     {
         if (!\is_int($value) || $value < 0) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a non-negative integer. Got: %s',
                 static::valueToString($value)
@@ -239,11 +264,14 @@ class Assert
      *
      * @psalm-assert bool $value
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function boolean(mixed $value, string $message = ''): bool
+    public static function boolean(mixed $value, string|callable $message = ''): bool
     {
         if (!\is_bool($value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a boolean. Got: %s',
                 static::typeToString($value)
@@ -258,11 +286,14 @@ class Assert
      *
      * @psalm-assert scalar $value
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function scalar(mixed $value, string $message = ''): int|bool|float|string
+    public static function scalar(mixed $value, string|callable $message = ''): int|bool|float|string
     {
         if (!\is_scalar($value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a scalar. Got: %s',
                 static::typeToString($value)
@@ -277,11 +308,14 @@ class Assert
      *
      * @psalm-assert object $value
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function object(mixed $value, string $message = ''): object
+    public static function object(mixed $value, string|callable $message = ''): object
     {
         if (!\is_object($value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected an object. Got: %s',
                 static::typeToString($value)
@@ -296,13 +330,16 @@ class Assert
      *
      * @psalm-assert object|string $value
      *
+     * @param string|callable():string $message
+     *
      * @psalm-return object|string
      *
      * @throws InvalidArgumentException
      */
-    public static function objectish(mixed $value, string $message = ''): object|string
+    public static function objectish(mixed $value, string|callable $message = ''): object|string
     {
         if (!\is_object($value) && !\is_string($value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected an objectish value. Got: %s',
                 static::typeToString($value)
@@ -310,6 +347,7 @@ class Assert
         }
 
         if (\is_string($value) && !\class_exists($value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected class to be defined. Got: %s',
                 $value
@@ -324,15 +362,18 @@ class Assert
      *
      * @psalm-assert resource $value
      *
+     * @param string|callable():string $message
+     *
      * @see https://www.php.net/manual/en/function.get-resource-type.php
      *
      * @psalm-return resource
      *
      * @throws InvalidArgumentException
      */
-    public static function resource(mixed $value, ?string $type = null, string $message = ''): mixed
+    public static function resource(mixed $value, ?string $type = null, string|callable $message = ''): mixed
     {
         if (!\is_resource($value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a resource. Got: %s',
                 static::typeToString($value),
@@ -341,6 +382,7 @@ class Assert
         }
 
         if ($type && $type !== \get_resource_type($value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a resource of type %2$s. Got: %s',
                 static::typeToString($value),
@@ -356,15 +398,18 @@ class Assert
      *
      * @psalm-assert object $value
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function isInitialized(mixed $value, string $property, string $message = ''): object
+    public static function isInitialized(mixed $value, string $property, string|callable $message = ''): object
     {
         Assert::object($value);
 
         $reflectionProperty = new ReflectionProperty($value, $property);
 
         if (!$reflectionProperty->isInitialized($value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected property %s to be initialized.',
                 $property,
@@ -379,11 +424,14 @@ class Assert
      *
      * @psalm-assert callable $value
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function isCallable(mixed $value, string $message = ''): callable
+    public static function isCallable(mixed $value, string|callable $message = ''): callable
     {
         if (!\is_callable($value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a callable. Got: %s',
                 static::typeToString($value)
@@ -398,11 +446,14 @@ class Assert
      *
      * @psalm-assert array $value
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function isArray(mixed $value, string $message = ''): array
+    public static function isArray(mixed $value, string|callable $message = ''): array
     {
         if (!\is_array($value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected an array. Got: %s',
                 static::typeToString($value)
@@ -417,11 +468,14 @@ class Assert
      *
      * @psalm-assert array|ArrayAccess $value
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function isArrayAccessible(mixed $value, string $message = ''): array|ArrayAccess
+    public static function isArrayAccessible(mixed $value, string|callable $message = ''): array|ArrayAccess
     {
         if (!\is_array($value) && !($value instanceof ArrayAccess)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected an array accessible. Got: %s',
                 static::typeToString($value)
@@ -436,11 +490,14 @@ class Assert
      *
      * @psalm-assert countable $value
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function isCountable(mixed $value, string $message = ''): array|Countable
+    public static function isCountable(mixed $value, string|callable $message = ''): array|Countable
     {
         if (!\is_array($value) && !($value instanceof Countable)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a countable. Got: %s',
                 static::typeToString($value)
@@ -455,11 +512,14 @@ class Assert
      *
      * @psalm-assert iterable $value
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function isIterable(mixed $value, string $message = ''): iterable
+    public static function isIterable(mixed $value, string|callable $message = ''): iterable
     {
         if (!\is_array($value) && !($value instanceof Traversable)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected an iterable. Got: %s',
                 static::typeToString($value)
@@ -476,17 +536,19 @@ class Assert
      *
      * @psalm-assert T $value
      *
+     * @param string|callable():string $message
      * @psalm-param class-string<T> $class
      *
      * @return T
      *
      * @throws InvalidArgumentException
      */
-    public static function isInstanceOf(mixed $value, mixed $class, string $message = ''): object
+    public static function isInstanceOf(mixed $value, mixed $class, string|callable $message = ''): object
     {
         static::string($class, 'Expected class as a string. Got: %s');
 
         if (!($value instanceof $class)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected an instance of %2$s. Got: %s',
                 static::typeToString($value),
@@ -501,17 +563,20 @@ class Assert
      * @template T of object
      *
      * @psalm-assert object $value
+     *
+     * @param string|callable():string $message
      * @psalm-param class-string<T> $class
      *
      * @return !T
      *
      * @throws InvalidArgumentException
      */
-    public static function notInstanceOf(mixed $value, mixed $class, string $message = ''): object
+    public static function notInstanceOf(mixed $value, mixed $class, string|callable $message = ''): object
     {
         static::string($class, 'Expected class as a string. Got: %s');
 
         if (!\is_object($value) || $value instanceof $class) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected an instance other than %2$s. Got: %s',
                 static::typeToString($value),
@@ -528,12 +593,13 @@ class Assert
      * @psalm-assert T $value
      *
      * @param T $value
+     * @param string|callable():string $message
      *
      * @return T
      *
      * @throws InvalidArgumentException
      */
-    public static function isInstanceOfAny(mixed $value, mixed $classes, string $message = ''): object
+    public static function isInstanceOfAny(mixed $value, mixed $classes, string|callable $message = ''): object
     {
         static::isIterable($classes);
 
@@ -545,6 +611,7 @@ class Assert
             }
         }
 
+        $message = self::resolveMessage($message);
         static::reportInvalidArgument(\sprintf(
             $message ?: 'Expected an instance of any of %2$s. Got: %s',
             static::typeToString($value),
@@ -558,12 +625,13 @@ class Assert
      * @psalm-assert T $value
      *
      * @param T $value
+     * @param string|callable():string $message
      *
      * @return T
      *
      * @throws InvalidArgumentException
      */
-    public static function isNotInstanceOfAny(mixed $value, mixed $classes, string $message = ''): mixed
+    public static function isNotInstanceOfAny(mixed $value, mixed $classes, string|callable $message = ''): mixed
     {
         static::isIterable($classes);
 
@@ -571,6 +639,7 @@ class Assert
             static::string($class, 'Expected class as a string. Got: %s');
 
             if ($value instanceof $class) {
+                $message = self::resolveMessage($message);
                 static::reportInvalidArgument(\sprintf(
                     $message ?: 'Expected not an instance of %2$s. Got: %s',
                     static::typeToString($value),
@@ -589,15 +658,18 @@ class Assert
      *
      * @psalm-assert T|class-string<T> $value
      *
+     * @param string|callable():string $message
+     *
      * @return T
      *
      * @throws InvalidArgumentException
      */
-    public static function isAOf(mixed $value, mixed $class, string $message = ''): object|string
+    public static function isAOf(mixed $value, mixed $class, string|callable $message = ''): object|string
     {
         static::string($class, 'Expected class as a string. Got: %s');
 
         if (!\is_a($value, $class, \is_string($value))) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected an instance of this class or to this class among its parents "%2$s". Got: %s',
                 static::valueToString($value),
@@ -616,17 +688,19 @@ class Assert
      * @psalm-assert object|class-string $value
      *
      * @param T $value
+     * @param string|callable():string $message
      *
      * @return T
      *
      * @throws InvalidArgumentException
      */
-    public static function isNotA(mixed $value, mixed $class, string $message = ''): object|string
+    public static function isNotA(mixed $value, mixed $class, string|callable $message = ''): object|string
     {
         static::objectish($value, $message);
         static::string($class, 'Expected class as a string. Got: %s');
 
         if (\is_a($value, $class, \is_string($value))) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected an instance of this class or to this class among its parents other than "%2$s". Got: %s',
                 static::valueToString($value),
@@ -642,11 +716,12 @@ class Assert
      *
      * @param object|string $value
      * @param string[]      $classes
+     * @param string|callable():string $message
      * @psalm-param array<class-string> $classes
      *
      * @throws InvalidArgumentException
      */
-    public static function isAnyOf(mixed $value, mixed $classes, string $message = ''): object|string
+    public static function isAnyOf(mixed $value, mixed $classes, string|callable $message = ''): object|string
     {
         static::objectish($value, $message);
         static::isIterable($classes);
@@ -659,6 +734,7 @@ class Assert
             }
         }
 
+        $message = self::resolveMessage($message);
         static::reportInvalidArgument(\sprintf(
             $message ?: 'Expected an instance of any of this classes or any of those classes among their parents "%2$s". Got: %s',
             static::valueToString($value),
@@ -671,13 +747,16 @@ class Assert
      *
      * @psalm-assert empty $value
      *
+     * @param string|callable():string $message
+     *
      * @psalm-return empty
      *
      * @throws InvalidArgumentException
      */
-    public static function isEmpty(mixed $value, string $message = ''): mixed
+    public static function isEmpty(mixed $value, string|callable $message = ''): mixed
     {
         if (!empty($value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected an empty value. Got: %s',
                 static::valueToString($value)
@@ -692,13 +771,16 @@ class Assert
      *
      * @psalm-assert !empty $value
      *
+     * @param string|callable():string $message
+     *
      * @psalm-return !empty
      *
      * @throws InvalidArgumentException
      */
-    public static function notEmpty(mixed $value, string $message = ''): mixed
+    public static function notEmpty(mixed $value, string|callable $message = ''): mixed
     {
         if (empty($value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a non-empty value. Got: %s',
                 static::valueToString($value)
@@ -713,11 +795,14 @@ class Assert
      *
      * @psalm-assert null $value
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function null(mixed $value, string $message = ''): null
+    public static function null(mixed $value, string|callable $message = ''): null
     {
         if (null !== $value) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected null. Got: %s',
                 static::valueToString($value)
@@ -732,13 +817,16 @@ class Assert
      *
      * @psalm-assert !null $value
      *
+     * @param string|callable():string $message
+     *
      * @psalm-return !null
      *
      * @throws InvalidArgumentException
      */
-    public static function notNull(mixed $value, string $message = ''): mixed
+    public static function notNull(mixed $value, string|callable $message = ''): mixed
     {
         if (null === $value) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(
                 $message ?: 'Expected a value other than null.'
             );
@@ -752,11 +840,14 @@ class Assert
      *
      * @psalm-assert true $value
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function true(mixed $value, string $message = ''): true
+    public static function true(mixed $value, string|callable $message = ''): true
     {
         if (true !== $value) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value to be true. Got: %s',
                 static::valueToString($value)
@@ -771,11 +862,14 @@ class Assert
      *
      * @psalm-assert false $value
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function false(mixed $value, string $message = ''): false
+    public static function false(mixed $value, string|callable $message = ''): false
     {
         if (false !== $value) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value to be false. Got: %s',
                 static::valueToString($value)
@@ -790,11 +884,14 @@ class Assert
      *
      * @psalm-assert !false $value
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function notFalse(mixed $value, string $message = ''): mixed
+    public static function notFalse(mixed $value, string|callable $message = ''): mixed
     {
         if (false === $value) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(
                 $message ?: 'Expected a value other than false.'
             );
@@ -806,15 +903,17 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
      * @psalm-param string $value
      *
      * @throws InvalidArgumentException
      */
-    public static function ip(mixed $value, string $message = ''): string
+    public static function ip(mixed $value, string|callable $message = ''): string
     {
         static::string($value, $message);
 
         if (false === \filter_var($value, \FILTER_VALIDATE_IP)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value to be an IP. Got: %s',
                 static::valueToString($value)
@@ -827,15 +926,17 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
      * @psalm-param string $value
      *
      * @throws InvalidArgumentException
      */
-    public static function ipv4(mixed $value, string $message = ''): string
+    public static function ipv4(mixed $value, string|callable $message = ''): string
     {
         static::string($value, $message);
 
         if (false === \filter_var($value, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV4)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value to be an IPv4. Got: %s',
                 static::valueToString($value)
@@ -848,15 +949,17 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
      * @psalm-param string $value
      *
      * @throws InvalidArgumentException
      */
-    public static function ipv6(mixed $value, string $message = ''): string
+    public static function ipv6(mixed $value, string|callable $message = ''): string
     {
         static::string($value, $message);
 
         if (false === \filter_var($value, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV6)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value to be an IPv6. Got: %s',
                 static::valueToString($value)
@@ -869,15 +972,17 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
      * @psalm-param string $value
      *
      * @throws InvalidArgumentException
      */
-    public static function email(mixed $value, string $message = ''): string
+    public static function email(mixed $value, string|callable $message = ''): string
     {
         static::string($value, $message);
 
         if (false === \filter_var($value, FILTER_VALIDATE_EMAIL, FILTER_FLAG_EMAIL_UNICODE)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value to be a valid e-mail address. Got: %s',
                 static::valueToString($value)
@@ -890,9 +995,11 @@ class Assert
     /**
      * Does non-strict comparisons on the items, so ['3', 3] will not pass the assertion.
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function uniqueValues(mixed $values, string $message = ''): array
+    public static function uniqueValues(mixed $values, string|callable $message = ''): array
     {
         static::isArray($values);
 
@@ -902,6 +1009,7 @@ class Assert
         if ($allValues !== $uniqueValues) {
             $difference = $allValues - $uniqueValues;
 
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected an array of unique values, but %s of them %s duplicated',
                 $difference,
@@ -913,11 +1021,14 @@ class Assert
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function eq(mixed $value, mixed $expect, string $message = ''): mixed
+    public static function eq(mixed $value, mixed $expect, string|callable $message = ''): mixed
     {
         if ($expect != $value) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value equal to %2$s. Got: %s',
                 static::valueToString($value),
@@ -929,11 +1040,14 @@ class Assert
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function notEq(mixed $value, mixed $expect, string $message = ''): mixed
+    public static function notEq(mixed $value, mixed $expect, string|callable $message = ''): mixed
     {
         if ($expect == $value) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a different value than %s.',
                 static::valueToString($expect)
@@ -946,11 +1060,14 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function same(mixed $value, mixed $expect, string $message = ''): mixed
+    public static function same(mixed $value, mixed $expect, string|callable $message = ''): mixed
     {
         if ($expect !== $value) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value identical to %2$s. Got: %s',
                 static::valueToString($value),
@@ -964,11 +1081,14 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function notSame(mixed $value, mixed $expect, string $message = ''): mixed
+    public static function notSame(mixed $value, mixed $expect, string|callable $message = ''): mixed
     {
         if ($expect === $value) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value not identical to %s.',
                 static::valueToString($expect)
@@ -981,11 +1101,14 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function greaterThan(mixed $value, mixed $limit, string $message = ''): mixed
+    public static function greaterThan(mixed $value, mixed $limit, string|callable $message = ''): mixed
     {
         if ($value <= $limit) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value greater than %2$s. Got: %s',
                 static::valueToString($value),
@@ -999,11 +1122,14 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function greaterThanEq(mixed $value, mixed $limit, string $message = ''): mixed
+    public static function greaterThanEq(mixed $value, mixed $limit, string|callable $message = ''): mixed
     {
         if ($value < $limit) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value greater than or equal to %2$s. Got: %s',
                 static::valueToString($value),
@@ -1017,11 +1143,14 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function lessThan(mixed $value, mixed $limit, string $message = ''): mixed
+    public static function lessThan(mixed $value, mixed $limit, string|callable $message = ''): mixed
     {
         if ($value >= $limit) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value less than %2$s. Got: %s',
                 static::valueToString($value),
@@ -1035,11 +1164,14 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function lessThanEq(mixed $value, mixed $limit, string $message = ''): mixed
+    public static function lessThanEq(mixed $value, mixed $limit, string|callable $message = ''): mixed
     {
         if ($value > $limit) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value less than or equal to %2$s. Got: %s',
                 static::valueToString($value),
@@ -1055,11 +1187,14 @@ class Assert
      *
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function range(mixed $value, mixed $min, mixed $max, string $message = ''): mixed
+    public static function range(mixed $value, mixed $min, mixed $max, string|callable $message = ''): mixed
     {
         if ($value < $min || $value > $max) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value between %2$s and %3$s. Got: %s',
                 static::valueToString($value),
@@ -1076,9 +1211,11 @@ class Assert
      *
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function oneOf(mixed $value, mixed $values, string $message = ''): mixed
+    public static function oneOf(mixed $value, mixed $values, string|callable $message = ''): mixed
     {
         static::inArray($value, $values, $message);
 
@@ -1090,13 +1227,16 @@ class Assert
      *
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function inArray(mixed $value, mixed $values, string $message = ''): mixed
+    public static function inArray(mixed $value, mixed $values, string|callable $message = ''): mixed
     {
         static::isArray($values);
 
         if (!\in_array($value, $values, true)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected one of: %2$s. Got: %s',
                 static::valueToString($value),
@@ -1112,9 +1252,11 @@ class Assert
      *
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function notOneOf(mixed $value, mixed $values, string $message = ''): mixed
+    public static function notOneOf(mixed $value, mixed $values, string|callable $message = ''): mixed
     {
         static::notInArray($value, $values, $message);
 
@@ -1129,13 +1271,16 @@ class Assert
      *
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function notInArray(mixed $value, mixed $values, string $message = ''): mixed
+    public static function notInArray(mixed $value, mixed $values, string|callable $message = ''): mixed
     {
         static::isArray($values);
 
         if (\in_array($value, $values, true)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: '%2$s was not expected to contain a value. Got: %s',
                 static::valueToString($value),
@@ -1149,14 +1294,17 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function contains(mixed $value, mixed $subString, string $message = ''): string
+    public static function contains(mixed $value, mixed $subString, string|callable $message = ''): string
     {
         static::string($value);
         static::string($subString);
 
         if (!\str_contains($value, $subString)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value to contain %2$s. Got: %s',
                 static::valueToString($value),
@@ -1170,14 +1318,17 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function notContains(mixed $value, mixed $subString, string $message = ''): string
+    public static function notContains(mixed $value, mixed $subString, string|callable $message = ''): string
     {
         static::string($value);
         static::string($subString);
 
         if (\str_contains($value, $subString)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: '%2$s was not expected to be contained in a value. Got: %s',
                 static::valueToString($value),
@@ -1191,13 +1342,16 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function notWhitespaceOnly(mixed $value, string $message = ''): string
+    public static function notWhitespaceOnly(mixed $value, string|callable $message = ''): string
     {
         static::string($value);
 
         if (\preg_match('/^\s*$/', $value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a non-whitespace string. Got: %s',
                 static::valueToString($value)
@@ -1210,14 +1364,17 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function startsWith(mixed $value, mixed $prefix, string $message = ''): string
+    public static function startsWith(mixed $value, mixed $prefix, string|callable $message = ''): string
     {
         static::string($value);
         static::string($prefix);
 
         if (!\str_starts_with($value, $prefix)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value to start with %2$s. Got: %s',
                 static::valueToString($value),
@@ -1231,14 +1388,17 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function notStartsWith(mixed $value, mixed $prefix, string $message = ''): string
+    public static function notStartsWith(mixed $value, mixed $prefix, string|callable $message = ''): string
     {
         static::string($value);
         static::string($prefix);
 
         if (\str_starts_with($value, $prefix)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value not to start with %2$s. Got: %s',
                 static::valueToString($value),
@@ -1252,9 +1412,11 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function startsWithLetter(mixed $value, string $message = ''): string
+    public static function startsWithLetter(mixed $value, string|callable $message = ''): string
     {
         static::string($value);
 
@@ -1268,6 +1430,7 @@ class Assert
         }
 
         if (!$valid) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value to start with a letter. Got: %s',
                 static::valueToString($value)
@@ -1280,14 +1443,17 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function endsWith(mixed $value, mixed $suffix, string $message = ''): string
+    public static function endsWith(mixed $value, mixed $suffix, string|callable $message = ''): string
     {
         static::string($value);
         static::string($suffix);
 
         if (!\str_ends_with($value, $suffix)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value to end with %2$s. Got: %s',
                 static::valueToString($value),
@@ -1301,14 +1467,17 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function notEndsWith(mixed $value, mixed $suffix, string $message = ''): string
+    public static function notEndsWith(mixed $value, mixed $suffix, string|callable $message = ''): string
     {
         static::string($value);
         static::string($suffix);
 
         if (\str_ends_with($value, $suffix)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value not to end with %2$s. Got: %s',
                 static::valueToString($value),
@@ -1322,14 +1491,17 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function regex(mixed $value, mixed $pattern, string $message = ''): string
+    public static function regex(mixed $value, mixed $pattern, string|callable $message = ''): string
     {
         static::string($value);
         static::string($pattern);
 
         if (!\preg_match($pattern, $value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'The value %s does not match the expected pattern.',
                 static::valueToString($value)
@@ -1342,14 +1514,17 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function notRegex(mixed $value, mixed $pattern, string $message = ''): string
+    public static function notRegex(mixed $value, mixed $pattern, string|callable $message = ''): string
     {
         static::string($value);
         static::string($pattern);
 
         if (\preg_match($pattern, $value, $matches, PREG_OFFSET_CAPTURE)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'The value %s matches the pattern %s (at offset %d).',
                 static::valueToString($value),
@@ -1364,13 +1539,16 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function unicodeLetters(mixed $value, string $message = ''): string
+    public static function unicodeLetters(mixed $value, string|callable $message = ''): string
     {
         static::string($value, $message);
 
         if (!\preg_match('/^\p{L}+$/u', $value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value to contain only Unicode letters. Got: %s',
                 static::valueToString($value)
@@ -1383,9 +1561,11 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function alpha(mixed $value, string $message = ''): string
+    public static function alpha(mixed $value, string|callable $message = ''): string
     {
         static::string($value, $message);
 
@@ -1395,6 +1575,7 @@ class Assert
         \setlocale(LC_CTYPE, $locale);
 
         if ($valid) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value to contain only letters. Got: %s',
                 static::valueToString($value)
@@ -1407,9 +1588,11 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function digits(mixed $value, string $message = ''): string
+    public static function digits(mixed $value, string|callable $message = ''): string
     {
         static::string($value, $message);
 
@@ -1419,6 +1602,7 @@ class Assert
         \setlocale(LC_CTYPE, $locale);
 
         if ($valid) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value to contain digits only. Got: %s',
                 static::valueToString($value)
@@ -1431,9 +1615,11 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function alnum(mixed $value, string $message = ''): string
+    public static function alnum(mixed $value, string|callable $message = ''): string
     {
         static::string($value, $message);
 
@@ -1443,6 +1629,7 @@ class Assert
         \setlocale(LC_CTYPE, $locale);
 
         if ($valid) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value to contain letters and digits only. Got: %s',
                 static::valueToString($value)
@@ -1457,9 +1644,11 @@ class Assert
      *
      * @psalm-assert lowercase-string $value
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function lower(mixed $value, string $message = ''): string
+    public static function lower(mixed $value, string|callable $message = ''): string
     {
         static::string($value, $message);
 
@@ -1469,6 +1658,7 @@ class Assert
         \setlocale(LC_CTYPE, $locale);
 
         if ($valid) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value to contain lowercase characters only. Got: %s',
                 static::valueToString($value)
@@ -1483,9 +1673,11 @@ class Assert
      *
      * @psalm-assert !lowercase-string $value
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function upper(mixed $value, string $message = ''): string
+    public static function upper(mixed $value, string|callable $message = ''): string
     {
         static::string($value, $message);
 
@@ -1495,6 +1687,7 @@ class Assert
         \setlocale(LC_CTYPE, $locale);
 
         if ($valid) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value to contain uppercase characters only. Got: %s',
                 static::valueToString($value)
@@ -1507,14 +1700,17 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function length(mixed $value, mixed $length, string $message = ''): string
+    public static function length(mixed $value, mixed $length, string|callable $message = ''): string
     {
         static::string($value);
         static::integerish($length);
 
         if ($length !== static::strlen($value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value to contain %2$s characters. Got: %s',
                 static::valueToString($value),
@@ -1530,14 +1726,17 @@ class Assert
      *
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function minLength(mixed $value, mixed $min, string $message = ''): string
+    public static function minLength(mixed $value, mixed $min, string|callable $message = ''): string
     {
         static::string($value);
         static::integerish($min);
 
         if (static::strlen($value) < $min) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value to contain at least %2$s characters. Got: %s',
                 static::valueToString($value),
@@ -1553,14 +1752,17 @@ class Assert
      *
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function maxLength(mixed $value, mixed $max, string $message = ''): string
+    public static function maxLength(mixed $value, mixed $max, string|callable $message = ''): string
     {
         static::string($value);
         static::integerish($max);
 
         if (static::strlen($value) > $max) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value to contain at most %2$s characters. Got: %s',
                 static::valueToString($value),
@@ -1576,9 +1778,11 @@ class Assert
      *
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function lengthBetween(mixed $value, mixed $min, mixed $max, string $message = ''): string
+    public static function lengthBetween(mixed $value, mixed $min, mixed $max, string|callable $message = ''): string
     {
         static::string($value);
         static::integerish($min);
@@ -1587,6 +1791,7 @@ class Assert
         $length = static::strlen($value);
 
         if ($length < $min || $length > $max) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a value to contain between %2$s and %3$s characters. Got: %s',
                 static::valueToString($value),
@@ -1601,13 +1806,16 @@ class Assert
     /**
      * Will also pass if $value is a directory, use Assert::file() instead if you need to be sure it is a file.
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function fileExists(mixed $value, string $message = ''): string
+    public static function fileExists(mixed $value, string|callable $message = ''): string
     {
         static::string($value);
 
         if (!\file_exists($value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'The path %s does not exist.',
                 static::valueToString($value)
@@ -1618,13 +1826,16 @@ class Assert
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function file(mixed $value, string $message = ''): string
+    public static function file(mixed $value, string|callable $message = ''): string
     {
         static::string($value);
 
         if (!\is_file($value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'The path %s is not a file.',
                 static::valueToString($value)
@@ -1635,13 +1846,16 @@ class Assert
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function directory(mixed $value, string $message = ''): string
+    public static function directory(mixed $value, string|callable $message = ''): string
     {
         static::string($value);
 
         if (!\is_dir($value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'The path %s is not a directory.',
                 static::valueToString($value)
@@ -1652,13 +1866,16 @@ class Assert
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function readable(mixed $value, string $message = ''): string
+    public static function readable(mixed $value, string|callable $message = ''): string
     {
         static::string($value);
 
         if (!\is_readable($value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'The path %s is not readable.',
                 static::valueToString($value)
@@ -1669,13 +1886,16 @@ class Assert
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function writable(mixed $value, string $message = ''): string
+    public static function writable(mixed $value, string|callable $message = ''): string
     {
         static::string($value);
 
         if (!\is_writable($value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'The path %s is not writable.',
                 static::valueToString($value)
@@ -1688,13 +1908,16 @@ class Assert
     /**
      * @psalm-assert class-string $value
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function classExists(mixed $value, string $message = ''): string
+    public static function classExists(mixed $value, string|callable $message = ''): string
     {
         static::string($value);
 
         if (!\class_exists($value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected an existing class name. Got: %s',
                 static::valueToString($value)
@@ -1712,17 +1935,19 @@ class Assert
      * @psalm-assert class-string<ExpectedType> $value
      *
      * @param class-string<ExpectedType> $class
+     * @param string|callable():string $message
      *
      * @return class-string<ExpectedType>
      *
      * @throws InvalidArgumentException
      */
-    public static function subclassOf(mixed $value, mixed $class, string $message = ''): string
+    public static function subclassOf(mixed $value, mixed $class, string|callable $message = ''): string
     {
         static::string($value);
         static::string($class);
 
         if (!\is_subclass_of($value, $class)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected a sub-class of %2$s. Got: %s',
                 static::valueToString($value),
@@ -1736,13 +1961,16 @@ class Assert
     /**
      * @psalm-assert class-string $value
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function interfaceExists(mixed $value, string $message = ''): string
+    public static function interfaceExists(mixed $value, string|callable $message = ''): string
     {
         static::string($value);
 
         if (!\interface_exists($value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected an existing interface name. got %s',
                 static::valueToString($value)
@@ -1761,10 +1989,11 @@ class Assert
      *
      * @param class-string<ExpectedType>|ExpectedType $value
      * @param class-string<ExpectedType> $interface
+     * @param string|callable():string $message
      *
      * @throws InvalidArgumentException
      */
-    public static function implementsInterface(mixed $value, mixed $interface, string $message = ''): object|string
+    public static function implementsInterface(mixed $value, mixed $interface, string|callable $message = ''): object|string
     {
         static::objectish($value);
 
@@ -1773,6 +2002,7 @@ class Assert
         static::isArray($implements);
 
         if (!\in_array($interface, $implements, true)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected an implementation of %2$s. Got: %s',
                 static::valueToString($value),
@@ -1787,14 +2017,16 @@ class Assert
      * @psalm-pure
      *
      * @param string|object $classOrObject
+     * @param string|callable():string $message
      *
      * @throws InvalidArgumentException
      */
-    public static function propertyExists(mixed $classOrObject, mixed $property, string $message = ''): object|string
+    public static function propertyExists(mixed $classOrObject, mixed $property, string|callable $message = ''): object|string
     {
         static::objectish($classOrObject);
 
         if (!\property_exists($classOrObject, $property)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected the property %s to exist.',
                 static::valueToString($property)
@@ -1808,13 +2040,15 @@ class Assert
      * @psalm-pure
      *
      * @param string|object $classOrObject
+     * @param string|callable():string $message
      * @psalm-param class-string|object $classOrObject
      *
      * @throws InvalidArgumentException
      */
-    public static function propertyNotExists(mixed $classOrObject, mixed $property, string $message = ''): mixed
+    public static function propertyNotExists(mixed $classOrObject, mixed $property, string|callable $message = ''): mixed
     {
         if (!(\is_string($classOrObject) || \is_object($classOrObject)) || \property_exists($classOrObject, $property)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected the property %s to not exist.',
                 static::valueToString($property)
@@ -1828,15 +2062,17 @@ class Assert
      * @psalm-pure
      *
      * @param string|object $classOrObject
+     * @param string|callable():string $message
      * @psalm-param class-string|object $classOrObject
      *
      * @throws InvalidArgumentException
      */
-    public static function methodExists(mixed $classOrObject, mixed $method, string $message = ''): object|string
+    public static function methodExists(mixed $classOrObject, mixed $method, string|callable $message = ''): object|string
     {
         static::objectish($classOrObject);
 
         if (!\method_exists($classOrObject, $method)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected the method %s to exist.',
                 static::valueToString($method)
@@ -1850,15 +2086,17 @@ class Assert
      * @psalm-pure
      *
      * @param string|object $classOrObject
+     * @param string|callable():string $message
      * @psalm-param class-string|object $classOrObject
      *
      * @throws InvalidArgumentException
      */
-    public static function methodNotExists(mixed $classOrObject, mixed $method, string $message = ''): mixed
+    public static function methodNotExists(mixed $classOrObject, mixed $method, string|callable $message = ''): mixed
     {
         static::objectish($classOrObject);
 
         if (\method_exists($classOrObject, $method)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected the method %s to not exist.',
                 static::valueToString($method)
@@ -1872,14 +2110,16 @@ class Assert
      * @psalm-pure
      *
      * @param string|int $key
+     * @param string|callable():string $message
      *
      * @throws InvalidArgumentException
      */
-    public static function keyExists(mixed $array, string|int $key, string $message = ''): array
+    public static function keyExists(mixed $array, string|int $key, string|callable $message = ''): array
     {
         static::isArray($array, $message);
 
         if (!(isset($array[$key]) || \array_key_exists($key, $array))) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected the key %s to exist.',
                 static::valueToString($key)
@@ -1893,14 +2133,16 @@ class Assert
      * @psalm-pure
      *
      * @param string|int $key
+     * @param string|callable():string $message
      *
      * @throws InvalidArgumentException
      */
-    public static function keyNotExists(mixed $array, string|int $key, string $message = ''): array
+    public static function keyNotExists(mixed $array, string|int $key, string|callable $message = ''): array
     {
         static::isArray($array, $message);
 
         if (isset($array[$key]) || \array_key_exists($key, $array)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected the key %s to not exist.',
                 static::valueToString($key)
@@ -1917,11 +2159,14 @@ class Assert
      *
      * @psalm-assert array-key $value
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function validArrayKey(mixed $value, string $message = ''): string|int
+    public static function validArrayKey(mixed $value, string|callable $message = ''): string|int
     {
         if (!(\is_int($value) || \is_string($value))) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected string or integer. Got: %s',
                 static::typeToString($value)
@@ -1932,9 +2177,11 @@ class Assert
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function count(mixed $array, mixed $number, string $message = ''): array|Countable
+    public static function count(mixed $array, mixed $number, string|callable $message = ''): array|Countable
     {
         static::isCountable($array);
         static::integerish($number);
@@ -1942,7 +2189,7 @@ class Assert
         static::eq(
             \count($array),
             $number,
-            \sprintf(
+            fn () => static::resolveMessage($message) ?: \sprintf(
                 $message ?: 'Expected an array to contain %d elements. Got: %d.',
                 $number,
                 \count($array)
@@ -1953,14 +2200,17 @@ class Assert
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function minCount(mixed $array, mixed $min, string $message = ''): array|Countable
+    public static function minCount(mixed $array, mixed $min, string|callable $message = ''): array|Countable
     {
         static::isCountable($array);
         static::integerish($min);
 
         if (\count($array) < $min) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected an array to contain at least %2$d elements. Got: %d',
                 \count($array),
@@ -1972,14 +2222,17 @@ class Assert
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function maxCount(mixed $array, mixed $max, string $message = ''): array|Countable
+    public static function maxCount(mixed $array, mixed $max, string|callable $message = ''): array|Countable
     {
         static::isCountable($array);
         static::integerish($max);
 
         if (\count($array) > $max) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected an array to contain at most %2$d elements. Got: %d',
                 \count($array),
@@ -1991,9 +2244,11 @@ class Assert
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function countBetween(mixed $array, mixed $min, mixed $max, string $message = ''): array|Countable
+    public static function countBetween(mixed $array, mixed $min, mixed $max, string|callable $message = ''): array|Countable
     {
         static::isCountable($array);
         static::integerish($min);
@@ -2002,6 +2257,7 @@ class Assert
         $count = \count($array);
 
         if ($count < $min || $count > $max) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Expected an array to contain between %2$d and %3$d elements. Got: %d',
                 $count,
@@ -2018,13 +2274,16 @@ class Assert
      *
      * @psalm-assert list<mixed> $array
      *
+     * @param string|callable():string $message
+     *
      * @psalm-return list<mixed>
      *
      * @throws InvalidArgumentException
      */
-    public static function isList(mixed $array, string $message = ''): array
+    public static function isList(mixed $array, string|callable $message = ''): array
     {
         if (!\is_array($array) || !\array_is_list($array)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(
                 $message ?: 'Expected list - non-associative array.'
             );
@@ -2038,11 +2297,13 @@ class Assert
      *
      * @psalm-assert non-empty-list<mixed> $array
      *
+     * @param string|callable():string $message
+     *
      * @psalm-return non-empty-list<mixed>
      *
      * @throws InvalidArgumentException
      */
-    public static function isNonEmptyList(mixed $array, string $message = ''): array
+    public static function isNonEmptyList(mixed $array, string|callable $message = ''): array
     {
         static::isList($array, $message);
         static::notEmpty($array, $message);
@@ -2058,16 +2319,18 @@ class Assert
      * @psalm-assert array<string, T> $array
      *
      * @param mixed|array<array-key, T> $array
+     * @param string|callable():string $message
      *
      * @return array<string, T>
      *
      * @throws InvalidArgumentException
      */
-    public static function isMap(mixed $array, string $message = ''): array
+    public static function isMap(mixed $array, string|callable $message = ''): array
     {
         static::isArray($array, $message);
 
         if (\count($array) > 0 && \array_is_list($array)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(
                 $message ?: 'Expected map - associative array with string keys.'
             );
@@ -2080,12 +2343,13 @@ class Assert
      * @psalm-assert callable $callable
      *
      * @param Closure|callable $callable
+     * @param string|callable():string $message
      *
      * @return Closure|callable-string
      *
      * @throws InvalidArgumentException
      */
-    public static function isStatic(mixed $callable, string $message = ''): Closure|string
+    public static function isStatic(mixed $callable, string|callable $message = ''): Closure|string
     {
         static::isCallable($callable, $message);
 
@@ -2094,6 +2358,7 @@ class Assert
         $reflection = new ReflectionFunction($callable);
 
         if (!$reflection->isStatic()) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(
                 $message ?: 'Closure is not static.'
             );
@@ -2106,12 +2371,13 @@ class Assert
      * @psalm-assert callable $callable
      *
      * @param Closure|callable $callable
+     * @param string|callable():string $message
      *
      * @return Closure|callable-string
      *
      * @throws InvalidArgumentException
      */
-    public static function notStatic(mixed $callable, string $message = ''): Closure|string
+    public static function notStatic(mixed $callable, string|callable $message = ''): Closure|string
     {
         static::isCallable($callable, $message);
 
@@ -2120,6 +2386,7 @@ class Assert
         $reflection = new ReflectionFunction($callable);
 
         if ($reflection->isStatic()) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(
                 $message ?: 'Closure is not static.'
             );
@@ -2137,12 +2404,13 @@ class Assert
      * @psalm-assert !empty $array
      *
      * @param array<string, T> $array
+     * @param string|callable():string $message
      *
      * @return array<string, T>
      *
      * @throws InvalidArgumentException
      */
-    public static function isNonEmptyMap(mixed $array, string $message = ''): array
+    public static function isNonEmptyMap(mixed $array, string|callable $message = ''): array
     {
         static::isMap($array, $message);
         static::notEmpty($array, $message);
@@ -2153,9 +2421,11 @@ class Assert
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @throws InvalidArgumentException
      */
-    public static function uuid(mixed $value, string $message = ''): string
+    public static function uuid(mixed $value, string|callable $message = ''): string
     {
         static::string($value, $message);
 
@@ -2169,6 +2439,7 @@ class Assert
         }
 
         if (!\preg_match('/^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/D', $value)) {
+            $message = self::resolveMessage($message);
             static::reportInvalidArgument(\sprintf(
                 $message ?: 'Value %s is not a valid UUID.',
                 static::valueToString($value)
@@ -2179,11 +2450,12 @@ class Assert
     }
 
     /**
+     * @param string|callable():string $message
      * @psalm-param class-string<Throwable> $class
      *
      * @throws InvalidArgumentException
      */
-    public static function throws(mixed $expression, string $class = Throwable::class, string $message = ''): callable
+    public static function throws(mixed $expression, string $class = Throwable::class, string|callable $message = ''): callable
     {
         static::string($class);
         static::isCallable($expression);
@@ -2198,6 +2470,8 @@ class Assert
                 return $expression;
             }
         }
+
+        $message = self::resolveMessage($message);
 
         static::reportInvalidArgument($message ?: \sprintf(
             'Expected to throw "%s", got "%s"',
@@ -2301,6 +2575,16 @@ class Assert
     protected static function reportInvalidArgument(string $message): never
     {
         throw new InvalidArgumentException($message);
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param string|callable():string $message
+     */
+    protected static function resolveMessage(string|callable $message): string
+    {
+        return \is_callable($message) ? $message() : $message;
     }
 
     private function __construct()

--- a/src/Mixin.php
+++ b/src/Mixin.php
@@ -19,11 +19,13 @@ trait Mixin
      *
      * @psalm-assert string|null $value
      *
+     * @param string|callable():string $message
+     *
      * @return string|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrString(mixed $value, string $message = ''): mixed
+    public static function nullOrString(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::string($value, $message);
 
@@ -35,11 +37,13 @@ trait Mixin
      *
      * @psalm-assert iterable<string> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
-    public static function allString(mixed $value, string $message = ''): iterable
+    public static function allString(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -55,11 +59,13 @@ trait Mixin
      *
      * @psalm-assert iterable<string|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrString(mixed $value, string $message = ''): iterable
+    public static function allNullOrString(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -75,11 +81,13 @@ trait Mixin
      *
      * @psalm-assert non-empty-string|null $value
      *
+     * @param string|callable():string $message
+     *
      * @return non-empty-string|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrStringNotEmpty(mixed $value, string $message = ''): mixed
+    public static function nullOrStringNotEmpty(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::stringNotEmpty($value, $message);
 
@@ -91,11 +99,13 @@ trait Mixin
      *
      * @psalm-assert iterable<non-empty-string> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<non-empty-string>
      *
      * @throws InvalidArgumentException
      */
-    public static function allStringNotEmpty(mixed $value, string $message = ''): iterable
+    public static function allStringNotEmpty(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -111,11 +121,13 @@ trait Mixin
      *
      * @psalm-assert iterable<non-empty-string|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<non-empty-string|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrStringNotEmpty(mixed $value, string $message = ''): iterable
+    public static function allNullOrStringNotEmpty(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -131,11 +143,13 @@ trait Mixin
      *
      * @psalm-assert int|null $value
      *
+     * @param string|callable():string $message
+     *
      * @return int|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrInteger(mixed $value, string $message = ''): mixed
+    public static function nullOrInteger(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::integer($value, $message);
 
@@ -147,11 +161,13 @@ trait Mixin
      *
      * @psalm-assert iterable<int> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<int>
      *
      * @throws InvalidArgumentException
      */
-    public static function allInteger(mixed $value, string $message = ''): iterable
+    public static function allInteger(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -167,11 +183,13 @@ trait Mixin
      *
      * @psalm-assert iterable<int|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<int|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrInteger(mixed $value, string $message = ''): iterable
+    public static function allNullOrInteger(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -187,11 +205,13 @@ trait Mixin
      *
      * @psalm-assert numeric|null $value
      *
+     * @param string|callable():string $message
+     *
      * @return numeric|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIntegerish(mixed $value, string $message = ''): mixed
+    public static function nullOrIntegerish(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::integerish($value, $message);
 
@@ -203,11 +223,13 @@ trait Mixin
      *
      * @psalm-assert iterable<numeric> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<numeric>
      *
      * @throws InvalidArgumentException
      */
-    public static function allIntegerish(mixed $value, string $message = ''): iterable
+    public static function allIntegerish(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -223,11 +245,13 @@ trait Mixin
      *
      * @psalm-assert iterable<numeric|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<numeric|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrIntegerish(mixed $value, string $message = ''): iterable
+    public static function allNullOrIntegerish(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -243,11 +267,13 @@ trait Mixin
      *
      * @psalm-assert positive-int|null $value
      *
+     * @param string|callable():string $message
+     *
      * @return positive-int|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrPositiveInteger(mixed $value, string $message = ''): mixed
+    public static function nullOrPositiveInteger(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::positiveInteger($value, $message);
 
@@ -259,11 +285,13 @@ trait Mixin
      *
      * @psalm-assert iterable<positive-int> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<positive-int>
      *
      * @throws InvalidArgumentException
      */
-    public static function allPositiveInteger(mixed $value, string $message = ''): iterable
+    public static function allPositiveInteger(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -279,11 +307,13 @@ trait Mixin
      *
      * @psalm-assert iterable<positive-int|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<positive-int|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrPositiveInteger(mixed $value, string $message = ''): iterable
+    public static function allNullOrPositiveInteger(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -299,11 +329,13 @@ trait Mixin
      *
      * @psalm-assert non-negative-int|null $value
      *
+     * @param string|callable():string $message
+     *
      * @return non-negative-int|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNotNegativeInteger(mixed $value, string $message = ''): mixed
+    public static function nullOrNotNegativeInteger(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::notNegativeInteger($value, $message);
 
@@ -315,11 +347,13 @@ trait Mixin
      *
      * @psalm-assert iterable<non-negative-int> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<non-negative-int>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNotNegativeInteger(mixed $value, string $message = ''): iterable
+    public static function allNotNegativeInteger(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -335,11 +369,13 @@ trait Mixin
      *
      * @psalm-assert iterable<non-negative-int|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<non-negative-int|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrNotNegativeInteger(mixed $value, string $message = ''): iterable
+    public static function allNullOrNotNegativeInteger(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -355,11 +391,13 @@ trait Mixin
      *
      * @psalm-assert negative-int|null $value
      *
+     * @param string|callable():string $message
+     *
      * @return negative-int|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNegativeInteger(mixed $value, string $message = ''): mixed
+    public static function nullOrNegativeInteger(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::negativeInteger($value, $message);
 
@@ -371,11 +409,13 @@ trait Mixin
      *
      * @psalm-assert iterable<negative-int> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<negative-int>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNegativeInteger(mixed $value, string $message = ''): iterable
+    public static function allNegativeInteger(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -391,11 +431,13 @@ trait Mixin
      *
      * @psalm-assert iterable<negative-int|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<negative-int|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrNegativeInteger(mixed $value, string $message = ''): iterable
+    public static function allNullOrNegativeInteger(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -411,11 +453,13 @@ trait Mixin
      *
      * @psalm-assert float|null $value
      *
+     * @param string|callable():string $message
+     *
      * @return float|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrFloat(mixed $value, string $message = ''): mixed
+    public static function nullOrFloat(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::float($value, $message);
 
@@ -427,11 +471,13 @@ trait Mixin
      *
      * @psalm-assert iterable<float> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<float>
      *
      * @throws InvalidArgumentException
      */
-    public static function allFloat(mixed $value, string $message = ''): iterable
+    public static function allFloat(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -447,11 +493,13 @@ trait Mixin
      *
      * @psalm-assert iterable<float|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<float|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrFloat(mixed $value, string $message = ''): iterable
+    public static function allNullOrFloat(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -467,11 +515,13 @@ trait Mixin
      *
      * @psalm-assert numeric|null $value
      *
+     * @param string|callable():string $message
+     *
      * @return numeric|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNumeric(mixed $value, string $message = ''): mixed
+    public static function nullOrNumeric(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::numeric($value, $message);
 
@@ -483,11 +533,13 @@ trait Mixin
      *
      * @psalm-assert iterable<numeric> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<numeric>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNumeric(mixed $value, string $message = ''): iterable
+    public static function allNumeric(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -503,11 +555,13 @@ trait Mixin
      *
      * @psalm-assert iterable<numeric|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<numeric|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrNumeric(mixed $value, string $message = ''): iterable
+    public static function allNullOrNumeric(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -523,11 +577,13 @@ trait Mixin
      *
      * @psalm-assert positive-int|0|null $value
      *
+     * @param string|callable():string $message
+     *
      * @return positive-int|0|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNatural(mixed $value, string $message = ''): mixed
+    public static function nullOrNatural(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::natural($value, $message);
 
@@ -539,11 +595,13 @@ trait Mixin
      *
      * @psalm-assert iterable<positive-int|0> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<positive-int|0>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNatural(mixed $value, string $message = ''): iterable
+    public static function allNatural(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -559,11 +617,13 @@ trait Mixin
      *
      * @psalm-assert iterable<positive-int|0|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<positive-int|0|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrNatural(mixed $value, string $message = ''): iterable
+    public static function allNullOrNatural(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -579,11 +639,13 @@ trait Mixin
      *
      * @psalm-assert bool|null $value
      *
+     * @param string|callable():string $message
+     *
      * @return bool|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrBoolean(mixed $value, string $message = ''): mixed
+    public static function nullOrBoolean(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::boolean($value, $message);
 
@@ -595,11 +657,13 @@ trait Mixin
      *
      * @psalm-assert iterable<bool> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<bool>
      *
      * @throws InvalidArgumentException
      */
-    public static function allBoolean(mixed $value, string $message = ''): iterable
+    public static function allBoolean(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -615,11 +679,13 @@ trait Mixin
      *
      * @psalm-assert iterable<bool|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<bool|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrBoolean(mixed $value, string $message = ''): iterable
+    public static function allNullOrBoolean(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -635,11 +701,13 @@ trait Mixin
      *
      * @psalm-assert scalar|null $value
      *
+     * @param string|callable():string $message
+     *
      * @return scalar|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrScalar(mixed $value, string $message = ''): mixed
+    public static function nullOrScalar(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::scalar($value, $message);
 
@@ -651,11 +719,13 @@ trait Mixin
      *
      * @psalm-assert iterable<scalar> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<scalar>
      *
      * @throws InvalidArgumentException
      */
-    public static function allScalar(mixed $value, string $message = ''): iterable
+    public static function allScalar(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -671,11 +741,13 @@ trait Mixin
      *
      * @psalm-assert iterable<scalar|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<scalar|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrScalar(mixed $value, string $message = ''): iterable
+    public static function allNullOrScalar(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -691,11 +763,13 @@ trait Mixin
      *
      * @psalm-assert object|null $value
      *
+     * @param string|callable():string $message
+     *
      * @return object|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrObject(mixed $value, string $message = ''): mixed
+    public static function nullOrObject(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::object($value, $message);
 
@@ -707,11 +781,13 @@ trait Mixin
      *
      * @psalm-assert iterable<object> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<object>
      *
      * @throws InvalidArgumentException
      */
-    public static function allObject(mixed $value, string $message = ''): iterable
+    public static function allObject(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -727,11 +803,13 @@ trait Mixin
      *
      * @psalm-assert iterable<object|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<object|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrObject(mixed $value, string $message = ''): iterable
+    public static function allNullOrObject(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -747,11 +825,13 @@ trait Mixin
      *
      * @psalm-assert object|string|null $value
      *
+     * @param string|callable():string $message
+     *
      * @return object|string|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrObjectish(mixed $value, string $message = ''): mixed
+    public static function nullOrObjectish(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::objectish($value, $message);
 
@@ -763,11 +843,13 @@ trait Mixin
      *
      * @psalm-assert iterable<object|string> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<object|string>
      *
      * @throws InvalidArgumentException
      */
-    public static function allObjectish(mixed $value, string $message = ''): iterable
+    public static function allObjectish(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -783,11 +865,13 @@ trait Mixin
      *
      * @psalm-assert iterable<object|string|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<object|string|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrObjectish(mixed $value, string $message = ''): iterable
+    public static function allNullOrObjectish(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -803,13 +887,15 @@ trait Mixin
      *
      * @psalm-assert resource|null $value
      *
+     * @param string|callable():string $message
+     *
      * @see https://www.php.net/manual/en/function.get-resource-type.php
      *
      * @return resource|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrResource(mixed $value, ?string $type = null, string $message = ''): mixed
+    public static function nullOrResource(mixed $value, ?string $type = null, callable|string $message = ''): mixed
     {
         null === $value || static::resource($value, $type, $message);
 
@@ -821,13 +907,15 @@ trait Mixin
      *
      * @psalm-assert iterable<resource> $value
      *
+     * @param string|callable():string $message
+     *
      * @see https://www.php.net/manual/en/function.get-resource-type.php
      *
      * @return iterable<resource>
      *
      * @throws InvalidArgumentException
      */
-    public static function allResource(mixed $value, ?string $type = null, string $message = ''): iterable
+    public static function allResource(mixed $value, ?string $type = null, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -843,13 +931,15 @@ trait Mixin
      *
      * @psalm-assert iterable<resource|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @see https://www.php.net/manual/en/function.get-resource-type.php
      *
      * @return iterable<resource|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrResource(mixed $value, ?string $type = null, string $message = ''): iterable
+    public static function allNullOrResource(mixed $value, ?string $type = null, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -865,11 +955,13 @@ trait Mixin
      *
      * @psalm-assert callable|null $value
      *
+     * @param string|callable():string $message
+     *
      * @return callable|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsCallable(mixed $value, string $message = ''): mixed
+    public static function nullOrIsCallable(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::isCallable($value, $message);
 
@@ -881,11 +973,13 @@ trait Mixin
      *
      * @psalm-assert iterable<callable> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<callable>
      *
      * @throws InvalidArgumentException
      */
-    public static function allIsCallable(mixed $value, string $message = ''): iterable
+    public static function allIsCallable(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -901,11 +995,13 @@ trait Mixin
      *
      * @psalm-assert iterable<callable|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<callable|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrIsCallable(mixed $value, string $message = ''): iterable
+    public static function allNullOrIsCallable(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -921,11 +1017,13 @@ trait Mixin
      *
      * @psalm-assert array|null $value
      *
+     * @param string|callable():string $message
+     *
      * @return array|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsArray(mixed $value, string $message = ''): mixed
+    public static function nullOrIsArray(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::isArray($value, $message);
 
@@ -937,11 +1035,13 @@ trait Mixin
      *
      * @psalm-assert iterable<array> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<array>
      *
      * @throws InvalidArgumentException
      */
-    public static function allIsArray(mixed $value, string $message = ''): iterable
+    public static function allIsArray(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -957,11 +1057,13 @@ trait Mixin
      *
      * @psalm-assert iterable<array|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<array|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrIsArray(mixed $value, string $message = ''): iterable
+    public static function allNullOrIsArray(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -977,11 +1079,13 @@ trait Mixin
      *
      * @psalm-assert array|ArrayAccess|null $value
      *
+     * @param string|callable():string $message
+     *
      * @return array|ArrayAccess|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsArrayAccessible(mixed $value, string $message = ''): mixed
+    public static function nullOrIsArrayAccessible(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::isArrayAccessible($value, $message);
 
@@ -993,11 +1097,13 @@ trait Mixin
      *
      * @psalm-assert iterable<array|ArrayAccess> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<array|ArrayAccess>
      *
      * @throws InvalidArgumentException
      */
-    public static function allIsArrayAccessible(mixed $value, string $message = ''): iterable
+    public static function allIsArrayAccessible(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1013,11 +1119,13 @@ trait Mixin
      *
      * @psalm-assert iterable<array|ArrayAccess|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<array|ArrayAccess|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrIsArrayAccessible(mixed $value, string $message = ''): iterable
+    public static function allNullOrIsArrayAccessible(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1033,11 +1141,13 @@ trait Mixin
      *
      * @psalm-assert countable|null $value
      *
+     * @param string|callable():string $message
+     *
      * @return countable|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsCountable(mixed $value, string $message = ''): mixed
+    public static function nullOrIsCountable(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::isCountable($value, $message);
 
@@ -1049,11 +1159,13 @@ trait Mixin
      *
      * @psalm-assert iterable<countable> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<countable>
      *
      * @throws InvalidArgumentException
      */
-    public static function allIsCountable(mixed $value, string $message = ''): iterable
+    public static function allIsCountable(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1069,11 +1181,13 @@ trait Mixin
      *
      * @psalm-assert iterable<countable|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<countable|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrIsCountable(mixed $value, string $message = ''): iterable
+    public static function allNullOrIsCountable(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1089,11 +1203,13 @@ trait Mixin
      *
      * @psalm-assert iterable|null $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsIterable(mixed $value, string $message = ''): mixed
+    public static function nullOrIsIterable(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::isIterable($value, $message);
 
@@ -1105,11 +1221,13 @@ trait Mixin
      *
      * @psalm-assert iterable<iterable> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<iterable>
      *
      * @throws InvalidArgumentException
      */
-    public static function allIsIterable(mixed $value, string $message = ''): iterable
+    public static function allIsIterable(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1125,11 +1243,13 @@ trait Mixin
      *
      * @psalm-assert iterable<iterable|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<iterable|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrIsIterable(mixed $value, string $message = ''): iterable
+    public static function allNullOrIsIterable(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1146,12 +1266,15 @@ trait Mixin
      * @template T of object
      * @psalm-assert T|null $value
      *
+     * @param string|callable():string $message
+     *
      * @psalm-param class-string<T> $class
+     *
      * @return T|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsInstanceOf(mixed $value, mixed $class, string $message = ''): mixed
+    public static function nullOrIsInstanceOf(mixed $value, mixed $class, callable|string $message = ''): mixed
     {
         null === $value || static::isInstanceOf($value, $class, $message);
 
@@ -1164,12 +1287,15 @@ trait Mixin
      * @template T of object
      * @psalm-assert iterable<T> $value
      *
+     * @param string|callable():string $message
+     *
      * @psalm-param class-string<T> $class
+     *
      * @return iterable<T>
      *
      * @throws InvalidArgumentException
      */
-    public static function allIsInstanceOf(mixed $value, mixed $class, string $message = ''): iterable
+    public static function allIsInstanceOf(mixed $value, mixed $class, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1186,12 +1312,15 @@ trait Mixin
      * @template T of object
      * @psalm-assert iterable<T|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @psalm-param class-string<T> $class
+     *
      * @return iterable<T|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrIsInstanceOf(mixed $value, mixed $class, string $message = ''): iterable
+    public static function allNullOrIsInstanceOf(mixed $value, mixed $class, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1204,12 +1333,16 @@ trait Mixin
 
     /**
      * @template T of object
+     *
+     * @param string|callable():string $message
+     *
      * @psalm-param class-string<T> $class
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNotInstanceOf(mixed $value, mixed $class, string $message = ''): mixed
+    public static function nullOrNotInstanceOf(mixed $value, mixed $class, callable|string $message = ''): mixed
     {
         null === $value || static::notInstanceOf($value, $class, $message);
 
@@ -1218,12 +1351,16 @@ trait Mixin
 
     /**
      * @template T of object
+     *
+     * @param string|callable():string $message
+     *
      * @psalm-param class-string<T> $class
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNotInstanceOf(mixed $value, mixed $class, string $message = ''): iterable
+    public static function allNotInstanceOf(mixed $value, mixed $class, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1238,12 +1375,15 @@ trait Mixin
      * @template T of object
      * @psalm-assert iterable<object|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @psalm-param class-string<T> $class
+     *
      * @return iterable<object|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrNotInstanceOf(mixed $value, mixed $class, string $message = ''): iterable
+    public static function allNullOrNotInstanceOf(mixed $value, mixed $class, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1258,13 +1398,14 @@ trait Mixin
      * @template T of object
      * @psalm-assert T|null $value
      *
-     * @param T|null $value
+     * @param T|null                   $value
+     * @param string|callable():string $message
      *
      * @return T|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsInstanceOfAny(mixed $value, mixed $classes, string $message = ''): mixed
+    public static function nullOrIsInstanceOfAny(mixed $value, mixed $classes, callable|string $message = ''): mixed
     {
         null === $value || static::isInstanceOfAny($value, $classes, $message);
 
@@ -1275,13 +1416,14 @@ trait Mixin
      * @template T of object
      * @psalm-assert iterable<T> $value
      *
-     * @param iterable<T> $value
+     * @param iterable<T>              $value
+     * @param string|callable():string $message
      *
      * @return iterable<T>
      *
      * @throws InvalidArgumentException
      */
-    public static function allIsInstanceOfAny(mixed $value, mixed $classes, string $message = ''): iterable
+    public static function allIsInstanceOfAny(mixed $value, mixed $classes, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1296,13 +1438,14 @@ trait Mixin
      * @template T of object
      * @psalm-assert iterable<T|null> $value
      *
-     * @param iterable<T|null> $value
+     * @param iterable<T|null>         $value
+     * @param string|callable():string $message
      *
      * @return iterable<T|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrIsInstanceOfAny(mixed $value, mixed $classes, string $message = ''): iterable
+    public static function allNullOrIsInstanceOfAny(mixed $value, mixed $classes, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1317,13 +1460,14 @@ trait Mixin
      * @template T
      * @psalm-assert T|null $value
      *
-     * @param T|null $value
+     * @param T|null                   $value
+     * @param string|callable():string $message
      *
      * @return T|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsNotInstanceOfAny(mixed $value, mixed $classes, string $message = ''): mixed
+    public static function nullOrIsNotInstanceOfAny(mixed $value, mixed $classes, callable|string $message = ''): mixed
     {
         null === $value || static::isNotInstanceOfAny($value, $classes, $message);
 
@@ -1334,13 +1478,14 @@ trait Mixin
      * @template T
      * @psalm-assert iterable<T> $value
      *
-     * @param iterable<T> $value
+     * @param iterable<T>              $value
+     * @param string|callable():string $message
      *
      * @return iterable<T>
      *
      * @throws InvalidArgumentException
      */
-    public static function allIsNotInstanceOfAny(mixed $value, mixed $classes, string $message = ''): iterable
+    public static function allIsNotInstanceOfAny(mixed $value, mixed $classes, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1355,13 +1500,14 @@ trait Mixin
      * @template T
      * @psalm-assert iterable<T|null> $value
      *
-     * @param iterable<T|null> $value
+     * @param iterable<T|null>         $value
+     * @param string|callable():string $message
      *
      * @return iterable<T|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrIsNotInstanceOfAny(mixed $value, mixed $classes, string $message = ''): iterable
+    public static function allNullOrIsNotInstanceOfAny(mixed $value, mixed $classes, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1378,11 +1524,13 @@ trait Mixin
      * @template T of object
      * @psalm-assert T|class-string<T>|null $value
      *
+     * @param string|callable():string $message
+     *
      * @return T|class-string<T>|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsAOf(mixed $value, mixed $class, string $message = ''): mixed
+    public static function nullOrIsAOf(mixed $value, mixed $class, callable|string $message = ''): mixed
     {
         null === $value || static::isAOf($value, $class, $message);
 
@@ -1395,11 +1543,13 @@ trait Mixin
      * @template T of object
      * @psalm-assert iterable<T|class-string<T>> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<T|class-string<T>>
      *
      * @throws InvalidArgumentException
      */
-    public static function allIsAOf(mixed $value, mixed $class, string $message = ''): iterable
+    public static function allIsAOf(mixed $value, mixed $class, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1416,11 +1566,13 @@ trait Mixin
      * @template T of object
      * @psalm-assert iterable<T|class-string<T>|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<T|class-string<T>|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrIsAOf(mixed $value, mixed $class, string $message = ''): iterable
+    public static function allNullOrIsAOf(mixed $value, mixed $class, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1436,13 +1588,14 @@ trait Mixin
      *
      * @template T
      *
-     * @param T|null $value
+     * @param T|null                   $value
+     * @param string|callable():string $message
      *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsNotA(mixed $value, mixed $class, string $message = ''): mixed
+    public static function nullOrIsNotA(mixed $value, mixed $class, callable|string $message = ''): mixed
     {
         null === $value || static::isNotA($value, $class, $message);
 
@@ -1454,13 +1607,14 @@ trait Mixin
      *
      * @template T
      *
-     * @param iterable<T> $value
+     * @param iterable<T>              $value
+     * @param string|callable():string $message
      *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allIsNotA(mixed $value, mixed $class, string $message = ''): iterable
+    public static function allIsNotA(mixed $value, mixed $class, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1477,13 +1631,14 @@ trait Mixin
      * @template T
      * @psalm-assert iterable<object|class-string|null> $value
      *
-     * @param iterable<T|null> $value
+     * @param iterable<T|null>         $value
+     * @param string|callable():string $message
      *
      * @return iterable<object|class-string|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrIsNotA(mixed $value, mixed $class, string $message = ''): iterable
+    public static function allNullOrIsNotA(mixed $value, mixed $class, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1497,8 +1652,9 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param object|string|null $value
-     * @param string[]           $classes
+     * @param object|string|null       $value
+     * @param string[]                 $classes
+     * @param string|callable():string $message
      *
      * @psalm-param array<class-string> $classes
      *
@@ -1506,7 +1662,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsAnyOf(mixed $value, mixed $classes, string $message = ''): mixed
+    public static function nullOrIsAnyOf(mixed $value, mixed $classes, callable|string $message = ''): mixed
     {
         null === $value || static::isAnyOf($value, $classes, $message);
 
@@ -1516,8 +1672,9 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param iterable<object|string> $value
-     * @param string[]                $classes
+     * @param iterable<object|string>  $value
+     * @param string[]                 $classes
+     * @param string|callable():string $message
      *
      * @psalm-param array<class-string> $classes
      *
@@ -1525,7 +1682,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allIsAnyOf(mixed $value, mixed $classes, string $message = ''): iterable
+    public static function allIsAnyOf(mixed $value, mixed $classes, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1541,6 +1698,7 @@ trait Mixin
      *
      * @param iterable<object|string|null> $value
      * @param string[]                     $classes
+     * @param string|callable():string     $message
      *
      * @psalm-param array<class-string> $classes
      *
@@ -1548,7 +1706,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrIsAnyOf(mixed $value, mixed $classes, string $message = ''): iterable
+    public static function allNullOrIsAnyOf(mixed $value, mixed $classes, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1564,11 +1722,13 @@ trait Mixin
      *
      * @psalm-assert empty $value
      *
+     * @param string|callable():string $message
+     *
      * @return empty
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsEmpty(mixed $value, string $message = ''): mixed
+    public static function nullOrIsEmpty(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::isEmpty($value, $message);
 
@@ -1580,11 +1740,13 @@ trait Mixin
      *
      * @psalm-assert iterable<empty> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<empty>
      *
      * @throws InvalidArgumentException
      */
-    public static function allIsEmpty(mixed $value, string $message = ''): iterable
+    public static function allIsEmpty(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1600,11 +1762,13 @@ trait Mixin
      *
      * @psalm-assert iterable<empty|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<empty|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrIsEmpty(mixed $value, string $message = ''): iterable
+    public static function allNullOrIsEmpty(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1618,11 +1782,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNotEmpty(mixed $value, string $message = ''): mixed
+    public static function nullOrNotEmpty(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::notEmpty($value, $message);
 
@@ -1632,11 +1798,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNotEmpty(mixed $value, string $message = ''): iterable
+    public static function allNotEmpty(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1652,11 +1820,13 @@ trait Mixin
      *
      * @psalm-assert iterable<!empty|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<!empty|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrNotEmpty(mixed $value, string $message = ''): iterable
+    public static function allNullOrNotEmpty(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1672,11 +1842,13 @@ trait Mixin
      *
      * @psalm-assert iterable<null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNull(mixed $value, string $message = ''): iterable
+    public static function allNull(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1690,11 +1862,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNotNull(mixed $value, string $message = ''): iterable
+    public static function allNotNull(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1710,11 +1884,13 @@ trait Mixin
      *
      * @psalm-assert true|null $value
      *
+     * @param string|callable():string $message
+     *
      * @return true|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrTrue(mixed $value, string $message = ''): mixed
+    public static function nullOrTrue(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::true($value, $message);
 
@@ -1726,11 +1902,13 @@ trait Mixin
      *
      * @psalm-assert iterable<true> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<true>
      *
      * @throws InvalidArgumentException
      */
-    public static function allTrue(mixed $value, string $message = ''): iterable
+    public static function allTrue(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1746,11 +1924,13 @@ trait Mixin
      *
      * @psalm-assert iterable<true|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<true|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrTrue(mixed $value, string $message = ''): iterable
+    public static function allNullOrTrue(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1766,11 +1946,13 @@ trait Mixin
      *
      * @psalm-assert false|null $value
      *
+     * @param string|callable():string $message
+     *
      * @return false|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrFalse(mixed $value, string $message = ''): mixed
+    public static function nullOrFalse(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::false($value, $message);
 
@@ -1782,11 +1964,13 @@ trait Mixin
      *
      * @psalm-assert iterable<false> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<false>
      *
      * @throws InvalidArgumentException
      */
-    public static function allFalse(mixed $value, string $message = ''): iterable
+    public static function allFalse(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1802,11 +1986,13 @@ trait Mixin
      *
      * @psalm-assert iterable<false|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<false|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrFalse(mixed $value, string $message = ''): iterable
+    public static function allNullOrFalse(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1820,11 +2006,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNotFalse(mixed $value, string $message = ''): mixed
+    public static function nullOrNotFalse(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::notFalse($value, $message);
 
@@ -1834,11 +2022,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNotFalse(mixed $value, string $message = ''): iterable
+    public static function allNotFalse(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1854,11 +2044,13 @@ trait Mixin
      *
      * @psalm-assert iterable<!false|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<!false|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrNotFalse(mixed $value, string $message = ''): iterable
+    public static function allNullOrNotFalse(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1872,12 +2064,15 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @psalm-param string|null $value
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIp(mixed $value, string $message = ''): mixed
+    public static function nullOrIp(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::ip($value, $message);
 
@@ -1887,12 +2082,15 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @psalm-param iterable<string> $value
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allIp(mixed $value, string $message = ''): iterable
+    public static function allIp(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1906,12 +2104,15 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @psalm-param iterable<string|null> $value
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrIp(mixed $value, string $message = ''): iterable
+    public static function allNullOrIp(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1925,12 +2126,15 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @psalm-param string|null $value
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIpv4(mixed $value, string $message = ''): mixed
+    public static function nullOrIpv4(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::ipv4($value, $message);
 
@@ -1940,12 +2144,15 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @psalm-param iterable<string> $value
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allIpv4(mixed $value, string $message = ''): iterable
+    public static function allIpv4(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1959,12 +2166,15 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @psalm-param iterable<string|null> $value
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrIpv4(mixed $value, string $message = ''): iterable
+    public static function allNullOrIpv4(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -1978,12 +2188,15 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @psalm-param string|null $value
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIpv6(mixed $value, string $message = ''): mixed
+    public static function nullOrIpv6(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::ipv6($value, $message);
 
@@ -1993,12 +2206,15 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @psalm-param iterable<string> $value
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allIpv6(mixed $value, string $message = ''): iterable
+    public static function allIpv6(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2012,12 +2228,15 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @psalm-param iterable<string|null> $value
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrIpv6(mixed $value, string $message = ''): iterable
+    public static function allNullOrIpv6(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2031,12 +2250,15 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @psalm-param string|null $value
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrEmail(mixed $value, string $message = ''): mixed
+    public static function nullOrEmail(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::email($value, $message);
 
@@ -2046,12 +2268,15 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @psalm-param iterable<string> $value
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allEmail(mixed $value, string $message = ''): iterable
+    public static function allEmail(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2065,12 +2290,15 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @psalm-param iterable<string|null> $value
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrEmail(mixed $value, string $message = ''): iterable
+    public static function allNullOrEmail(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2082,11 +2310,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrUniqueValues(mixed $values, string $message = ''): mixed
+    public static function nullOrUniqueValues(mixed $values, callable|string $message = ''): mixed
     {
         null === $values || static::uniqueValues($values, $message);
 
@@ -2094,11 +2324,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allUniqueValues(mixed $values, string $message = ''): mixed
+    public static function allUniqueValues(mixed $values, callable|string $message = ''): mixed
     {
         static::isIterable($values);
 
@@ -2110,11 +2342,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrUniqueValues(mixed $values, string $message = ''): mixed
+    public static function allNullOrUniqueValues(mixed $values, callable|string $message = ''): mixed
     {
         static::isIterable($values);
 
@@ -2126,11 +2360,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrEq(mixed $value, mixed $expect, string $message = ''): mixed
+    public static function nullOrEq(mixed $value, mixed $expect, callable|string $message = ''): mixed
     {
         null === $value || static::eq($value, $expect, $message);
 
@@ -2138,11 +2374,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allEq(mixed $value, mixed $expect, string $message = ''): iterable
+    public static function allEq(mixed $value, mixed $expect, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2154,11 +2392,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrEq(mixed $value, mixed $expect, string $message = ''): iterable
+    public static function allNullOrEq(mixed $value, mixed $expect, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2170,11 +2410,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNotEq(mixed $value, mixed $expect, string $message = ''): mixed
+    public static function nullOrNotEq(mixed $value, mixed $expect, callable|string $message = ''): mixed
     {
         null === $value || static::notEq($value, $expect, $message);
 
@@ -2182,11 +2424,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNotEq(mixed $value, mixed $expect, string $message = ''): iterable
+    public static function allNotEq(mixed $value, mixed $expect, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2198,11 +2442,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrNotEq(mixed $value, mixed $expect, string $message = ''): iterable
+    public static function allNullOrNotEq(mixed $value, mixed $expect, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2216,11 +2462,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrSame(mixed $value, mixed $expect, string $message = ''): mixed
+    public static function nullOrSame(mixed $value, mixed $expect, callable|string $message = ''): mixed
     {
         null === $value || static::same($value, $expect, $message);
 
@@ -2230,11 +2478,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allSame(mixed $value, mixed $expect, string $message = ''): iterable
+    public static function allSame(mixed $value, mixed $expect, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2248,11 +2498,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrSame(mixed $value, mixed $expect, string $message = ''): iterable
+    public static function allNullOrSame(mixed $value, mixed $expect, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2266,11 +2518,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNotSame(mixed $value, mixed $expect, string $message = ''): mixed
+    public static function nullOrNotSame(mixed $value, mixed $expect, callable|string $message = ''): mixed
     {
         null === $value || static::notSame($value, $expect, $message);
 
@@ -2280,11 +2534,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNotSame(mixed $value, mixed $expect, string $message = ''): iterable
+    public static function allNotSame(mixed $value, mixed $expect, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2298,11 +2554,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrNotSame(mixed $value, mixed $expect, string $message = ''): iterable
+    public static function allNullOrNotSame(mixed $value, mixed $expect, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2316,11 +2574,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrGreaterThan(mixed $value, mixed $limit, string $message = ''): mixed
+    public static function nullOrGreaterThan(mixed $value, mixed $limit, callable|string $message = ''): mixed
     {
         null === $value || static::greaterThan($value, $limit, $message);
 
@@ -2330,11 +2590,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allGreaterThan(mixed $value, mixed $limit, string $message = ''): iterable
+    public static function allGreaterThan(mixed $value, mixed $limit, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2348,11 +2610,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrGreaterThan(mixed $value, mixed $limit, string $message = ''): iterable
+    public static function allNullOrGreaterThan(mixed $value, mixed $limit, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2366,11 +2630,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrGreaterThanEq(mixed $value, mixed $limit, string $message = ''): mixed
+    public static function nullOrGreaterThanEq(mixed $value, mixed $limit, callable|string $message = ''): mixed
     {
         null === $value || static::greaterThanEq($value, $limit, $message);
 
@@ -2380,11 +2646,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allGreaterThanEq(mixed $value, mixed $limit, string $message = ''): iterable
+    public static function allGreaterThanEq(mixed $value, mixed $limit, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2398,11 +2666,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrGreaterThanEq(mixed $value, mixed $limit, string $message = ''): iterable
+    public static function allNullOrGreaterThanEq(mixed $value, mixed $limit, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2416,11 +2686,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrLessThan(mixed $value, mixed $limit, string $message = ''): mixed
+    public static function nullOrLessThan(mixed $value, mixed $limit, callable|string $message = ''): mixed
     {
         null === $value || static::lessThan($value, $limit, $message);
 
@@ -2430,11 +2702,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allLessThan(mixed $value, mixed $limit, string $message = ''): iterable
+    public static function allLessThan(mixed $value, mixed $limit, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2448,11 +2722,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrLessThan(mixed $value, mixed $limit, string $message = ''): iterable
+    public static function allNullOrLessThan(mixed $value, mixed $limit, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2466,11 +2742,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrLessThanEq(mixed $value, mixed $limit, string $message = ''): mixed
+    public static function nullOrLessThanEq(mixed $value, mixed $limit, callable|string $message = ''): mixed
     {
         null === $value || static::lessThanEq($value, $limit, $message);
 
@@ -2480,11 +2758,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allLessThanEq(mixed $value, mixed $limit, string $message = ''): iterable
+    public static function allLessThanEq(mixed $value, mixed $limit, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2498,11 +2778,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrLessThanEq(mixed $value, mixed $limit, string $message = ''): iterable
+    public static function allNullOrLessThanEq(mixed $value, mixed $limit, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2516,11 +2798,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrRange(mixed $value, mixed $min, mixed $max, string $message = ''): mixed
+    public static function nullOrRange(mixed $value, mixed $min, mixed $max, callable|string $message = ''): mixed
     {
         null === $value || static::range($value, $min, $max, $message);
 
@@ -2530,11 +2814,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allRange(mixed $value, mixed $min, mixed $max, string $message = ''): iterable
+    public static function allRange(mixed $value, mixed $min, mixed $max, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2548,11 +2834,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrRange(mixed $value, mixed $min, mixed $max, string $message = ''): iterable
+    public static function allNullOrRange(mixed $value, mixed $min, mixed $max, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2566,11 +2854,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrOneOf(mixed $value, mixed $values, string $message = ''): mixed
+    public static function nullOrOneOf(mixed $value, mixed $values, callable|string $message = ''): mixed
     {
         null === $value || static::oneOf($value, $values, $message);
 
@@ -2580,11 +2870,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allOneOf(mixed $value, mixed $values, string $message = ''): iterable
+    public static function allOneOf(mixed $value, mixed $values, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2598,11 +2890,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrOneOf(mixed $value, mixed $values, string $message = ''): iterable
+    public static function allNullOrOneOf(mixed $value, mixed $values, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2616,11 +2910,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrInArray(mixed $value, mixed $values, string $message = ''): mixed
+    public static function nullOrInArray(mixed $value, mixed $values, callable|string $message = ''): mixed
     {
         null === $value || static::inArray($value, $values, $message);
 
@@ -2630,11 +2926,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allInArray(mixed $value, mixed $values, string $message = ''): iterable
+    public static function allInArray(mixed $value, mixed $values, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2648,11 +2946,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrInArray(mixed $value, mixed $values, string $message = ''): iterable
+    public static function allNullOrInArray(mixed $value, mixed $values, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2666,11 +2966,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNotOneOf(mixed $value, mixed $values, string $message = ''): mixed
+    public static function nullOrNotOneOf(mixed $value, mixed $values, callable|string $message = ''): mixed
     {
         null === $value || static::notOneOf($value, $values, $message);
 
@@ -2680,11 +2982,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNotOneOf(mixed $value, mixed $values, string $message = ''): iterable
+    public static function allNotOneOf(mixed $value, mixed $values, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2698,11 +3002,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrNotOneOf(mixed $value, mixed $values, string $message = ''): iterable
+    public static function allNullOrNotOneOf(mixed $value, mixed $values, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2716,11 +3022,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNotInArray(mixed $value, mixed $values, string $message = ''): mixed
+    public static function nullOrNotInArray(mixed $value, mixed $values, callable|string $message = ''): mixed
     {
         null === $value || static::notInArray($value, $values, $message);
 
@@ -2730,11 +3038,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNotInArray(mixed $value, mixed $values, string $message = ''): iterable
+    public static function allNotInArray(mixed $value, mixed $values, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2748,11 +3058,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrNotInArray(mixed $value, mixed $values, string $message = ''): iterable
+    public static function allNullOrNotInArray(mixed $value, mixed $values, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2766,11 +3078,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrContains(mixed $value, mixed $subString, string $message = ''): mixed
+    public static function nullOrContains(mixed $value, mixed $subString, callable|string $message = ''): mixed
     {
         null === $value || static::contains($value, $subString, $message);
 
@@ -2780,11 +3094,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allContains(mixed $value, mixed $subString, string $message = ''): iterable
+    public static function allContains(mixed $value, mixed $subString, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2798,11 +3114,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrContains(mixed $value, mixed $subString, string $message = ''): iterable
+    public static function allNullOrContains(mixed $value, mixed $subString, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2816,11 +3134,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNotContains(mixed $value, mixed $subString, string $message = ''): mixed
+    public static function nullOrNotContains(mixed $value, mixed $subString, callable|string $message = ''): mixed
     {
         null === $value || static::notContains($value, $subString, $message);
 
@@ -2830,11 +3150,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNotContains(mixed $value, mixed $subString, string $message = ''): iterable
+    public static function allNotContains(mixed $value, mixed $subString, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2848,11 +3170,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrNotContains(mixed $value, mixed $subString, string $message = ''): iterable
+    public static function allNullOrNotContains(mixed $value, mixed $subString, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2866,11 +3190,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNotWhitespaceOnly(mixed $value, string $message = ''): mixed
+    public static function nullOrNotWhitespaceOnly(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::notWhitespaceOnly($value, $message);
 
@@ -2880,11 +3206,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNotWhitespaceOnly(mixed $value, string $message = ''): iterable
+    public static function allNotWhitespaceOnly(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2898,11 +3226,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrNotWhitespaceOnly(mixed $value, string $message = ''): iterable
+    public static function allNullOrNotWhitespaceOnly(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2916,11 +3246,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrStartsWith(mixed $value, mixed $prefix, string $message = ''): mixed
+    public static function nullOrStartsWith(mixed $value, mixed $prefix, callable|string $message = ''): mixed
     {
         null === $value || static::startsWith($value, $prefix, $message);
 
@@ -2930,11 +3262,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allStartsWith(mixed $value, mixed $prefix, string $message = ''): iterable
+    public static function allStartsWith(mixed $value, mixed $prefix, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2948,11 +3282,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrStartsWith(mixed $value, mixed $prefix, string $message = ''): iterable
+    public static function allNullOrStartsWith(mixed $value, mixed $prefix, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2966,11 +3302,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNotStartsWith(mixed $value, mixed $prefix, string $message = ''): mixed
+    public static function nullOrNotStartsWith(mixed $value, mixed $prefix, callable|string $message = ''): mixed
     {
         null === $value || static::notStartsWith($value, $prefix, $message);
 
@@ -2980,11 +3318,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNotStartsWith(mixed $value, mixed $prefix, string $message = ''): iterable
+    public static function allNotStartsWith(mixed $value, mixed $prefix, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -2998,11 +3338,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrNotStartsWith(mixed $value, mixed $prefix, string $message = ''): iterable
+    public static function allNullOrNotStartsWith(mixed $value, mixed $prefix, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3016,11 +3358,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrStartsWithLetter(mixed $value, string $message = ''): mixed
+    public static function nullOrStartsWithLetter(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::startsWithLetter($value, $message);
 
@@ -3030,11 +3374,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allStartsWithLetter(mixed $value, string $message = ''): iterable
+    public static function allStartsWithLetter(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3048,11 +3394,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrStartsWithLetter(mixed $value, string $message = ''): iterable
+    public static function allNullOrStartsWithLetter(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3066,11 +3414,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrEndsWith(mixed $value, mixed $suffix, string $message = ''): mixed
+    public static function nullOrEndsWith(mixed $value, mixed $suffix, callable|string $message = ''): mixed
     {
         null === $value || static::endsWith($value, $suffix, $message);
 
@@ -3080,11 +3430,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allEndsWith(mixed $value, mixed $suffix, string $message = ''): iterable
+    public static function allEndsWith(mixed $value, mixed $suffix, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3098,11 +3450,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrEndsWith(mixed $value, mixed $suffix, string $message = ''): iterable
+    public static function allNullOrEndsWith(mixed $value, mixed $suffix, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3116,11 +3470,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNotEndsWith(mixed $value, mixed $suffix, string $message = ''): mixed
+    public static function nullOrNotEndsWith(mixed $value, mixed $suffix, callable|string $message = ''): mixed
     {
         null === $value || static::notEndsWith($value, $suffix, $message);
 
@@ -3130,11 +3486,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNotEndsWith(mixed $value, mixed $suffix, string $message = ''): iterable
+    public static function allNotEndsWith(mixed $value, mixed $suffix, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3148,11 +3506,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrNotEndsWith(mixed $value, mixed $suffix, string $message = ''): iterable
+    public static function allNullOrNotEndsWith(mixed $value, mixed $suffix, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3166,11 +3526,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrRegex(mixed $value, mixed $pattern, string $message = ''): mixed
+    public static function nullOrRegex(mixed $value, mixed $pattern, callable|string $message = ''): mixed
     {
         null === $value || static::regex($value, $pattern, $message);
 
@@ -3180,11 +3542,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allRegex(mixed $value, mixed $pattern, string $message = ''): iterable
+    public static function allRegex(mixed $value, mixed $pattern, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3198,11 +3562,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrRegex(mixed $value, mixed $pattern, string $message = ''): iterable
+    public static function allNullOrRegex(mixed $value, mixed $pattern, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3216,11 +3582,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNotRegex(mixed $value, mixed $pattern, string $message = ''): mixed
+    public static function nullOrNotRegex(mixed $value, mixed $pattern, callable|string $message = ''): mixed
     {
         null === $value || static::notRegex($value, $pattern, $message);
 
@@ -3230,11 +3598,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNotRegex(mixed $value, mixed $pattern, string $message = ''): iterable
+    public static function allNotRegex(mixed $value, mixed $pattern, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3248,11 +3618,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrNotRegex(mixed $value, mixed $pattern, string $message = ''): iterable
+    public static function allNullOrNotRegex(mixed $value, mixed $pattern, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3266,11 +3638,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrUnicodeLetters(mixed $value, string $message = ''): mixed
+    public static function nullOrUnicodeLetters(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::unicodeLetters($value, $message);
 
@@ -3280,11 +3654,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allUnicodeLetters(mixed $value, string $message = ''): iterable
+    public static function allUnicodeLetters(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3298,11 +3674,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrUnicodeLetters(mixed $value, string $message = ''): iterable
+    public static function allNullOrUnicodeLetters(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3316,11 +3694,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrAlpha(mixed $value, string $message = ''): mixed
+    public static function nullOrAlpha(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::alpha($value, $message);
 
@@ -3330,11 +3710,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allAlpha(mixed $value, string $message = ''): iterable
+    public static function allAlpha(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3348,11 +3730,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrAlpha(mixed $value, string $message = ''): iterable
+    public static function allNullOrAlpha(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3366,11 +3750,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrDigits(mixed $value, string $message = ''): mixed
+    public static function nullOrDigits(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::digits($value, $message);
 
@@ -3380,11 +3766,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allDigits(mixed $value, string $message = ''): iterable
+    public static function allDigits(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3398,11 +3786,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrDigits(mixed $value, string $message = ''): iterable
+    public static function allNullOrDigits(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3416,11 +3806,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrAlnum(mixed $value, string $message = ''): mixed
+    public static function nullOrAlnum(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::alnum($value, $message);
 
@@ -3430,11 +3822,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allAlnum(mixed $value, string $message = ''): iterable
+    public static function allAlnum(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3448,11 +3842,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrAlnum(mixed $value, string $message = ''): iterable
+    public static function allNullOrAlnum(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3468,11 +3864,13 @@ trait Mixin
      *
      * @psalm-assert lowercase-string|null $value
      *
+     * @param string|callable():string $message
+     *
      * @return lowercase-string|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrLower(mixed $value, string $message = ''): mixed
+    public static function nullOrLower(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::lower($value, $message);
 
@@ -3484,11 +3882,13 @@ trait Mixin
      *
      * @psalm-assert iterable<lowercase-string> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<lowercase-string>
      *
      * @throws InvalidArgumentException
      */
-    public static function allLower(mixed $value, string $message = ''): iterable
+    public static function allLower(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3504,11 +3904,13 @@ trait Mixin
      *
      * @psalm-assert iterable<lowercase-string|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<lowercase-string|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrLower(mixed $value, string $message = ''): iterable
+    public static function allNullOrLower(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3522,11 +3924,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrUpper(mixed $value, string $message = ''): mixed
+    public static function nullOrUpper(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::upper($value, $message);
 
@@ -3536,11 +3940,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allUpper(mixed $value, string $message = ''): iterable
+    public static function allUpper(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3556,11 +3962,13 @@ trait Mixin
      *
      * @psalm-assert iterable<!lowercase-string|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<!lowercase-string|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrUpper(mixed $value, string $message = ''): iterable
+    public static function allNullOrUpper(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3574,11 +3982,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrLength(mixed $value, mixed $length, string $message = ''): mixed
+    public static function nullOrLength(mixed $value, mixed $length, callable|string $message = ''): mixed
     {
         null === $value || static::length($value, $length, $message);
 
@@ -3588,11 +3998,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allLength(mixed $value, mixed $length, string $message = ''): iterable
+    public static function allLength(mixed $value, mixed $length, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3606,11 +4018,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrLength(mixed $value, mixed $length, string $message = ''): iterable
+    public static function allNullOrLength(mixed $value, mixed $length, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3624,11 +4038,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrMinLength(mixed $value, mixed $min, string $message = ''): mixed
+    public static function nullOrMinLength(mixed $value, mixed $min, callable|string $message = ''): mixed
     {
         null === $value || static::minLength($value, $min, $message);
 
@@ -3638,11 +4054,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allMinLength(mixed $value, mixed $min, string $message = ''): iterable
+    public static function allMinLength(mixed $value, mixed $min, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3656,11 +4074,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrMinLength(mixed $value, mixed $min, string $message = ''): iterable
+    public static function allNullOrMinLength(mixed $value, mixed $min, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3674,11 +4094,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrMaxLength(mixed $value, mixed $max, string $message = ''): mixed
+    public static function nullOrMaxLength(mixed $value, mixed $max, callable|string $message = ''): mixed
     {
         null === $value || static::maxLength($value, $max, $message);
 
@@ -3688,11 +4110,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allMaxLength(mixed $value, mixed $max, string $message = ''): iterable
+    public static function allMaxLength(mixed $value, mixed $max, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3706,11 +4130,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrMaxLength(mixed $value, mixed $max, string $message = ''): iterable
+    public static function allNullOrMaxLength(mixed $value, mixed $max, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3724,11 +4150,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrLengthBetween(mixed $value, mixed $min, mixed $max, string $message = ''): mixed
+    public static function nullOrLengthBetween(mixed $value, mixed $min, mixed $max, callable|string $message = ''): mixed
     {
         null === $value || static::lengthBetween($value, $min, $max, $message);
 
@@ -3738,11 +4166,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allLengthBetween(mixed $value, mixed $min, mixed $max, string $message = ''): iterable
+    public static function allLengthBetween(mixed $value, mixed $min, mixed $max, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3756,11 +4186,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrLengthBetween(mixed $value, mixed $min, mixed $max, string $message = ''): iterable
+    public static function allNullOrLengthBetween(mixed $value, mixed $min, mixed $max, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3772,11 +4204,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrFileExists(mixed $value, string $message = ''): mixed
+    public static function nullOrFileExists(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::fileExists($value, $message);
 
@@ -3784,11 +4218,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allFileExists(mixed $value, string $message = ''): iterable
+    public static function allFileExists(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3800,11 +4236,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrFileExists(mixed $value, string $message = ''): iterable
+    public static function allNullOrFileExists(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3816,11 +4254,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrFile(mixed $value, string $message = ''): mixed
+    public static function nullOrFile(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::file($value, $message);
 
@@ -3828,11 +4268,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allFile(mixed $value, string $message = ''): iterable
+    public static function allFile(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3844,11 +4286,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrFile(mixed $value, string $message = ''): iterable
+    public static function allNullOrFile(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3860,11 +4304,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrDirectory(mixed $value, string $message = ''): mixed
+    public static function nullOrDirectory(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::directory($value, $message);
 
@@ -3872,11 +4318,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allDirectory(mixed $value, string $message = ''): iterable
+    public static function allDirectory(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3888,11 +4336,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrDirectory(mixed $value, string $message = ''): iterable
+    public static function allNullOrDirectory(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3904,11 +4354,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrReadable(mixed $value, string $message = ''): mixed
+    public static function nullOrReadable(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::readable($value, $message);
 
@@ -3916,11 +4368,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allReadable(mixed $value, string $message = ''): iterable
+    public static function allReadable(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3932,11 +4386,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrReadable(mixed $value, string $message = ''): iterable
+    public static function allNullOrReadable(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3948,11 +4404,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrWritable(mixed $value, string $message = ''): mixed
+    public static function nullOrWritable(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::writable($value, $message);
 
@@ -3960,11 +4418,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allWritable(mixed $value, string $message = ''): iterable
+    public static function allWritable(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3976,11 +4436,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrWritable(mixed $value, string $message = ''): iterable
+    public static function allNullOrWritable(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -3994,11 +4456,13 @@ trait Mixin
     /**
      * @psalm-assert class-string|null $value
      *
+     * @param string|callable():string $message
+     *
      * @return class-string|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrClassExists(mixed $value, string $message = ''): mixed
+    public static function nullOrClassExists(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::classExists($value, $message);
 
@@ -4008,11 +4472,13 @@ trait Mixin
     /**
      * @psalm-assert iterable<class-string> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<class-string>
      *
      * @throws InvalidArgumentException
      */
-    public static function allClassExists(mixed $value, string $message = ''): iterable
+    public static function allClassExists(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -4026,11 +4492,13 @@ trait Mixin
     /**
      * @psalm-assert iterable<class-string|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<class-string|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrClassExists(mixed $value, string $message = ''): iterable
+    public static function allNullOrClassExists(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -4048,12 +4516,13 @@ trait Mixin
      * @psalm-assert class-string<ExpectedType>|null $value
      *
      * @param class-string<ExpectedType> $class
+     * @param string|callable():string   $message
      *
      * @return class-string<ExpectedType>|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrSubclassOf(mixed $value, mixed $class, string $message = ''): mixed
+    public static function nullOrSubclassOf(mixed $value, mixed $class, callable|string $message = ''): mixed
     {
         null === $value || static::subclassOf($value, $class, $message);
 
@@ -4067,12 +4536,13 @@ trait Mixin
      * @psalm-assert iterable<class-string<ExpectedType>> $value
      *
      * @param class-string<ExpectedType> $class
+     * @param string|callable():string   $message
      *
      * @return iterable<class-string<ExpectedType>>
      *
      * @throws InvalidArgumentException
      */
-    public static function allSubclassOf(mixed $value, mixed $class, string $message = ''): iterable
+    public static function allSubclassOf(mixed $value, mixed $class, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -4090,12 +4560,13 @@ trait Mixin
      * @psalm-assert iterable<class-string<ExpectedType>|null> $value
      *
      * @param class-string<ExpectedType> $class
+     * @param string|callable():string   $message
      *
      * @return iterable<class-string<ExpectedType>|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrSubclassOf(mixed $value, mixed $class, string $message = ''): iterable
+    public static function allNullOrSubclassOf(mixed $value, mixed $class, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -4109,11 +4580,13 @@ trait Mixin
     /**
      * @psalm-assert class-string|null $value
      *
+     * @param string|callable():string $message
+     *
      * @return class-string|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrInterfaceExists(mixed $value, string $message = ''): mixed
+    public static function nullOrInterfaceExists(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::interfaceExists($value, $message);
 
@@ -4123,11 +4596,13 @@ trait Mixin
     /**
      * @psalm-assert iterable<class-string> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<class-string>
      *
      * @throws InvalidArgumentException
      */
-    public static function allInterfaceExists(mixed $value, string $message = ''): iterable
+    public static function allInterfaceExists(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -4141,11 +4616,13 @@ trait Mixin
     /**
      * @psalm-assert iterable<class-string|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<class-string|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrInterfaceExists(mixed $value, string $message = ''): iterable
+    public static function allNullOrInterfaceExists(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -4164,12 +4641,13 @@ trait Mixin
      *
      * @param class-string<ExpectedType>|ExpectedType|null $value
      * @param class-string<ExpectedType>                   $interface
+     * @param string|callable():string                     $message
      *
      * @return class-string<ExpectedType>|ExpectedType|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrImplementsInterface(mixed $value, mixed $interface, string $message = ''): mixed
+    public static function nullOrImplementsInterface(mixed $value, mixed $interface, callable|string $message = ''): mixed
     {
         null === $value || static::implementsInterface($value, $interface, $message);
 
@@ -4184,12 +4662,13 @@ trait Mixin
      *
      * @param iterable<class-string<ExpectedType>|ExpectedType> $value
      * @param class-string<ExpectedType>                        $interface
+     * @param string|callable():string                          $message
      *
      * @return iterable<class-string<ExpectedType>|ExpectedType>
      *
      * @throws InvalidArgumentException
      */
-    public static function allImplementsInterface(mixed $value, mixed $interface, string $message = ''): iterable
+    public static function allImplementsInterface(mixed $value, mixed $interface, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -4208,12 +4687,13 @@ trait Mixin
      *
      * @param iterable<class-string<ExpectedType>|ExpectedType|null> $value
      * @param class-string<ExpectedType>                             $interface
+     * @param string|callable():string                               $message
      *
      * @return iterable<class-string<ExpectedType>|ExpectedType|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrImplementsInterface(mixed $value, mixed $interface, string $message = ''): iterable
+    public static function allNullOrImplementsInterface(mixed $value, mixed $interface, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -4227,13 +4707,14 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|object|null $classOrObject
+     * @param string|object|null       $classOrObject
+     * @param string|callable():string $message
      *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrPropertyExists(mixed $classOrObject, mixed $property, string $message = ''): mixed
+    public static function nullOrPropertyExists(mixed $classOrObject, mixed $property, callable|string $message = ''): mixed
     {
         null === $classOrObject || static::propertyExists($classOrObject, $property, $message);
 
@@ -4243,13 +4724,14 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param iterable<string|object> $classOrObject
+     * @param iterable<string|object>  $classOrObject
+     * @param string|callable():string $message
      *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allPropertyExists(mixed $classOrObject, mixed $property, string $message = ''): mixed
+    public static function allPropertyExists(mixed $classOrObject, mixed $property, callable|string $message = ''): mixed
     {
         static::isIterable($classOrObject);
 
@@ -4264,12 +4746,13 @@ trait Mixin
      * @psalm-pure
      *
      * @param iterable<string|object|null> $classOrObject
+     * @param string|callable():string     $message
      *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrPropertyExists(mixed $classOrObject, mixed $property, string $message = ''): mixed
+    public static function allNullOrPropertyExists(mixed $classOrObject, mixed $property, callable|string $message = ''): mixed
     {
         static::isIterable($classOrObject);
 
@@ -4283,7 +4766,8 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|object|null $classOrObject
+     * @param string|object|null       $classOrObject
+     * @param string|callable():string $message
      *
      * @psalm-param class-string|object|null $classOrObject
      *
@@ -4291,7 +4775,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrPropertyNotExists(mixed $classOrObject, mixed $property, string $message = ''): mixed
+    public static function nullOrPropertyNotExists(mixed $classOrObject, mixed $property, callable|string $message = ''): mixed
     {
         null === $classOrObject || static::propertyNotExists($classOrObject, $property, $message);
 
@@ -4301,7 +4785,8 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param iterable<string|object> $classOrObject
+     * @param iterable<string|object>  $classOrObject
+     * @param string|callable():string $message
      *
      * @psalm-param iterable<class-string|object> $classOrObject
      *
@@ -4309,7 +4794,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allPropertyNotExists(mixed $classOrObject, mixed $property, string $message = ''): mixed
+    public static function allPropertyNotExists(mixed $classOrObject, mixed $property, callable|string $message = ''): mixed
     {
         static::isIterable($classOrObject);
 
@@ -4324,6 +4809,7 @@ trait Mixin
      * @psalm-pure
      *
      * @param iterable<string|object|null> $classOrObject
+     * @param string|callable():string     $message
      *
      * @psalm-param iterable<class-string|object|null> $classOrObject
      *
@@ -4331,7 +4817,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrPropertyNotExists(mixed $classOrObject, mixed $property, string $message = ''): mixed
+    public static function allNullOrPropertyNotExists(mixed $classOrObject, mixed $property, callable|string $message = ''): mixed
     {
         static::isIterable($classOrObject);
 
@@ -4345,7 +4831,8 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|object|null $classOrObject
+     * @param string|object|null       $classOrObject
+     * @param string|callable():string $message
      *
      * @psalm-param class-string|object|null $classOrObject
      *
@@ -4353,7 +4840,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrMethodExists(mixed $classOrObject, mixed $method, string $message = ''): mixed
+    public static function nullOrMethodExists(mixed $classOrObject, mixed $method, callable|string $message = ''): mixed
     {
         null === $classOrObject || static::methodExists($classOrObject, $method, $message);
 
@@ -4363,7 +4850,8 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param iterable<string|object> $classOrObject
+     * @param iterable<string|object>  $classOrObject
+     * @param string|callable():string $message
      *
      * @psalm-param iterable<class-string|object> $classOrObject
      *
@@ -4371,7 +4859,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allMethodExists(mixed $classOrObject, mixed $method, string $message = ''): mixed
+    public static function allMethodExists(mixed $classOrObject, mixed $method, callable|string $message = ''): mixed
     {
         static::isIterable($classOrObject);
 
@@ -4386,6 +4874,7 @@ trait Mixin
      * @psalm-pure
      *
      * @param iterable<string|object|null> $classOrObject
+     * @param string|callable():string     $message
      *
      * @psalm-param iterable<class-string|object|null> $classOrObject
      *
@@ -4393,7 +4882,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrMethodExists(mixed $classOrObject, mixed $method, string $message = ''): mixed
+    public static function allNullOrMethodExists(mixed $classOrObject, mixed $method, callable|string $message = ''): mixed
     {
         static::isIterable($classOrObject);
 
@@ -4407,7 +4896,8 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|object|null $classOrObject
+     * @param string|object|null       $classOrObject
+     * @param string|callable():string $message
      *
      * @psalm-param class-string|object|null $classOrObject
      *
@@ -4415,7 +4905,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrMethodNotExists(mixed $classOrObject, mixed $method, string $message = ''): mixed
+    public static function nullOrMethodNotExists(mixed $classOrObject, mixed $method, callable|string $message = ''): mixed
     {
         null === $classOrObject || static::methodNotExists($classOrObject, $method, $message);
 
@@ -4425,7 +4915,8 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param iterable<string|object> $classOrObject
+     * @param iterable<string|object>  $classOrObject
+     * @param string|callable():string $message
      *
      * @psalm-param iterable<class-string|object> $classOrObject
      *
@@ -4433,7 +4924,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allMethodNotExists(mixed $classOrObject, mixed $method, string $message = ''): mixed
+    public static function allMethodNotExists(mixed $classOrObject, mixed $method, callable|string $message = ''): mixed
     {
         static::isIterable($classOrObject);
 
@@ -4448,6 +4939,7 @@ trait Mixin
      * @psalm-pure
      *
      * @param iterable<string|object|null> $classOrObject
+     * @param string|callable():string     $message
      *
      * @psalm-param iterable<class-string|object|null> $classOrObject
      *
@@ -4455,7 +4947,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrMethodNotExists(mixed $classOrObject, mixed $method, string $message = ''): mixed
+    public static function allNullOrMethodNotExists(mixed $classOrObject, mixed $method, callable|string $message = ''): mixed
     {
         static::isIterable($classOrObject);
 
@@ -4469,13 +4961,14 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|int $key
+     * @param string|int               $key
+     * @param string|callable():string $message
      *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrKeyExists(mixed $array, string|int $key, string $message = ''): mixed
+    public static function nullOrKeyExists(mixed $array, string|int $key, callable|string $message = ''): mixed
     {
         null === $array || static::keyExists($array, $key, $message);
 
@@ -4485,13 +4978,14 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|int $key
+     * @param string|int               $key
+     * @param string|callable():string $message
      *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allKeyExists(mixed $array, string|int $key, string $message = ''): mixed
+    public static function allKeyExists(mixed $array, string|int $key, callable|string $message = ''): mixed
     {
         static::isIterable($array);
 
@@ -4505,13 +4999,14 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|int $key
+     * @param string|int               $key
+     * @param string|callable():string $message
      *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrKeyExists(mixed $array, string|int $key, string $message = ''): mixed
+    public static function allNullOrKeyExists(mixed $array, string|int $key, callable|string $message = ''): mixed
     {
         static::isIterable($array);
 
@@ -4525,13 +5020,14 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|int $key
+     * @param string|int               $key
+     * @param string|callable():string $message
      *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrKeyNotExists(mixed $array, string|int $key, string $message = ''): mixed
+    public static function nullOrKeyNotExists(mixed $array, string|int $key, callable|string $message = ''): mixed
     {
         null === $array || static::keyNotExists($array, $key, $message);
 
@@ -4541,13 +5037,14 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|int $key
+     * @param string|int               $key
+     * @param string|callable():string $message
      *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allKeyNotExists(mixed $array, string|int $key, string $message = ''): mixed
+    public static function allKeyNotExists(mixed $array, string|int $key, callable|string $message = ''): mixed
     {
         static::isIterable($array);
 
@@ -4561,13 +5058,14 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|int $key
+     * @param string|int               $key
+     * @param string|callable():string $message
      *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrKeyNotExists(mixed $array, string|int $key, string $message = ''): mixed
+    public static function allNullOrKeyNotExists(mixed $array, string|int $key, callable|string $message = ''): mixed
     {
         static::isIterable($array);
 
@@ -4583,11 +5081,13 @@ trait Mixin
      *
      * @psalm-assert array-key|null $value
      *
+     * @param string|callable():string $message
+     *
      * @return array-key|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrValidArrayKey(mixed $value, string $message = ''): mixed
+    public static function nullOrValidArrayKey(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::validArrayKey($value, $message);
 
@@ -4599,11 +5099,13 @@ trait Mixin
      *
      * @psalm-assert iterable<array-key> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<array-key>
      *
      * @throws InvalidArgumentException
      */
-    public static function allValidArrayKey(mixed $value, string $message = ''): iterable
+    public static function allValidArrayKey(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -4619,11 +5121,13 @@ trait Mixin
      *
      * @psalm-assert iterable<array-key|null> $value
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<array-key|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrValidArrayKey(mixed $value, string $message = ''): iterable
+    public static function allNullOrValidArrayKey(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -4635,11 +5139,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrCount(mixed $array, mixed $number, string $message = ''): mixed
+    public static function nullOrCount(mixed $array, mixed $number, callable|string $message = ''): mixed
     {
         null === $array || static::count($array, $number, $message);
 
@@ -4647,11 +5153,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allCount(mixed $array, mixed $number, string $message = ''): mixed
+    public static function allCount(mixed $array, mixed $number, callable|string $message = ''): mixed
     {
         static::isIterable($array);
 
@@ -4663,11 +5171,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrCount(mixed $array, mixed $number, string $message = ''): mixed
+    public static function allNullOrCount(mixed $array, mixed $number, callable|string $message = ''): mixed
     {
         static::isIterable($array);
 
@@ -4679,11 +5189,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrMinCount(mixed $array, mixed $min, string $message = ''): mixed
+    public static function nullOrMinCount(mixed $array, mixed $min, callable|string $message = ''): mixed
     {
         null === $array || static::minCount($array, $min, $message);
 
@@ -4691,11 +5203,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allMinCount(mixed $array, mixed $min, string $message = ''): mixed
+    public static function allMinCount(mixed $array, mixed $min, callable|string $message = ''): mixed
     {
         static::isIterable($array);
 
@@ -4707,11 +5221,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrMinCount(mixed $array, mixed $min, string $message = ''): mixed
+    public static function allNullOrMinCount(mixed $array, mixed $min, callable|string $message = ''): mixed
     {
         static::isIterable($array);
 
@@ -4723,11 +5239,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrMaxCount(mixed $array, mixed $max, string $message = ''): mixed
+    public static function nullOrMaxCount(mixed $array, mixed $max, callable|string $message = ''): mixed
     {
         null === $array || static::maxCount($array, $max, $message);
 
@@ -4735,11 +5253,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allMaxCount(mixed $array, mixed $max, string $message = ''): mixed
+    public static function allMaxCount(mixed $array, mixed $max, callable|string $message = ''): mixed
     {
         static::isIterable($array);
 
@@ -4751,11 +5271,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrMaxCount(mixed $array, mixed $max, string $message = ''): mixed
+    public static function allNullOrMaxCount(mixed $array, mixed $max, callable|string $message = ''): mixed
     {
         static::isIterable($array);
 
@@ -4767,11 +5289,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrCountBetween(mixed $array, mixed $min, mixed $max, string $message = ''): mixed
+    public static function nullOrCountBetween(mixed $array, mixed $min, mixed $max, callable|string $message = ''): mixed
     {
         null === $array || static::countBetween($array, $min, $max, $message);
 
@@ -4779,11 +5303,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allCountBetween(mixed $array, mixed $min, mixed $max, string $message = ''): mixed
+    public static function allCountBetween(mixed $array, mixed $min, mixed $max, callable|string $message = ''): mixed
     {
         static::isIterable($array);
 
@@ -4795,11 +5321,13 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrCountBetween(mixed $array, mixed $min, mixed $max, string $message = ''): mixed
+    public static function allNullOrCountBetween(mixed $array, mixed $min, mixed $max, callable|string $message = ''): mixed
     {
         static::isIterable($array);
 
@@ -4815,11 +5343,13 @@ trait Mixin
      *
      * @psalm-assert list<mixed>|null $array
      *
+     * @param string|callable():string $message
+     *
      * @return list<mixed>|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsList(mixed $array, string $message = ''): mixed
+    public static function nullOrIsList(mixed $array, callable|string $message = ''): mixed
     {
         null === $array || static::isList($array, $message);
 
@@ -4831,11 +5361,13 @@ trait Mixin
      *
      * @psalm-assert iterable<list<mixed>> $array
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<list<mixed>>
      *
      * @throws InvalidArgumentException
      */
-    public static function allIsList(mixed $array, string $message = ''): mixed
+    public static function allIsList(mixed $array, callable|string $message = ''): mixed
     {
         static::isIterable($array);
 
@@ -4851,11 +5383,13 @@ trait Mixin
      *
      * @psalm-assert iterable<list<mixed>|null> $array
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<list<mixed>|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrIsList(mixed $array, string $message = ''): mixed
+    public static function allNullOrIsList(mixed $array, callable|string $message = ''): mixed
     {
         static::isIterable($array);
 
@@ -4871,11 +5405,13 @@ trait Mixin
      *
      * @psalm-assert non-empty-list<mixed>|null $array
      *
+     * @param string|callable():string $message
+     *
      * @return non-empty-list<mixed>|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsNonEmptyList(mixed $array, string $message = ''): mixed
+    public static function nullOrIsNonEmptyList(mixed $array, callable|string $message = ''): mixed
     {
         null === $array || static::isNonEmptyList($array, $message);
 
@@ -4887,11 +5423,13 @@ trait Mixin
      *
      * @psalm-assert iterable<non-empty-list<mixed>> $array
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<non-empty-list<mixed>>
      *
      * @throws InvalidArgumentException
      */
-    public static function allIsNonEmptyList(mixed $array, string $message = ''): mixed
+    public static function allIsNonEmptyList(mixed $array, callable|string $message = ''): mixed
     {
         static::isIterable($array);
 
@@ -4907,11 +5445,13 @@ trait Mixin
      *
      * @psalm-assert iterable<non-empty-list<mixed>|null> $array
      *
+     * @param string|callable():string $message
+     *
      * @return iterable<non-empty-list<mixed>|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrIsNonEmptyList(mixed $array, string $message = ''): mixed
+    public static function allNullOrIsNonEmptyList(mixed $array, callable|string $message = ''): mixed
     {
         static::isIterable($array);
 
@@ -4929,12 +5469,13 @@ trait Mixin
      * @psalm-assert array<string, T>|null $array
      *
      * @param mixed|array<array-key, T>|null $array
+     * @param string|callable():string       $message
      *
      * @return array<string, T>|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsMap(mixed $array, string $message = ''): mixed
+    public static function nullOrIsMap(mixed $array, callable|string $message = ''): mixed
     {
         null === $array || static::isMap($array, $message);
 
@@ -4948,12 +5489,13 @@ trait Mixin
      * @psalm-assert iterable<array<string, T>> $array
      *
      * @param iterable<mixed|array<array-key, T>> $array
+     * @param string|callable():string            $message
      *
      * @return iterable<array<string, T>>
      *
      * @throws InvalidArgumentException
      */
-    public static function allIsMap(mixed $array, string $message = ''): mixed
+    public static function allIsMap(mixed $array, callable|string $message = ''): mixed
     {
         static::isIterable($array);
 
@@ -4971,12 +5513,13 @@ trait Mixin
      * @psalm-assert iterable<array<string, T>|null> $array
      *
      * @param iterable<mixed|array<array-key, T>|null> $array
+     * @param string|callable():string                 $message
      *
      * @return iterable<array<string, T>|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrIsMap(mixed $array, string $message = ''): mixed
+    public static function allNullOrIsMap(mixed $array, callable|string $message = ''): mixed
     {
         static::isIterable($array);
 
@@ -4990,13 +5533,14 @@ trait Mixin
     /**
      * @psalm-assert callable|null $callable
      *
-     * @param Closure|callable|null $callable
+     * @param Closure|callable|null    $callable
+     * @param string|callable():string $message
      *
      * @return callable|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsStatic(mixed $callable, string $message = ''): mixed
+    public static function nullOrIsStatic(mixed $callable, callable|string $message = ''): mixed
     {
         null === $callable || static::isStatic($callable, $message);
 
@@ -5007,12 +5551,13 @@ trait Mixin
      * @psalm-assert iterable<callable> $callable
      *
      * @param iterable<Closure|callable> $callable
+     * @param string|callable():string   $message
      *
      * @return iterable<callable>
      *
      * @throws InvalidArgumentException
      */
-    public static function allIsStatic(mixed $callable, string $message = ''): mixed
+    public static function allIsStatic(mixed $callable, callable|string $message = ''): mixed
     {
         static::isIterable($callable);
 
@@ -5027,12 +5572,13 @@ trait Mixin
      * @psalm-assert iterable<callable|null> $callable
      *
      * @param iterable<Closure|callable|null> $callable
+     * @param string|callable():string        $message
      *
      * @return iterable<callable|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrIsStatic(mixed $callable, string $message = ''): mixed
+    public static function allNullOrIsStatic(mixed $callable, callable|string $message = ''): mixed
     {
         static::isIterable($callable);
 
@@ -5046,13 +5592,14 @@ trait Mixin
     /**
      * @psalm-assert callable|null $callable
      *
-     * @param Closure|callable|null $callable
+     * @param Closure|callable|null    $callable
+     * @param string|callable():string $message
      *
      * @return callable|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNotStatic(mixed $callable, string $message = ''): mixed
+    public static function nullOrNotStatic(mixed $callable, callable|string $message = ''): mixed
     {
         null === $callable || static::notStatic($callable, $message);
 
@@ -5063,12 +5610,13 @@ trait Mixin
      * @psalm-assert iterable<callable> $callable
      *
      * @param iterable<Closure|callable> $callable
+     * @param string|callable():string   $message
      *
      * @return iterable<callable>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNotStatic(mixed $callable, string $message = ''): mixed
+    public static function allNotStatic(mixed $callable, callable|string $message = ''): mixed
     {
         static::isIterable($callable);
 
@@ -5083,12 +5631,13 @@ trait Mixin
      * @psalm-assert iterable<callable|null> $callable
      *
      * @param iterable<Closure|callable|null> $callable
+     * @param string|callable():string        $message
      *
      * @return iterable<callable|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrNotStatic(mixed $callable, string $message = ''): mixed
+    public static function allNullOrNotStatic(mixed $callable, callable|string $message = ''): mixed
     {
         static::isIterable($callable);
 
@@ -5104,13 +5653,14 @@ trait Mixin
      *
      * @template T
      *
-     * @param array<string, T>|null $array
+     * @param array<string, T>|null    $array
+     * @param string|callable():string $message
      *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsNonEmptyMap(mixed $array, string $message = ''): mixed
+    public static function nullOrIsNonEmptyMap(mixed $array, callable|string $message = ''): mixed
     {
         null === $array || static::isNonEmptyMap($array, $message);
 
@@ -5123,12 +5673,13 @@ trait Mixin
      * @template T
      *
      * @param iterable<array<string, T>> $array
+     * @param string|callable():string   $message
      *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allIsNonEmptyMap(mixed $array, string $message = ''): mixed
+    public static function allIsNonEmptyMap(mixed $array, callable|string $message = ''): mixed
     {
         static::isIterable($array);
 
@@ -5147,12 +5698,13 @@ trait Mixin
      * @psalm-assert iterable<!empty|null> $array
      *
      * @param iterable<array<string, T>|null> $array
+     * @param string|callable():string        $message
      *
      * @return iterable<!empty|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrIsNonEmptyMap(mixed $array, string $message = ''): mixed
+    public static function allNullOrIsNonEmptyMap(mixed $array, callable|string $message = ''): mixed
     {
         static::isIterable($array);
 
@@ -5166,11 +5718,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrUuid(mixed $value, string $message = ''): mixed
+    public static function nullOrUuid(mixed $value, callable|string $message = ''): mixed
     {
         null === $value || static::uuid($value, $message);
 
@@ -5180,11 +5734,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allUuid(mixed $value, string $message = ''): iterable
+    public static function allUuid(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -5198,11 +5754,13 @@ trait Mixin
     /**
      * @psalm-pure
      *
+     * @param string|callable():string $message
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrUuid(mixed $value, string $message = ''): iterable
+    public static function allNullOrUuid(mixed $value, callable|string $message = ''): iterable
     {
         static::isIterable($value);
 
@@ -5214,12 +5772,15 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @psalm-param class-string<Throwable> $class
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrThrows(mixed $expression, string $class = 'Throwable', string $message = ''): mixed
+    public static function nullOrThrows(mixed $expression, string $class = 'Throwable', callable|string $message = ''): mixed
     {
         null === $expression || static::throws($expression, $class, $message);
 
@@ -5227,12 +5788,15 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @psalm-param class-string<Throwable> $class
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allThrows(mixed $expression, string $class = 'Throwable', string $message = ''): mixed
+    public static function allThrows(mixed $expression, string $class = 'Throwable', callable|string $message = ''): mixed
     {
         static::isIterable($expression);
 
@@ -5244,12 +5808,15 @@ trait Mixin
     }
 
     /**
+     * @param string|callable():string $message
+     *
      * @psalm-param class-string<Throwable> $class
+     *
      * @return mixed
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrThrows(mixed $expression, string $class = 'Throwable', string $message = ''): mixed
+    public static function allNullOrThrows(mixed $expression, string $class = 'Throwable', callable|string $message = ''): mixed
     {
         static::isIterable($expression);
 

--- a/tests/AssertTest.php
+++ b/tests/AssertTest.php
@@ -22,7 +22,6 @@ use Exception;
 use LogicException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use ReflectionMethod;
 use RuntimeException;
 use SimpleXMLElement;
 use stdClass;
@@ -697,7 +696,7 @@ class AssertTest extends TestCase
             $this->markTestSkipped("The method $method could have specific message handling instead of custom message.");
         }
 
-        if (null === reset($args)) {
+        if ($args === []) {
             $this->addToAssertionCount(1);
 
             return;
@@ -712,26 +711,8 @@ class AssertTest extends TestCase
             $this->expectExceptionMessage('Custom error message');
         }
 
-        $ref = new ReflectionMethod('Webmozart\Assert\Assert', $method);
-        $params = $ref->getParameters();
-        $messageParamIndex = null;
-        foreach ($params as $i => $param) {
-            if ($param->getName() === 'message') {
-                $messageParamIndex = $i;
-                break;
-            }
-        }
-        if ($messageParamIndex !== null) {
-            while (count($args) < $messageParamIndex) {
-                $param = $params[count($args)];
-                if ($param->isDefaultValueAvailable()) {
-                    $args[] = $param->getDefaultValue();
-                }
-            }
-        }
-
-        $args[] = 'Custom error message';
-        $result = call_user_func_array(['Webmozart\Assert\Assert', $method], $args);
+        $args['message'] = 'Custom error message';
+        $result = Assert::$method(...$args);
 
         $this->assertSame($args[array_key_first($args)], $result);
     }
@@ -739,7 +720,7 @@ class AssertTest extends TestCase
     #[DataProvider('getTests')]
     public function testLazyMessageCallbackCalled(string $method, array $args, bool $success, bool $multibyte = false): void
     {
-        if (null === reset($args)) {
+        if ($args === []) {
             $this->addToAssertionCount(1);
 
             return;
@@ -755,31 +736,13 @@ class AssertTest extends TestCase
 
         $called = 0;
 
-        $ref = new ReflectionMethod('Webmozart\Assert\Assert', $method);
-        $params = $ref->getParameters();
-        $messageParamIndex = null;
-        foreach ($params as $i => $param) {
-            if ($param->getName() === 'message') {
-                $messageParamIndex = $i;
-                break;
-            }
-        }
-        if ($messageParamIndex !== null) {
-            while (count($args) < $messageParamIndex) {
-                $param = $params[count($args)];
-                if ($param->isDefaultValueAvailable()) {
-                    $args[] = $param->getDefaultValue();
-                }
-            }
-        }
-
-        $args[] = function () use (&$called) {
+        $args['message'] = function () use (&$called) {
             ++$called;
 
             return 'Custom error message number';
         };
 
-        call_user_func_array(['Webmozart\Assert\Assert', $method], $args);
+        Assert::$method(...$args);
 
         $expectedCalled = $success ? 0 : 1;
         $this->assertSame($expectedCalled, $called, sprintf('The lazy message callback should be called exactly %d times.', $expectedCalled));

--- a/tests/AssertTest.php
+++ b/tests/AssertTest.php
@@ -22,6 +22,7 @@ use Exception;
 use LogicException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 use RuntimeException;
 use SimpleXMLElement;
 use stdClass;
@@ -36,6 +37,13 @@ class AssertTest extends TestCase
 {
     private const SKIP_MIXIN_ASSERTION_TESTS = [
         'isInitialized',
+    ];
+
+    private const SKIP_CUSTOM_MESSAGE_TESTS = [
+        'isAOf',
+        'isAnyOf',
+        'isNotA',
+        'startsWithLetter',
     ];
 
     public static function getResource()
@@ -659,6 +667,101 @@ class AssertTest extends TestCase
 
         $result = call_user_func_array(['Webmozart\Assert\Assert', $method], $args);
         $this->assertSame($args[array_key_first($args)], $result);
+    }
+
+    #[DataProvider('getTests')]
+    public function testCustomMessage(string $method, array $args, bool $success, bool $multibyte = false): void
+    {
+        if (in_array($method, self::SKIP_CUSTOM_MESSAGE_TESTS)) {
+            $this->markTestSkipped("The method $method could have specific message handling instead of custom message.");
+        }
+
+        if (null === reset($args)) {
+            $this->addToAssertionCount(1);
+
+            return;
+        }
+
+        if ($multibyte && !function_exists('mb_strlen')) {
+            $this->markTestSkipped('The function mb_strlen() is not available');
+        }
+
+        if (!$success) {
+            $this->expectException('\InvalidArgumentException');
+            $this->expectExceptionMessage('Custom error message');
+        }
+
+        $ref = new ReflectionMethod('Webmozart\Assert\Assert', $method);
+        $params = $ref->getParameters();
+        $messageParamIndex = null;
+        foreach ($params as $i => $param) {
+            if ($param->getName() === 'message') {
+                $messageParamIndex = $i;
+                break;
+            }
+        }
+        if ($messageParamIndex !== null) {
+            while (count($args) < $messageParamIndex) {
+                $param = $params[count($args)];
+                if ($param->isDefaultValueAvailable()) {
+                    $args[] = $param->getDefaultValue();
+                }
+            }
+        }
+
+        $args[] = 'Custom error message';
+        $result = call_user_func_array(['Webmozart\Assert\Assert', $method], $args);
+
+        $this->assertSame($args[array_key_first($args)], $result);
+    }
+
+    #[DataProvider('getTests')]
+    public function testLazyMessageCallbackCalled(string $method, array $args, bool $success, bool $multibyte = false): void
+    {
+        if (null === reset($args)) {
+            $this->addToAssertionCount(1);
+
+            return;
+        }
+
+        if ($multibyte && !function_exists('mb_strlen')) {
+            $this->markTestSkipped('The function mb_strlen() is not available');
+        }
+
+        if (!$success) {
+            $this->expectException('\InvalidArgumentException');
+        }
+
+        $called = 0;
+
+        $ref = new ReflectionMethod('Webmozart\Assert\Assert', $method);
+        $params = $ref->getParameters();
+        $messageParamIndex = null;
+        foreach ($params as $i => $param) {
+            if ($param->getName() === 'message') {
+                $messageParamIndex = $i;
+                break;
+            }
+        }
+        if ($messageParamIndex !== null) {
+            while (count($args) < $messageParamIndex) {
+                $param = $params[count($args)];
+                if ($param->isDefaultValueAvailable()) {
+                    $args[] = $param->getDefaultValue();
+                }
+            }
+        }
+
+        $args[] = function () use (&$called) {
+            ++$called;
+
+            return 'Custom error message number';
+        };
+
+        call_user_func_array(['Webmozart\Assert\Assert', $method], $args);
+
+        $expectedCalled = $success ? 0 : 1;
+        $this->assertSame($expectedCalled, $called, sprintf('The lazy message callback should be called exactly %d times.', $expectedCalled));
     }
 
     #[DataProvider('getTests')]


### PR DESCRIPTION
Closes #265

## Summary
This PR adds support for lazy assertion messages by allowing `$message` to be either a string or a callable returning a string.

The callable is only executed when the assertion fails, avoiding unnecessary computation in the success case.

## Changes
- Allow `string|callable():string` for `$message` parameter
- Resolve callable messages only on failure
- Keep full backward compatibility with existing string messages
- Updated relevant assertions accordingly

## Example

```php
Assert::string($value, fn() => expensiveMessage());
```