### PR TITLE
Add tests for object comparison behavior and clarify uniqueValues() documentation

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -889,6 +889,7 @@ class Assert
 
     /**
      * Does non-strict comparisons on the items, so ['3', 3] will not pass the assertion.
+     * Note: objects with identical properties are also considered equal.
      *
      * @throws InvalidArgumentException
      */

--- a/tests/AssertTest.php
+++ b/tests/AssertTest.php
@@ -53,6 +53,10 @@ class AssertTest extends TestCase
         $normalList = ['foo' => 'b', 3];
         unset($normalList['foo']);
 
+        $a = new ToStringClass('testString');
+        $b = new ToStringClass('testString');
+        $c = new ToStringClass('otherString');
+
         return [
             ['string', ['value'], true],
             ['string', [''], true],
@@ -251,6 +255,9 @@ class AssertTest extends TestCase
             ['eq', [1, '1'], true],
             ['eq', [1, true], true],
             ['eq', [1, 0], false],
+            ['eq', [$a, $a], true],
+            ['eq', [$a, $b], true],
+            ['eq', [$a, $c], false],
             ['notEq', [1, 0], true],
             ['notEq', [1, 1], false],
             ['notEq', [1, '1'], false],
@@ -259,10 +266,14 @@ class AssertTest extends TestCase
             ['same', [1, '1'], false],
             ['same', [1, true], false],
             ['same', [1, 0], false],
+            ['same', [$a, $b], false],
+            ['same', [$a, $a], true],
             ['notSame', [1, 0], true],
             ['notSame', [1, 1], false],
             ['notSame', [1, '1'], true],
             ['notSame', [1, true], true],
+            ['notSame', [$a, $b], true],
+            ['notSame', [$a, $a], false],
             ['greaterThan', [1, 0], true],
             ['greaterThan', [0, 0], false],
             ['greaterThanEq', [2, 1], true],
@@ -283,8 +294,15 @@ class AssertTest extends TestCase
             ['notOneOf', [1, ['1', '2', '3']], true],
             ['inArray', [1, [1, 2, 3]], true],
             ['inArray', [1, ['1', '2', '3']], false],
+            ['inArray', [$a, [$a]], true],
+            ['inArray', [$a, [(string) $a]], false],
+            ['inArray', [$a, [$b]], false],
+            ['inArray', [$a, [$c]], false],
             ['notInArray', [1, [1, 2, 3]], false],
             ['notInArray', [1, ['1', '2', '3']], true],
+            ['notInArray', [$a, [$a]], false],
+            ['notInArray', [$a, [$b]], true],
+            ['notInArray', [$a, [$c]], true],
             ['contains', ['abcd', 'ab'], true],
             ['contains', ['abcd', 'bc'], true],
             ['contains', ['abcd', 'cd'], true],
@@ -628,6 +646,9 @@ class AssertTest extends TestCase
             ['uniqueValues', [['qwerty', 'qwerty']], false],
             ['uniqueValues', [['asdfg', 'qwerty']], true],
             ['uniqueValues', [[123, '123']], false],
+            ['uniqueValues', [[$a, $a]], false],
+            ['uniqueValues', [[$a, $b]], false],
+            ['uniqueValues', [[$a, $c]], true],
             ['isStatic', [static function () {}], true],
             ['isStatic', [function () {}], false],
             ['notStatic', [static function () {}], false],


### PR DESCRIPTION
This PR adds test coverage for object comparison behavior across several assertions and clarifies the documentation of `uniqueValues()`.

## Details

### 1. Additional test cases

Added tests to explicitly document how assertions behave when working with objects:

- `eq()` uses non-strict comparison (`==`)
- `same()` / `notSame()` use strict comparison (`===`)
- `inArray()` / `notInArray()` use strict comparison
- `uniqueValues()` uses non-strict comparison via `array_unique()`

These tests highlight edge cases where objects with identical properties are considered equal, even if they are different instances.

### 2. Documentation update

Updated the `uniqueValues()` docblock to clarify that non-strict comparison also applies to objects:

```php
Note: objects with identical properties are also considered equal.
```

## Motivation

While the behavior is technically correct and already partially documented, it can be surprising when working with objects. These changes aim to:

- make the behavior explicit
- improve test coverage
- prevent future regressions

## Example

```php
$a = new ToStringClass('testString');
$b = new ToStringClass('testString');

Assert::uniqueValues([$a, $b]); // fails (non-strict comparison)
```

## BC

No backward compatibility break. Only tests and documentation were added.
