### PR TITLE
Add @psalm-pure to count assertion methods

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -2178,6 +2178,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string|callable():string $message
      *
      * @throws InvalidArgumentException
@@ -2201,6 +2203,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string|callable():string $message
      *
      * @throws InvalidArgumentException
@@ -2223,6 +2227,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string|callable():string $message
      *
      * @throws InvalidArgumentException
@@ -2245,6 +2251,8 @@ class Assert
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string|callable():string $message
      *
      * @throws InvalidArgumentException

--- a/src/Mixin.php
+++ b/src/Mixin.php
@@ -5139,6 +5139,8 @@ trait Mixin
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string|callable():string $message
      *
      * @return mixed
@@ -5153,6 +5155,8 @@ trait Mixin
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string|callable():string $message
      *
      * @return mixed
@@ -5171,6 +5175,8 @@ trait Mixin
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string|callable():string $message
      *
      * @return mixed
@@ -5189,6 +5195,8 @@ trait Mixin
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string|callable():string $message
      *
      * @return mixed
@@ -5203,6 +5211,8 @@ trait Mixin
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string|callable():string $message
      *
      * @return mixed
@@ -5221,6 +5231,8 @@ trait Mixin
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string|callable():string $message
      *
      * @return mixed
@@ -5239,6 +5251,8 @@ trait Mixin
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string|callable():string $message
      *
      * @return mixed
@@ -5253,6 +5267,8 @@ trait Mixin
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string|callable():string $message
      *
      * @return mixed
@@ -5271,6 +5287,8 @@ trait Mixin
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string|callable():string $message
      *
      * @return mixed
@@ -5289,6 +5307,8 @@ trait Mixin
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string|callable():string $message
      *
      * @return mixed
@@ -5303,6 +5323,8 @@ trait Mixin
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string|callable():string $message
      *
      * @return mixed
@@ -5321,6 +5343,8 @@ trait Mixin
     }
 
     /**
+     * @psalm-pure
+     *
      * @param string|callable():string $message
      *
      * @return mixed


### PR DESCRIPTION
Added `@psalm-pure` to `count()`, `minCount()`, `maxCount()`, and `countBetween()`. Most other methods have it already but this was being handled as maybe impure by PHPStan on a project I'm working on so thought I'd add it.