### PR TITLE
Fixup some psalm return types

### DIFF
--- a/bin/generate.php
+++ b/bin/generate.php
@@ -8,9 +8,11 @@ declare(strict_types=1);
  */
 
 use Webmozart\Assert\Bin\MixinGenerator;
+use Webmozart\Assert\Bin\StaticAnalysisNonReturnGenerator;
 
 require_once __DIR__.'/../vendor/autoload.php';
 
 file_put_contents(__DIR__.'/../src/Mixin.php', (new MixinGenerator())->generate());
+(new StaticAnalysisNonReturnGenerator(__DIR__.'/../tests/static-analysis'))->generate();
 
 echo "Done.";

--- a/bin/src/MixinGenerator.php
+++ b/bin/src/MixinGenerator.php
@@ -237,7 +237,7 @@ BODY;
                     $parameterTypes[$parameterReflection->name] = 'mixed';
 
                     $nativeReturnType = match ($typeTemplate) {
-                        '%s|null' => $this->reduceParameterType($parameterReflection->getType()),
+                        '%s|null' => $this->nullableReturnType($method->getReturnType()),
                         'iterable<%s>' => 'iterable',
                         'iterable<%s|null>' => 'iterable',
                     };
@@ -366,6 +366,19 @@ BODY;
         }
 
         return ($type->allowsNull() ? '?' : '') . $type->getName();
+    }
+
+    private function nullableReturnType(?ReflectionType $type): string
+    {
+        if ($type === null) {
+            return 'mixed';
+        }
+        $typeStr = $this->reduceParameterType($type);
+        if ($typeStr === 'mixed') {
+            return 'mixed';
+        }
+
+        return $typeStr.'|null';
     }
 
     private function applyTypeTemplate(string $type, string $typeTemplate): string

--- a/bin/src/MixinGenerator.php
+++ b/bin/src/MixinGenerator.php
@@ -27,6 +27,8 @@ final class MixinGenerator
     private array $unsupportedMethods = [
         'nullOrNotInstanceOf',  // not supported by psalm (https://github.com/vimeo/psalm/issues/3443)
         'allNotInstanceOf',     // not supported by psalm (https://github.com/vimeo/psalm/issues/3443)
+        'allIsNotInstanceOfAny',
+        'allNullOrIsNotInstanceOfAny',
         'nullOrNotEmpty',       // not supported by psalm (https://github.com/vimeo/psalm/issues/3443)
         'allNotEmpty',          // not supported by psalm (https://github.com/vimeo/psalm/issues/3443)
         'allNotNull',           // not supported by psalm (https://github.com/vimeo/psalm/issues/3443)
@@ -351,7 +353,13 @@ BODY;
             return \implode('|', \array_map([$this, 'reduceParameterType'], $type->getTypes()));
         }
 
-        $type = Assert::isInstanceOf($type, ReflectionNamedType::class);
+        if (!$type instanceof ReflectionNamedType) {
+            throw new RuntimeException(sprintf(
+                'Expected a "%s" instance, got "%s".',
+                ReflectionNamedType::class,
+                get_debug_type($type)
+            ));
+        }
 
         if ($type->getName() === 'mixed') {
             return $type->getName();

--- a/bin/src/MixinGenerator.php
+++ b/bin/src/MixinGenerator.php
@@ -248,6 +248,12 @@ BODY;
             }
         }
 
+        // Ensure @template comes before @param, and @param values match function signature order
+        $parsedComment = $this->reorderAnnotations($parsedComment);
+        if (isset($parsedComment['param'])) {
+            $parsedComment['param'] = $this->reorderParamsBySignature($parsedComment['param'], $parameters);
+        }
+
         if (in_array($newMethodName, $this->skipMethods, true)) {
             return null;
         }
@@ -601,6 +607,70 @@ BODY;
         }
 
         return [trim($matches[1]), $matches[2], $matches[3] ?? null];
+    }
+
+    /**
+     * Ensures @template annotations appear before @param annotations.
+     *
+     * @param array<string, list<string>> $annotations
+     *
+     * @return array<string, list<string>>
+     */
+    private function reorderAnnotations(array $annotations): array
+    {
+        $keys = array_keys($annotations);
+        $templatePos = array_search('template', $keys, true);
+        $paramPos = array_search('param', $keys, true);
+
+        if ($templatePos === false || $paramPos === false || $templatePos < $paramPos) {
+            return $annotations;
+        }
+
+        $result = [];
+        foreach ($annotations as $key => $values) {
+            if ($key === 'param') {
+                $result['template'] = $annotations['template'];
+            }
+            if ($key !== 'template') {
+                $result[$key] = $values;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Reorders @param doc entries to match the function signature parameter order.
+     *
+     * @param list<string> $paramDocs
+     * @param list<string> $parameterNames
+     *
+     * @return list<string>
+     */
+    private function reorderParamsBySignature(array $paramDocs, array $parameterNames): array
+    {
+        $byVarName = [];
+        $withoutVarName = [];
+
+        foreach ($paramDocs as $doc) {
+            $parts = $this->splitDocLine($doc);
+            if (isset($parts[1])) {
+                $byVarName[$parts[1]] = $doc;
+            } else {
+                $withoutVarName[] = $doc;
+            }
+        }
+
+        $ordered = [];
+        foreach ($parameterNames as $name) {
+            $key = '$'.$name;
+            if (isset($byVarName[$key])) {
+                $ordered[] = $byVarName[$key];
+                unset($byVarName[$key]);
+            }
+        }
+
+        return array_merge($ordered, array_values($byVarName), $withoutVarName);
     }
 
     /**

--- a/bin/src/MixinGenerator.php
+++ b/bin/src/MixinGenerator.php
@@ -78,6 +78,7 @@ PHP
         $assert = new ReflectionClass(Assert::class);
 
         $namespace = sprintf("namespace %s;\n\n", $assert->getNamespaceName());
+        $namespace .= sprintf("use %s;\n", \Closure::class);
         $namespace .= sprintf("use %s;\n", ArrayAccess::class);
         $namespace .= sprintf("use %s;\n", Countable::class);
         $namespace .= sprintf("use %s;\n", Throwable::class);
@@ -233,7 +234,7 @@ BODY;
             }
 
             if ($parameterReflection->hasType()) {
-                if ($parameterReflection->name === 'value') {
+                if (count($parameters) === 1) {
                     $parameterTypes[$parameterReflection->name] = 'mixed';
 
                     $nativeReturnType = match ($typeTemplate) {

--- a/bin/src/MixinGenerator.php
+++ b/bin/src/MixinGenerator.php
@@ -277,14 +277,24 @@ BODY;
 
             foreach ($values as $i => $value) {
                 $parts = $this->splitDocLine($value);
-                if (('param' === $key || 'psalm-param' === $key) && isset($parts[1]) && isset($parameters[0]) && $parts[1] === '$'.$parameters[0] && 'mixed' !== $parts[0]) {
+                if ('param' === $key && isset($parts[1]) && isset($parameters[0]) && $parts[1] === '$'.$parameters[0] && 'mixed' !== $parts[0]) {
                     $parts[0] = $this->applyTypeTemplate($parts[0], $typeTemplate);
 
                     $values[$i] = \implode(' ', $parts);
+
+                    if ('mixed' === $phpdocReturnType) {
+                        $phpdocReturnType = $parts[0];
+                    }
                 }
             }
 
-            if ('psalm-return' === $key || 'return' === $key) {
+            if ('return' === $key) {
+                foreach ($values as $value) {
+                    $parts = $this->splitDocLine($value);
+                    if ('mixed' !== $parts[0]) {
+                        $phpdocReturnType = $this->applyTypeTemplate($parts[0], $typeTemplate);
+                    }
+                }
                 continue;
             }
 
@@ -322,6 +332,20 @@ BODY;
             if ('deprecated' === $key || 'psalm-pure' === $key || 'psalm-assert' === $key || 'see' === $key) {
                 $phpdocLines[] = '';
             }
+        }
+
+        if ('mixed' === $phpdocReturnType) {
+            $returnType = $method->getReturnType();
+            if ($returnType !== null) {
+                $returnTypeStr = $this->reduceParameterType($returnType);
+                if ('mixed' !== $returnTypeStr) {
+                    $phpdocReturnType = $this->applyTypeTemplate($returnTypeStr, $typeTemplate);
+                }
+            }
+        }
+
+        if ('mixed' === $phpdocReturnType && 'mixed' !== $nativeReturnType) {
+            $phpdocReturnType = $nativeReturnType;
         }
 
         $phpdocLines[] = '@return '.$phpdocReturnType;
@@ -398,7 +422,7 @@ BODY;
             return false;
         }
 
-        return 'psalm-assert' === $key || 'psalm-return' === $key;
+        return 'psalm-assert' === $key;
     }
 
     /**

--- a/bin/src/StaticAnalysisNonReturnGenerator.php
+++ b/bin/src/StaticAnalysisNonReturnGenerator.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Bin;
+
+use RuntimeException;
+
+final class StaticAnalysisNonReturnGenerator
+{
+    private const SOURCE_NAMESPACE = 'namespace Webmozart\\Assert\\Tests\\StaticAnalysis;';
+    private const TARGET_NAMESPACE = 'namespace Webmozart\\Assert\\Tests\\StaticAnalysis\\NonReturn;';
+
+    public function __construct(
+        private string $staticAnalysisDirectory
+    ) {
+    }
+
+    public function generate(): void
+    {
+        $targetDirectory = $this->targetDirectory();
+
+        if (!is_dir($targetDirectory) && !mkdir($targetDirectory, 0777, true) && !is_dir($targetDirectory)) {
+            throw new RuntimeException(sprintf('Could not create "%s".', $targetDirectory));
+        }
+
+        foreach ($this->generatedFiles() as $targetFile => $content) {
+            if (false === file_put_contents($targetFile, $content)) {
+                throw new RuntimeException(sprintf('Could not write "%s".', $targetFile));
+            }
+        }
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function generatedFiles(): array
+    {
+        $generatedFiles = [];
+
+        foreach ($this->sourceFiles() as $sourceFile) {
+            $content = file_get_contents($sourceFile);
+            if (false === $content) {
+                throw new RuntimeException(sprintf('Could not read "%s".', $sourceFile));
+            }
+
+            $generatedFiles[$this->targetDirectory().'/'.basename($sourceFile)] = $this->generateFileContent($content, $sourceFile);
+        }
+
+        return $generatedFiles;
+    }
+
+    public function generateFileContent(string $content, string $sourceFile): string
+    {
+        $content = str_replace(self::SOURCE_NAMESPACE, self::TARGET_NAMESPACE, $content);
+
+        $replacementCount = 0;
+        $generatedContent = preg_replace_callback(
+            '/^(\s*)return Assert::([A-Za-z0-9_]+)\((\$[A-Za-z_][A-Za-z0-9_]*)([^;\n]*)\);$/m',
+            static function (array $matches): string {
+                return sprintf(
+                    "%sAssert::%s(%s%s);\n\n%sreturn %s;",
+                    $matches[1],
+                    $matches[2],
+                    $matches[3],
+                    $matches[4],
+                    $matches[1],
+                    $matches[3]
+                );
+            },
+            $content,
+            -1,
+            $replacementCount
+        );
+
+        if (null === $generatedContent) {
+            throw new RuntimeException(sprintf('Could not generate non-return static analysis test from "%s".', $sourceFile));
+        }
+
+        $generatedContent = preg_replace("/;\n{3,}([ \t]+return )/", ";\n\n$1", $generatedContent);
+        if (null === $generatedContent) {
+            throw new RuntimeException(sprintf('Could not normalize non-return static analysis test from "%s".', $sourceFile));
+        }
+
+        $expectedReplacementCount = substr_count($content, 'return Assert::');
+        if ($replacementCount !== $expectedReplacementCount) {
+            throw new RuntimeException(sprintf(
+                'Expected to replace %d return assertions in "%s", replaced %d.',
+                $expectedReplacementCount,
+                $sourceFile,
+                (int) $replacementCount
+            ));
+        }
+
+        return $generatedContent;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function sourceFiles(): array
+    {
+        $files = glob($this->staticAnalysisDirectory.'/assert-*.php');
+        if (false === $files) {
+            throw new RuntimeException(sprintf('Could not scan "%s".', $this->staticAnalysisDirectory));
+        }
+
+        sort($files);
+
+        return $files;
+    }
+
+    private function targetDirectory(): string
+    {
+        return $this->staticAnalysisDirectory.'/non-return';
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,9 @@
         }
     },
     "extra": {
+        "psalm": {
+            "pluginClass": "Webmozart\\Assert\\PsalmPlugin"
+        },
         "branch-alias": {
             "dev-feature/2-0": "2.0-dev",
             "dev-master": "2.0-dev"

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-feature/2-0": "2.0-dev"
+            "dev-feature/2-0": "2.0-dev",
+            "dev-master": "2.0-dev"
         }
     },
     "scripts": {
@@ -63,5 +64,8 @@
         "cs-fix": "./tools/php-cs-fixer/vendor/bin/php-cs-fixer fix",
         "static-analysis": "./tools/psalm/vendor/bin/psalm --threads=4 --root=$(pwd)",
         "test": "./tools/phpunit/vendor/bin/phpunit"
+    },
+    "require-dev": {
+        "vimeo/psalm": "^6"
     }
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="8"
+    errorLevel="1"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
@@ -10,4 +10,8 @@
         <directory name="bin"/>
         <directory name="tests/static-analysis" />
     </projectFiles>
+
+    <plugins>
+        <plugin filename="src/PsalmPlugin.php" />
+    </plugins>
 </psalm>

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -908,7 +908,7 @@ class Assert
      * @psalm-pure
      *
      * @param string|callable():string $message
-     * @psalm-assert string $value
+     * @psalm-param string $value
      *
      * @throws InvalidArgumentException
      */
@@ -931,7 +931,7 @@ class Assert
      * @psalm-pure
      *
      * @param string|callable():string $message
-     * @psalm-assert string $value
+     * @psalm-param string $value
      *
      * @throws InvalidArgumentException
      */
@@ -954,7 +954,7 @@ class Assert
      * @psalm-pure
      *
      * @param string|callable():string $message
-     * @psalm-assert string $value
+     * @psalm-param string $value
      *
      * @throws InvalidArgumentException
      */
@@ -977,7 +977,7 @@ class Assert
      * @psalm-pure
      *
      * @param string|callable():string $message
-     * @psalm-assert string $value
+     * @psalm-param string $value
      *
      * @throws InvalidArgumentException
      */
@@ -2352,7 +2352,7 @@ class Assert
     }
 
     /**
-     * @psalm-assert callable $callable
+     * @psalm-param callable $callable
      *
      * @param string|callable():string $message
      *
@@ -2379,7 +2379,7 @@ class Assert
     }
 
     /**
-     * @psalm-assert callable $callable
+     * @psalm-param callable $callable
      *
      * @param string|callable():string $message
      *

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1000,6 +1000,8 @@ class Assert
      * Does non-strict comparisons on the items, so ['3', 3] will not pass the assertion.
      * Note: objects with identical properties are also considered equal.
      *
+     * @psalm-assert array $values
+     * 
      * @param string|callable():string $message
      *
      * @throws InvalidArgumentException

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -590,7 +590,7 @@ class Assert
      *
      * @psalm-assert T $value
      *
-     * @param T $value
+     * @param array<class-string<T>> $classes
      * @param string|callable():string $message
      *
      * @return T
@@ -620,7 +620,7 @@ class Assert
     /**
      * @template T
      *
-     * @psalm-assert T $value
+     * @psalm-assert object|class-string $value
      *
      * @param T $value
      * @param string|callable():string $message
@@ -713,11 +713,14 @@ class Assert
     /**
      * @psalm-pure
      *
-     * @param object|string $value
-     * @param string[]      $classes
+     * @psalm-assert T $value
+     * 
+     * @template T as object
+     * 
+     * @param array<class-string<T>> $classes
      * @param string|callable():string $message
-     * @psalm-param array<class-string> $classes
      *
+     * @return T
      * @throws InvalidArgumentException
      */
     public static function isAnyOf(mixed $value, mixed $classes, string|callable $message = ''): object|string
@@ -818,8 +821,8 @@ class Assert
      *
      * @template T
      * @param T|null $value
-     * @throws InvalidArgumentException
      * @return T
+     * @throws InvalidArgumentException
      */
     public static function notNull(mixed $value, string|callable $message = ''): mixed
     {
@@ -886,8 +889,8 @@ class Assert
      *
      * @template T
      * @param T|false $value
-     * @throws InvalidArgumentException
      * @return T
+     * @throws InvalidArgumentException
      */
     public static function notFalse(mixed $value, string|callable $message = ''): mixed
     {
@@ -905,7 +908,7 @@ class Assert
      * @psalm-pure
      *
      * @param string|callable():string $message
-     * @psalm-param string $value
+     * @psalm-assert string $value
      *
      * @throws InvalidArgumentException
      */
@@ -928,7 +931,7 @@ class Assert
      * @psalm-pure
      *
      * @param string|callable():string $message
-     * @psalm-param string $value
+     * @psalm-assert string $value
      *
      * @throws InvalidArgumentException
      */
@@ -951,7 +954,7 @@ class Assert
      * @psalm-pure
      *
      * @param string|callable():string $message
-     * @psalm-param string $value
+     * @psalm-assert string $value
      *
      * @throws InvalidArgumentException
      */
@@ -974,7 +977,7 @@ class Assert
      * @psalm-pure
      *
      * @param string|callable():string $message
-     * @psalm-param string $value
+     * @psalm-assert string $value
      *
      * @throws InvalidArgumentException
      */
@@ -2351,7 +2354,6 @@ class Assert
     /**
      * @psalm-assert callable $callable
      *
-     * @param Closure|callable $callable
      * @param string|callable():string $message
      *
      * @return Closure|callable-string
@@ -2379,7 +2381,6 @@ class Assert
     /**
      * @psalm-assert callable $callable
      *
-     * @param Closure|callable $callable
      * @param string|callable():string $message
      *
      * @return Closure|callable-string

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -567,8 +567,6 @@ class Assert
      * @param string|callable():string $message
      * @psalm-param class-string<T> $class
      *
-     * @return !T
-     *
      * @throws InvalidArgumentException
      */
     public static function notInstanceOf(mixed $value, mixed $class, string|callable $message = ''): object
@@ -659,8 +657,9 @@ class Assert
      * @psalm-assert T|class-string<T> $value
      *
      * @param string|callable():string $message
+     * @psalm-param class-string<T> $class
      *
-     * @return T
+     * @psalm-return T|class-string<T>
      *
      * @throws InvalidArgumentException
      */
@@ -690,7 +689,7 @@ class Assert
      * @param T $value
      * @param string|callable():string $message
      *
-     * @return T
+     * @psalm-return object|class-string
      *
      * @throws InvalidArgumentException
      */
@@ -773,8 +772,6 @@ class Assert
      *
      * @param string|callable():string $message
      *
-     * @psalm-return !empty
-     *
      * @throws InvalidArgumentException
      */
     public static function notEmpty(mixed $value, string|callable $message = ''): mixed
@@ -818,8 +815,6 @@ class Assert
      * @psalm-assert !null $value
      *
      * @param string|callable():string $message
-     *
-     * @psalm-return !null
      *
      * @throws InvalidArgumentException
      */
@@ -1647,6 +1642,8 @@ class Assert
      *
      * @param string|callable():string $message
      *
+     * @psalm-return lowercase-string
+     *
      * @throws InvalidArgumentException
      */
     public static function lower(mixed $value, string|callable $message = ''): string
@@ -1911,6 +1908,8 @@ class Assert
      *
      * @param string|callable():string $message
      *
+     * @psalm-return class-string
+     *
      * @throws InvalidArgumentException
      */
     public static function classExists(mixed $value, string|callable $message = ''): string
@@ -1964,6 +1963,8 @@ class Assert
      *
      * @param string|callable():string $message
      *
+     * @psalm-return class-string
+     *
      * @throws InvalidArgumentException
      */
     public static function interfaceExists(mixed $value, string|callable $message = ''): string
@@ -1988,9 +1989,10 @@ class Assert
      *
      * @psalm-assert class-string<ExpectedType>|ExpectedType $value
      *
-     * @param class-string<ExpectedType>|ExpectedType $value
      * @param class-string<ExpectedType> $interface
      * @param string|callable():string $message
+     *
+     * @psalm-return class-string<ExpectedType>|ExpectedType
      *
      * @throws InvalidArgumentException
      */
@@ -2407,7 +2409,7 @@ class Assert
      * @param array<string, T> $array
      * @param string|callable():string $message
      *
-     * @return array<string, T>
+     * @psalm-return non-empty-array<string, T>
      *
      * @throws InvalidArgumentException
      */

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -817,7 +817,7 @@ class Assert
      * @param string|callable():string $message
      *
      * @template T
-     * @param T|null $input
+     * @param T|null $value
      * @throws InvalidArgumentException
      * @return T
      */
@@ -885,7 +885,7 @@ class Assert
      * @param string|callable():string $message
      *
      * @template T
-     * @param T|false $input
+     * @param T|false $value
      * @throws InvalidArgumentException
      * @return T
      */

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1680,7 +1680,7 @@ class Assert
     /**
      * @psalm-pure
      *
-     * @psalm-assert !lowercase-string $value
+     * @psalm-assert string $value
      *
      * @param string|callable():string $message
      *

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -816,7 +816,10 @@ class Assert
      *
      * @param string|callable():string $message
      *
+     * @template T
+     * @param T|null $input
      * @throws InvalidArgumentException
+     * @return T
      */
     public static function notNull(mixed $value, string|callable $message = ''): mixed
     {
@@ -881,7 +884,10 @@ class Assert
      *
      * @param string|callable():string $message
      *
+     * @template T
+     * @param T|false $input
      * @throws InvalidArgumentException
+     * @return T
      */
     public static function notFalse(mixed $value, string|callable $message = ''): mixed
     {

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -62,7 +62,7 @@ class Assert
      * @psalm-assert non-empty-string $value
      * @param string|callable():string $message
      *
-     * @psalm-return non-empty-string
+     * @return non-empty-string
      *
      * @throws InvalidArgumentException
      */
@@ -124,7 +124,7 @@ class Assert
      *
      * @param string|callable():string $message
      *
-     * @psalm-return positive-int
+     * @return positive-int
      *
      * @throws InvalidArgumentException
      */
@@ -148,7 +148,7 @@ class Assert
      * @psalm-assert non-negative-int $value
      * @param string|callable():string $message
      *
-     * @psalm-return non-negative-int
+     * @return non-negative-int
      *
      * @throws InvalidArgumentException
      */
@@ -172,7 +172,7 @@ class Assert
      * @psalm-assert negative-int $value
      * @param string|callable():string $message
      *
-     * @psalm-return negative-int
+     * @return negative-int
      *
      * @throws InvalidArgumentException
      */
@@ -242,7 +242,7 @@ class Assert
      *
      * @param string|callable():string $message
      *
-     * @psalm-return positive-int|0
+     * @return positive-int|0
      *
      * @throws InvalidArgumentException
      */
@@ -332,7 +332,7 @@ class Assert
      *
      * @param string|callable():string $message
      *
-     * @psalm-return object|string
+     * @return object|string
      *
      * @throws InvalidArgumentException
      */
@@ -366,7 +366,7 @@ class Assert
      *
      * @see https://www.php.net/manual/en/function.get-resource-type.php
      *
-     * @psalm-return resource
+     * @return resource
      *
      * @throws InvalidArgumentException
      */
@@ -537,7 +537,7 @@ class Assert
      * @psalm-assert T $value
      *
      * @param string|callable():string $message
-     * @psalm-param class-string<T> $class
+     * @param class-string<T> $class
      *
      * @return T
      *
@@ -565,7 +565,7 @@ class Assert
      * @psalm-assert object $value
      *
      * @param string|callable():string $message
-     * @psalm-param class-string<T> $class
+     * @param class-string<T> $class
      *
      * @throws InvalidArgumentException
      */
@@ -657,9 +657,9 @@ class Assert
      * @psalm-assert T|class-string<T> $value
      *
      * @param string|callable():string $message
-     * @psalm-param class-string<T> $class
+     * @param class-string<T> $class
      *
-     * @psalm-return T|class-string<T>
+     * @return T|class-string<T>
      *
      * @throws InvalidArgumentException
      */
@@ -689,7 +689,7 @@ class Assert
      * @param T $value
      * @param string|callable():string $message
      *
-     * @psalm-return object|class-string
+     * @return object|class-string
      *
      * @throws InvalidArgumentException
      */
@@ -751,7 +751,7 @@ class Assert
      *
      * @param string|callable():string $message
      *
-     * @psalm-return empty
+     * @return empty
      *
      * @throws InvalidArgumentException
      */
@@ -908,7 +908,7 @@ class Assert
      * @psalm-pure
      *
      * @param string|callable():string $message
-     * @psalm-param string $value
+     * @param string $value
      *
      * @throws InvalidArgumentException
      */
@@ -931,7 +931,7 @@ class Assert
      * @psalm-pure
      *
      * @param string|callable():string $message
-     * @psalm-param string $value
+     * @param string $value
      *
      * @throws InvalidArgumentException
      */
@@ -954,7 +954,7 @@ class Assert
      * @psalm-pure
      *
      * @param string|callable():string $message
-     * @psalm-param string $value
+     * @param string $value
      *
      * @throws InvalidArgumentException
      */
@@ -977,7 +977,7 @@ class Assert
      * @psalm-pure
      *
      * @param string|callable():string $message
-     * @psalm-param string $value
+     * @param string $value
      *
      * @throws InvalidArgumentException
      */
@@ -1651,7 +1651,7 @@ class Assert
      *
      * @param string|callable():string $message
      *
-     * @psalm-return lowercase-string
+     * @return lowercase-string
      *
      * @throws InvalidArgumentException
      */
@@ -1917,7 +1917,7 @@ class Assert
      *
      * @param string|callable():string $message
      *
-     * @psalm-return class-string
+     * @return class-string
      *
      * @throws InvalidArgumentException
      */
@@ -1972,7 +1972,7 @@ class Assert
      *
      * @param string|callable():string $message
      *
-     * @psalm-return class-string
+     * @return class-string
      *
      * @throws InvalidArgumentException
      */
@@ -2001,7 +2001,7 @@ class Assert
      * @param class-string<ExpectedType> $interface
      * @param string|callable():string $message
      *
-     * @psalm-return class-string<ExpectedType>|ExpectedType
+     * @return class-string<ExpectedType>|ExpectedType
      *
      * @throws InvalidArgumentException
      */
@@ -2051,9 +2051,8 @@ class Assert
     /**
      * @psalm-pure
      *
-     * @param string|object $classOrObject
+     * @param class-string|object $classOrObject
      * @param string|callable():string $message
-     * @psalm-param class-string|object $classOrObject
      *
      * @throws InvalidArgumentException
      */
@@ -2073,9 +2072,8 @@ class Assert
     /**
      * @psalm-pure
      *
-     * @param string|object $classOrObject
+     * @param class-string|object $classOrObject
      * @param string|callable():string $message
-     * @psalm-param class-string|object $classOrObject
      *
      * @throws InvalidArgumentException
      */
@@ -2097,9 +2095,8 @@ class Assert
     /**
      * @psalm-pure
      *
-     * @param string|object $classOrObject
+     * @param class-string|object $classOrObject
      * @param string|callable():string $message
-     * @psalm-param class-string|object $classOrObject
      *
      * @throws InvalidArgumentException
      */
@@ -2288,7 +2285,7 @@ class Assert
      *
      * @param string|callable():string $message
      *
-     * @psalm-return list<mixed>
+     * @return list<mixed>
      *
      * @throws InvalidArgumentException
      */
@@ -2311,7 +2308,7 @@ class Assert
      *
      * @param string|callable():string $message
      *
-     * @psalm-return non-empty-list<mixed>
+     * @return non-empty-list<mixed>
      *
      * @throws InvalidArgumentException
      */
@@ -2352,7 +2349,7 @@ class Assert
     }
 
     /**
-     * @psalm-param callable $callable
+     * @param callable $callable
      *
      * @param string|callable():string $message
      *
@@ -2379,7 +2376,7 @@ class Assert
     }
 
     /**
-     * @psalm-param callable $callable
+     * @param callable $callable
      *
      * @param string|callable():string $message
      *
@@ -2416,7 +2413,7 @@ class Assert
      * @param array<string, T> $array
      * @param string|callable():string $message
      *
-     * @psalm-return non-empty-array<string, T>
+     * @return non-empty-array<string, T>
      *
      * @throws InvalidArgumentException
      */
@@ -2461,7 +2458,7 @@ class Assert
 
     /**
      * @param string|callable():string $message
-     * @psalm-param class-string<Throwable> $class
+     * @param class-string<Throwable> $class
      *
      * @throws InvalidArgumentException
      */

--- a/src/Mixin.php
+++ b/src/Mixin.php
@@ -25,7 +25,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrString(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrString(mixed $value, callable|string $message = ''): string|null
     {
         null === $value || static::string($value, $message);
 
@@ -87,7 +87,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrStringNotEmpty(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrStringNotEmpty(mixed $value, callable|string $message = ''): string|null
     {
         null === $value || static::stringNotEmpty($value, $message);
 
@@ -149,7 +149,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrInteger(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrInteger(mixed $value, callable|string $message = ''): int|null
     {
         null === $value || static::integer($value, $message);
 
@@ -211,7 +211,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIntegerish(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrIntegerish(mixed $value, callable|string $message = ''): string|int|float|null
     {
         null === $value || static::integerish($value, $message);
 
@@ -273,7 +273,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrPositiveInteger(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrPositiveInteger(mixed $value, callable|string $message = ''): int|null
     {
         null === $value || static::positiveInteger($value, $message);
 
@@ -335,7 +335,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNotNegativeInteger(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrNotNegativeInteger(mixed $value, callable|string $message = ''): int|null
     {
         null === $value || static::notNegativeInteger($value, $message);
 
@@ -397,7 +397,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNegativeInteger(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrNegativeInteger(mixed $value, callable|string $message = ''): int|null
     {
         null === $value || static::negativeInteger($value, $message);
 
@@ -459,7 +459,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrFloat(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrFloat(mixed $value, callable|string $message = ''): float|null
     {
         null === $value || static::float($value, $message);
 
@@ -521,7 +521,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNumeric(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrNumeric(mixed $value, callable|string $message = ''): string|int|float|null
     {
         null === $value || static::numeric($value, $message);
 
@@ -583,7 +583,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNatural(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrNatural(mixed $value, callable|string $message = ''): int|null
     {
         null === $value || static::natural($value, $message);
 
@@ -645,7 +645,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrBoolean(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrBoolean(mixed $value, callable|string $message = ''): bool|null
     {
         null === $value || static::boolean($value, $message);
 
@@ -707,7 +707,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrScalar(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrScalar(mixed $value, callable|string $message = ''): string|int|float|bool|null
     {
         null === $value || static::scalar($value, $message);
 
@@ -769,7 +769,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrObject(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrObject(mixed $value, callable|string $message = ''): object|null
     {
         null === $value || static::object($value, $message);
 
@@ -831,7 +831,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrObjectish(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrObjectish(mixed $value, callable|string $message = ''): object|string|null
     {
         null === $value || static::objectish($value, $message);
 
@@ -961,7 +961,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsCallable(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrIsCallable(mixed $value, callable|string $message = ''): callable|null
     {
         null === $value || static::isCallable($value, $message);
 
@@ -1023,7 +1023,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsArray(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrIsArray(mixed $value, callable|string $message = ''): array|null
     {
         null === $value || static::isArray($value, $message);
 
@@ -1085,7 +1085,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsArrayAccessible(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrIsArrayAccessible(mixed $value, callable|string $message = ''): ArrayAccess|array|null
     {
         null === $value || static::isArrayAccessible($value, $message);
 
@@ -1147,7 +1147,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsCountable(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrIsCountable(mixed $value, callable|string $message = ''): Countable|array|null
     {
         null === $value || static::isCountable($value, $message);
 
@@ -1209,7 +1209,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsIterable(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrIsIterable(mixed $value, callable|string $message = ''): iterable|null
     {
         null === $value || static::isIterable($value, $message);
 
@@ -1274,7 +1274,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsInstanceOf(mixed $value, mixed $class, callable|string $message = ''): mixed
+    public static function nullOrIsInstanceOf(mixed $value, mixed $class, callable|string $message = ''): object|null
     {
         null === $value || static::isInstanceOf($value, $class, $message);
 
@@ -1342,7 +1342,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNotInstanceOf(mixed $value, mixed $class, callable|string $message = ''): mixed
+    public static function nullOrNotInstanceOf(mixed $value, mixed $class, callable|string $message = ''): object|null
     {
         null === $value || static::notInstanceOf($value, $class, $message);
 
@@ -1405,7 +1405,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsInstanceOfAny(mixed $value, mixed $classes, callable|string $message = ''): mixed
+    public static function nullOrIsInstanceOfAny(mixed $value, mixed $classes, callable|string $message = ''): object|null
     {
         null === $value || static::isInstanceOfAny($value, $classes, $message);
 
@@ -1530,7 +1530,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsAOf(mixed $value, mixed $class, callable|string $message = ''): mixed
+    public static function nullOrIsAOf(mixed $value, mixed $class, callable|string $message = ''): object|string|null
     {
         null === $value || static::isAOf($value, $class, $message);
 
@@ -1599,7 +1599,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsNotA(mixed $value, mixed $class, callable|string $message = ''): mixed
+    public static function nullOrIsNotA(mixed $value, mixed $class, callable|string $message = ''): object|string|null
     {
         null === $value || static::isNotA($value, $class, $message);
 
@@ -1667,7 +1667,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsAnyOf(mixed $value, mixed $classes, callable|string $message = ''): mixed
+    public static function nullOrIsAnyOf(mixed $value, mixed $classes, callable|string $message = ''): object|string|null
     {
         null === $value || static::isAnyOf($value, $classes, $message);
 
@@ -1900,7 +1900,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrTrue(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrTrue(mixed $value, callable|string $message = ''): true|null
     {
         null === $value || static::true($value, $message);
 
@@ -1962,7 +1962,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrFalse(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrFalse(mixed $value, callable|string $message = ''): false|null
     {
         null === $value || static::false($value, $message);
 
@@ -2091,7 +2091,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIp(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrIp(mixed $value, callable|string $message = ''): string|null
     {
         null === $value || static::ip($value, $message);
 
@@ -2153,7 +2153,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIpv4(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrIpv4(mixed $value, callable|string $message = ''): string|null
     {
         null === $value || static::ipv4($value, $message);
 
@@ -2215,7 +2215,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIpv6(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrIpv6(mixed $value, callable|string $message = ''): string|null
     {
         null === $value || static::ipv6($value, $message);
 
@@ -2277,7 +2277,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrEmail(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrEmail(mixed $value, callable|string $message = ''): string|null
     {
         null === $value || static::email($value, $message);
 
@@ -3103,7 +3103,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrContains(mixed $value, mixed $subString, callable|string $message = ''): mixed
+    public static function nullOrContains(mixed $value, mixed $subString, callable|string $message = ''): string|null
     {
         null === $value || static::contains($value, $subString, $message);
 
@@ -3159,7 +3159,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNotContains(mixed $value, mixed $subString, callable|string $message = ''): mixed
+    public static function nullOrNotContains(mixed $value, mixed $subString, callable|string $message = ''): string|null
     {
         null === $value || static::notContains($value, $subString, $message);
 
@@ -3215,7 +3215,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNotWhitespaceOnly(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrNotWhitespaceOnly(mixed $value, callable|string $message = ''): string|null
     {
         null === $value || static::notWhitespaceOnly($value, $message);
 
@@ -3271,7 +3271,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrStartsWith(mixed $value, mixed $prefix, callable|string $message = ''): mixed
+    public static function nullOrStartsWith(mixed $value, mixed $prefix, callable|string $message = ''): string|null
     {
         null === $value || static::startsWith($value, $prefix, $message);
 
@@ -3327,7 +3327,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNotStartsWith(mixed $value, mixed $prefix, callable|string $message = ''): mixed
+    public static function nullOrNotStartsWith(mixed $value, mixed $prefix, callable|string $message = ''): string|null
     {
         null === $value || static::notStartsWith($value, $prefix, $message);
 
@@ -3383,7 +3383,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrStartsWithLetter(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrStartsWithLetter(mixed $value, callable|string $message = ''): string|null
     {
         null === $value || static::startsWithLetter($value, $message);
 
@@ -3439,7 +3439,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrEndsWith(mixed $value, mixed $suffix, callable|string $message = ''): mixed
+    public static function nullOrEndsWith(mixed $value, mixed $suffix, callable|string $message = ''): string|null
     {
         null === $value || static::endsWith($value, $suffix, $message);
 
@@ -3495,7 +3495,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNotEndsWith(mixed $value, mixed $suffix, callable|string $message = ''): mixed
+    public static function nullOrNotEndsWith(mixed $value, mixed $suffix, callable|string $message = ''): string|null
     {
         null === $value || static::notEndsWith($value, $suffix, $message);
 
@@ -3551,7 +3551,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrRegex(mixed $value, mixed $pattern, callable|string $message = ''): mixed
+    public static function nullOrRegex(mixed $value, mixed $pattern, callable|string $message = ''): string|null
     {
         null === $value || static::regex($value, $pattern, $message);
 
@@ -3607,7 +3607,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNotRegex(mixed $value, mixed $pattern, callable|string $message = ''): mixed
+    public static function nullOrNotRegex(mixed $value, mixed $pattern, callable|string $message = ''): string|null
     {
         null === $value || static::notRegex($value, $pattern, $message);
 
@@ -3663,7 +3663,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrUnicodeLetters(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrUnicodeLetters(mixed $value, callable|string $message = ''): string|null
     {
         null === $value || static::unicodeLetters($value, $message);
 
@@ -3719,7 +3719,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrAlpha(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrAlpha(mixed $value, callable|string $message = ''): string|null
     {
         null === $value || static::alpha($value, $message);
 
@@ -3775,7 +3775,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrDigits(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrDigits(mixed $value, callable|string $message = ''): string|null
     {
         null === $value || static::digits($value, $message);
 
@@ -3831,7 +3831,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrAlnum(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrAlnum(mixed $value, callable|string $message = ''): string|null
     {
         null === $value || static::alnum($value, $message);
 
@@ -3889,7 +3889,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrLower(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrLower(mixed $value, callable|string $message = ''): string|null
     {
         null === $value || static::lower($value, $message);
 
@@ -3949,7 +3949,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrUpper(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrUpper(mixed $value, callable|string $message = ''): string|null
     {
         null === $value || static::upper($value, $message);
 
@@ -4007,7 +4007,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrLength(mixed $value, mixed $length, callable|string $message = ''): mixed
+    public static function nullOrLength(mixed $value, mixed $length, callable|string $message = ''): string|null
     {
         null === $value || static::length($value, $length, $message);
 
@@ -4063,7 +4063,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrMinLength(mixed $value, mixed $min, callable|string $message = ''): mixed
+    public static function nullOrMinLength(mixed $value, mixed $min, callable|string $message = ''): string|null
     {
         null === $value || static::minLength($value, $min, $message);
 
@@ -4119,7 +4119,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrMaxLength(mixed $value, mixed $max, callable|string $message = ''): mixed
+    public static function nullOrMaxLength(mixed $value, mixed $max, callable|string $message = ''): string|null
     {
         null === $value || static::maxLength($value, $max, $message);
 
@@ -4175,7 +4175,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrLengthBetween(mixed $value, mixed $min, mixed $max, callable|string $message = ''): mixed
+    public static function nullOrLengthBetween(mixed $value, mixed $min, mixed $max, callable|string $message = ''): string|null
     {
         null === $value || static::lengthBetween($value, $min, $max, $message);
 
@@ -4229,7 +4229,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrFileExists(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrFileExists(mixed $value, callable|string $message = ''): string|null
     {
         null === $value || static::fileExists($value, $message);
 
@@ -4279,7 +4279,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrFile(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrFile(mixed $value, callable|string $message = ''): string|null
     {
         null === $value || static::file($value, $message);
 
@@ -4329,7 +4329,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrDirectory(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrDirectory(mixed $value, callable|string $message = ''): string|null
     {
         null === $value || static::directory($value, $message);
 
@@ -4379,7 +4379,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrReadable(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrReadable(mixed $value, callable|string $message = ''): string|null
     {
         null === $value || static::readable($value, $message);
 
@@ -4429,7 +4429,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrWritable(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrWritable(mixed $value, callable|string $message = ''): string|null
     {
         null === $value || static::writable($value, $message);
 
@@ -4481,7 +4481,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrClassExists(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrClassExists(mixed $value, callable|string $message = ''): string|null
     {
         null === $value || static::classExists($value, $message);
 
@@ -4541,7 +4541,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrSubclassOf(mixed $value, mixed $class, callable|string $message = ''): mixed
+    public static function nullOrSubclassOf(mixed $value, mixed $class, callable|string $message = ''): string|null
     {
         null === $value || static::subclassOf($value, $class, $message);
 
@@ -4605,7 +4605,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrInterfaceExists(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrInterfaceExists(mixed $value, callable|string $message = ''): string|null
     {
         null === $value || static::interfaceExists($value, $message);
 
@@ -4665,7 +4665,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrImplementsInterface(mixed $value, mixed $interface, callable|string $message = ''): mixed
+    public static function nullOrImplementsInterface(mixed $value, mixed $interface, callable|string $message = ''): object|string|null
     {
         null === $value || static::implementsInterface($value, $interface, $message);
 
@@ -5103,7 +5103,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrValidArrayKey(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrValidArrayKey(mixed $value, callable|string $message = ''): string|int|null
     {
         null === $value || static::validArrayKey($value, $message);
 
@@ -5734,7 +5734,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrUuid(mixed $value, callable|string $message = ''): mixed
+    public static function nullOrUuid(mixed $value, callable|string $message = ''): string|null
     {
         null === $value || static::uuid($value, $message);
 

--- a/src/Mixin.php
+++ b/src/Mixin.php
@@ -1267,8 +1267,8 @@ trait Mixin
      * @template T of object
      * @psalm-assert T|null $value
      *
-     * @param string|callable():string $message
      * @param class-string<T>          $class
+     * @param string|callable():string $message
      *
      * @return T|null
      *
@@ -1287,8 +1287,8 @@ trait Mixin
      * @template T of object
      * @psalm-assert iterable<T> $value
      *
-     * @param string|callable():string $message
      * @param class-string<T>          $class
+     * @param string|callable():string $message
      *
      * @return iterable<T>
      *
@@ -1311,8 +1311,8 @@ trait Mixin
      * @template T of object
      * @psalm-assert iterable<T|null> $value
      *
-     * @param string|callable():string $message
      * @param class-string<T>          $class
+     * @param string|callable():string $message
      *
      * @return iterable<T|null>
      *
@@ -1332,8 +1332,8 @@ trait Mixin
     /**
      * @template T of object
      *
-     * @param string|callable():string $message
      * @param class-string<T>          $class
+     * @param string|callable():string $message
      *
      * @return object|null
      *
@@ -1349,8 +1349,8 @@ trait Mixin
     /**
      * @template T of object
      *
-     * @param string|callable():string $message
      * @param class-string<T>          $class
+     * @param string|callable():string $message
      *
      * @return iterable<object>
      *
@@ -1371,8 +1371,8 @@ trait Mixin
      * @template T of object
      * @psalm-assert iterable<object|null> $value
      *
-     * @param string|callable():string $message
      * @param class-string<T>          $class
+     * @param string|callable():string $message
      *
      * @return iterable<object|null>
      *
@@ -1517,8 +1517,8 @@ trait Mixin
      * @template T of object
      * @psalm-assert T|class-string<T>|null $value
      *
-     * @param string|callable():string $message
      * @param class-string<T>          $class
+     * @param string|callable():string $message
      *
      * @return T|class-string<T>|null
      *
@@ -1537,8 +1537,8 @@ trait Mixin
      * @template T of object
      * @psalm-assert iterable<T|class-string<T>> $value
      *
-     * @param string|callable():string $message
      * @param class-string<T>          $class
+     * @param string|callable():string $message
      *
      * @return iterable<T|class-string<T>>
      *
@@ -1561,8 +1561,8 @@ trait Mixin
      * @template T of object
      * @psalm-assert iterable<T|class-string<T>|null> $value
      *
-     * @param string|callable():string $message
      * @param class-string<T>          $class
+     * @param string|callable():string $message
      *
      * @return iterable<T|class-string<T>|null>
      *
@@ -1861,10 +1861,10 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|callable():string $message
-     * @param iterable<T|null>         $value
-     *
      * @template T
+     *
+     * @param iterable<T|null>         $value
+     * @param string|callable():string $message
      *
      * @return iterable<T>
      *
@@ -2008,10 +2008,10 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|callable():string $message
-     * @param T|false|null             $value
-     *
      * @template T
+     *
+     * @param T|false|null             $value
+     * @param string|callable():string $message
      *
      * @return T|null
      *
@@ -2027,10 +2027,10 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|callable():string $message
-     * @param iterable<T|false>        $value
-     *
      * @template T
+     *
+     * @param iterable<T|false>        $value
+     * @param string|callable():string $message
      *
      * @return iterable<T>
      *
@@ -2052,10 +2052,10 @@ trait Mixin
      *
      * @psalm-assert iterable<!false|null> $value
      *
-     * @param string|callable():string $message
-     * @param iterable<T|false|null>   $value
-     *
      * @template T
+     *
+     * @param iterable<T|false|null>   $value
+     * @param string|callable():string $message
      *
      * @return iterable<T|null>
      *
@@ -2075,8 +2075,8 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|callable():string $message
      * @param string|null              $value
+     * @param string|callable():string $message
      *
      * @return string|null
      *
@@ -2092,8 +2092,8 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|callable():string $message
      * @param iterable<string>         $value
+     * @param string|callable():string $message
      *
      * @return iterable<string>
      *
@@ -2113,8 +2113,8 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|callable():string $message
      * @param iterable<string|null>    $value
+     * @param string|callable():string $message
      *
      * @return iterable<string|null>
      *
@@ -2134,8 +2134,8 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|callable():string $message
      * @param string|null              $value
+     * @param string|callable():string $message
      *
      * @return string|null
      *
@@ -2151,8 +2151,8 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|callable():string $message
      * @param iterable<string>         $value
+     * @param string|callable():string $message
      *
      * @return iterable<string>
      *
@@ -2172,8 +2172,8 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|callable():string $message
      * @param iterable<string|null>    $value
+     * @param string|callable():string $message
      *
      * @return iterable<string|null>
      *
@@ -2193,8 +2193,8 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|callable():string $message
      * @param string|null              $value
+     * @param string|callable():string $message
      *
      * @return string|null
      *
@@ -2210,8 +2210,8 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|callable():string $message
      * @param iterable<string>         $value
+     * @param string|callable():string $message
      *
      * @return iterable<string>
      *
@@ -2231,8 +2231,8 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|callable():string $message
      * @param iterable<string|null>    $value
+     * @param string|callable():string $message
      *
      * @return iterable<string|null>
      *
@@ -2252,8 +2252,8 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|callable():string $message
      * @param string|null              $value
+     * @param string|callable():string $message
      *
      * @return string|null
      *
@@ -2269,8 +2269,8 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|callable():string $message
      * @param iterable<string>         $value
+     * @param string|callable():string $message
      *
      * @return iterable<string>
      *
@@ -2290,8 +2290,8 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|callable():string $message
      * @param iterable<string|null>    $value
+     * @param string|callable():string $message
      *
      * @return iterable<string|null>
      *
@@ -3965,11 +3965,11 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @psalm-assert iterable<!lowercase-string|null> $value
+     * @psalm-assert iterable<string|null> $value
      *
      * @param string|callable():string $message
      *
-     * @return iterable<!lowercase-string|null>
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -5744,8 +5744,8 @@ trait Mixin
     }
 
     /**
-     * @param string|callable():string $message
      * @param class-string<Throwable>  $class
+     * @param string|callable():string $message
      *
      * @return callable|null
      *
@@ -5759,8 +5759,8 @@ trait Mixin
     }
 
     /**
-     * @param string|callable():string $message
      * @param class-string<Throwable>  $class
+     * @param string|callable():string $message
      *
      * @return iterable<callable>
      *
@@ -5778,8 +5778,8 @@ trait Mixin
     }
 
     /**
-     * @param string|callable():string $message
      * @param class-string<Throwable>  $class
+     * @param string|callable():string $message
      *
      * @return iterable<callable|null>
      *

--- a/src/Mixin.php
+++ b/src/Mixin.php
@@ -2085,9 +2085,9 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @psalm-assert string|null $value
+     * @psalm-param string|null $value
      *
-     * @return string|null
+     * @return mixed
      *
      * @throws InvalidArgumentException
      */
@@ -2103,9 +2103,9 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @psalm-assert iterable<string> $value
+     * @psalm-param iterable<string> $value
      *
-     * @return iterable<string>
+     * @return mixed
      *
      * @throws InvalidArgumentException
      */
@@ -2125,9 +2125,9 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @psalm-assert iterable<string|null> $value
+     * @psalm-param iterable<string|null> $value
      *
-     * @return iterable<string|null>
+     * @return mixed
      *
      * @throws InvalidArgumentException
      */
@@ -2147,9 +2147,9 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @psalm-assert string|null $value
+     * @psalm-param string|null $value
      *
-     * @return string|null
+     * @return mixed
      *
      * @throws InvalidArgumentException
      */
@@ -2165,9 +2165,9 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @psalm-assert iterable<string> $value
+     * @psalm-param iterable<string> $value
      *
-     * @return iterable<string>
+     * @return mixed
      *
      * @throws InvalidArgumentException
      */
@@ -2187,9 +2187,9 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @psalm-assert iterable<string|null> $value
+     * @psalm-param iterable<string|null> $value
      *
-     * @return iterable<string|null>
+     * @return mixed
      *
      * @throws InvalidArgumentException
      */
@@ -2209,9 +2209,9 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @psalm-assert string|null $value
+     * @psalm-param string|null $value
      *
-     * @return string|null
+     * @return mixed
      *
      * @throws InvalidArgumentException
      */
@@ -2227,9 +2227,9 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @psalm-assert iterable<string> $value
+     * @psalm-param iterable<string> $value
      *
-     * @return iterable<string>
+     * @return mixed
      *
      * @throws InvalidArgumentException
      */
@@ -2249,9 +2249,9 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @psalm-assert iterable<string|null> $value
+     * @psalm-param iterable<string|null> $value
      *
-     * @return iterable<string|null>
+     * @return mixed
      *
      * @throws InvalidArgumentException
      */
@@ -2271,9 +2271,9 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @psalm-assert string|null $value
+     * @psalm-param string|null $value
      *
-     * @return string|null
+     * @return mixed
      *
      * @throws InvalidArgumentException
      */
@@ -2289,9 +2289,9 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @psalm-assert iterable<string> $value
+     * @psalm-param iterable<string> $value
      *
-     * @return iterable<string>
+     * @return mixed
      *
      * @throws InvalidArgumentException
      */
@@ -2311,9 +2311,9 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @psalm-assert iterable<string|null> $value
+     * @psalm-param iterable<string|null> $value
      *
-     * @return iterable<string|null>
+     * @return mixed
      *
      * @throws InvalidArgumentException
      */
@@ -5547,11 +5547,11 @@ trait Mixin
     }
 
     /**
-     * @psalm-assert callable|null $callable
+     * @psalm-param callable|null $callable
      *
      * @param string|callable():string $message
      *
-     * @return callable|null
+     * @return mixed
      *
      * @throws InvalidArgumentException
      */
@@ -5563,11 +5563,11 @@ trait Mixin
     }
 
     /**
-     * @psalm-assert iterable<callable> $callable
+     * @psalm-param iterable<callable> $callable
      *
      * @param string|callable():string $message
      *
-     * @return iterable<callable>
+     * @return mixed
      *
      * @throws InvalidArgumentException
      */
@@ -5583,11 +5583,11 @@ trait Mixin
     }
 
     /**
-     * @psalm-assert iterable<callable|null> $callable
+     * @psalm-param iterable<callable|null> $callable
      *
      * @param string|callable():string $message
      *
-     * @return iterable<callable|null>
+     * @return mixed
      *
      * @throws InvalidArgumentException
      */
@@ -5603,11 +5603,11 @@ trait Mixin
     }
 
     /**
-     * @psalm-assert callable|null $callable
+     * @psalm-param callable|null $callable
      *
      * @param string|callable():string $message
      *
-     * @return callable|null
+     * @return mixed
      *
      * @throws InvalidArgumentException
      */
@@ -5619,11 +5619,11 @@ trait Mixin
     }
 
     /**
-     * @psalm-assert iterable<callable> $callable
+     * @psalm-param iterable<callable> $callable
      *
      * @param string|callable():string $message
      *
-     * @return iterable<callable>
+     * @return mixed
      *
      * @throws InvalidArgumentException
      */
@@ -5639,11 +5639,11 @@ trait Mixin
     }
 
     /**
-     * @psalm-assert iterable<callable|null> $callable
+     * @psalm-param iterable<callable|null> $callable
      *
      * @param string|callable():string $message
      *
-     * @return iterable<callable|null>
+     * @return mixed
      *
      * @throws InvalidArgumentException
      */

--- a/src/Mixin.php
+++ b/src/Mixin.php
@@ -1267,8 +1267,7 @@ trait Mixin
      * @psalm-assert T|null $value
      *
      * @param string|callable():string $message
-     *
-     * @psalm-param class-string<T> $class
+     * @param class-string<T>          $class
      *
      * @return T|null
      *
@@ -1288,8 +1287,7 @@ trait Mixin
      * @psalm-assert iterable<T> $value
      *
      * @param string|callable():string $message
-     *
-     * @psalm-param class-string<T> $class
+     * @param class-string<T>          $class
      *
      * @return iterable<T>
      *
@@ -1313,8 +1311,7 @@ trait Mixin
      * @psalm-assert iterable<T|null> $value
      *
      * @param string|callable():string $message
-     *
-     * @psalm-param class-string<T> $class
+     * @param class-string<T>          $class
      *
      * @return iterable<T|null>
      *
@@ -1335,10 +1332,9 @@ trait Mixin
      * @template T of object
      *
      * @param string|callable():string $message
+     * @param class-string<T>          $class
      *
-     * @psalm-param class-string<T> $class
-     *
-     * @return mixed
+     * @return object|null
      *
      * @throws InvalidArgumentException
      */
@@ -1353,10 +1349,9 @@ trait Mixin
      * @template T of object
      *
      * @param string|callable():string $message
+     * @param class-string<T>          $class
      *
-     * @psalm-param class-string<T> $class
-     *
-     * @return mixed
+     * @return iterable<object>
      *
      * @throws InvalidArgumentException
      */
@@ -1376,8 +1371,7 @@ trait Mixin
      * @psalm-assert iterable<object|null> $value
      *
      * @param string|callable():string $message
-     *
-     * @psalm-param class-string<T> $class
+     * @param class-string<T>          $class
      *
      * @return iterable<object|null>
      *
@@ -1463,7 +1457,7 @@ trait Mixin
      * @param T|null                   $value
      * @param string|callable():string $message
      *
-     * @return object|class-string|null
+     * @return T|null
      *
      * @throws InvalidArgumentException
      */
@@ -1480,7 +1474,7 @@ trait Mixin
      * @param iterable<T>              $value
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<T>
      *
      * @throws InvalidArgumentException
      */
@@ -1501,7 +1495,7 @@ trait Mixin
      * @param iterable<T|null>         $value
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<T|null>
      *
      * @throws InvalidArgumentException
      */
@@ -1523,8 +1517,7 @@ trait Mixin
      * @psalm-assert T|class-string<T>|null $value
      *
      * @param string|callable():string $message
-     *
-     * @psalm-param class-string<T> $class
+     * @param class-string<T>          $class
      *
      * @return T|class-string<T>|null
      *
@@ -1544,8 +1537,7 @@ trait Mixin
      * @psalm-assert iterable<T|class-string<T>> $value
      *
      * @param string|callable():string $message
-     *
-     * @psalm-param class-string<T> $class
+     * @param class-string<T>          $class
      *
      * @return iterable<T|class-string<T>>
      *
@@ -1569,8 +1561,7 @@ trait Mixin
      * @psalm-assert iterable<T|class-string<T>|null> $value
      *
      * @param string|callable():string $message
-     *
-     * @psalm-param class-string<T> $class
+     * @param class-string<T>          $class
      *
      * @return iterable<T|class-string<T>|null>
      *
@@ -1595,7 +1586,7 @@ trait Mixin
      * @param T|null                   $value
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return object|class-string|null
      *
      * @throws InvalidArgumentException
      */
@@ -1614,7 +1605,7 @@ trait Mixin
      * @param iterable<T>              $value
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<object|class-string>
      *
      * @throws InvalidArgumentException
      */
@@ -1807,7 +1798,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -1874,7 +1865,7 @@ trait Mixin
      *
      * @template T
      *
-     * @return mixed
+     * @return iterable<T>
      *
      * @throws InvalidArgumentException
      */
@@ -2021,7 +2012,7 @@ trait Mixin
      *
      * @template T
      *
-     * @return mixed
+     * @return T|null
      *
      * @throws InvalidArgumentException
      */
@@ -2040,7 +2031,7 @@ trait Mixin
      *
      * @template T
      *
-     * @return mixed
+     * @return iterable<T>
      *
      * @throws InvalidArgumentException
      */
@@ -2065,7 +2056,7 @@ trait Mixin
      *
      * @template T
      *
-     * @return iterable<!false|null>
+     * @return iterable<T|null>
      *
      * @throws InvalidArgumentException
      */
@@ -2084,10 +2075,9 @@ trait Mixin
      * @psalm-pure
      *
      * @param string|callable():string $message
+     * @param string|null              $value
      *
-     * @psalm-param string|null $value
-     *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -2102,10 +2092,9 @@ trait Mixin
      * @psalm-pure
      *
      * @param string|callable():string $message
+     * @param iterable<string>         $value
      *
-     * @psalm-param iterable<string> $value
-     *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -2124,10 +2113,9 @@ trait Mixin
      * @psalm-pure
      *
      * @param string|callable():string $message
+     * @param iterable<string|null>    $value
      *
-     * @psalm-param iterable<string|null> $value
-     *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -2146,10 +2134,9 @@ trait Mixin
      * @psalm-pure
      *
      * @param string|callable():string $message
+     * @param string|null              $value
      *
-     * @psalm-param string|null $value
-     *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -2164,10 +2151,9 @@ trait Mixin
      * @psalm-pure
      *
      * @param string|callable():string $message
+     * @param iterable<string>         $value
      *
-     * @psalm-param iterable<string> $value
-     *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -2186,10 +2172,9 @@ trait Mixin
      * @psalm-pure
      *
      * @param string|callable():string $message
+     * @param iterable<string|null>    $value
      *
-     * @psalm-param iterable<string|null> $value
-     *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -2208,10 +2193,9 @@ trait Mixin
      * @psalm-pure
      *
      * @param string|callable():string $message
+     * @param string|null              $value
      *
-     * @psalm-param string|null $value
-     *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -2226,10 +2210,9 @@ trait Mixin
      * @psalm-pure
      *
      * @param string|callable():string $message
+     * @param iterable<string>         $value
      *
-     * @psalm-param iterable<string> $value
-     *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -2248,10 +2231,9 @@ trait Mixin
      * @psalm-pure
      *
      * @param string|callable():string $message
+     * @param iterable<string|null>    $value
      *
-     * @psalm-param iterable<string|null> $value
-     *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -2270,10 +2252,9 @@ trait Mixin
      * @psalm-pure
      *
      * @param string|callable():string $message
+     * @param string|null              $value
      *
-     * @psalm-param string|null $value
-     *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -2288,10 +2269,9 @@ trait Mixin
      * @psalm-pure
      *
      * @param string|callable():string $message
+     * @param iterable<string>         $value
      *
-     * @psalm-param iterable<string> $value
-     *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -2310,10 +2290,9 @@ trait Mixin
      * @psalm-pure
      *
      * @param string|callable():string $message
+     * @param iterable<string|null>    $value
      *
-     * @psalm-param iterable<string|null> $value
-     *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -2331,7 +2310,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return array|null
      *
      * @throws InvalidArgumentException
      */
@@ -2345,7 +2324,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<array>
      *
      * @throws InvalidArgumentException
      */
@@ -2363,7 +2342,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<array|null>
      *
      * @throws InvalidArgumentException
      */
@@ -2395,7 +2374,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -2413,7 +2392,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -2445,7 +2424,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -2463,7 +2442,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -2499,7 +2478,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -2519,7 +2498,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -2555,7 +2534,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -2575,7 +2554,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -2611,7 +2590,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -2631,7 +2610,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -2667,7 +2646,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -2687,7 +2666,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -2723,7 +2702,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -2743,7 +2722,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -2779,7 +2758,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -2799,7 +2778,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -2835,7 +2814,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -2855,7 +2834,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -2891,7 +2870,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -2911,7 +2890,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -2947,7 +2926,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -2967,7 +2946,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -3003,7 +2982,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -3023,7 +3002,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -3059,7 +3038,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -3079,7 +3058,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable
      *
      * @throws InvalidArgumentException
      */
@@ -3099,7 +3078,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -3115,7 +3094,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -3135,7 +3114,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -3155,7 +3134,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -3171,7 +3150,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -3191,7 +3170,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -3211,7 +3190,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -3227,7 +3206,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -3247,7 +3226,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -3267,7 +3246,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -3283,7 +3262,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -3303,7 +3282,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -3323,7 +3302,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -3339,7 +3318,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -3359,7 +3338,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -3379,7 +3358,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -3395,7 +3374,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -3415,7 +3394,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -3435,7 +3414,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -3451,7 +3430,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -3471,7 +3450,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -3491,7 +3470,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -3507,7 +3486,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -3527,7 +3506,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -3547,7 +3526,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -3563,7 +3542,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -3583,7 +3562,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -3603,7 +3582,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -3619,7 +3598,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -3639,7 +3618,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -3659,7 +3638,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -3675,7 +3654,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -3695,7 +3674,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -3715,7 +3694,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -3731,7 +3710,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -3751,7 +3730,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -3771,7 +3750,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -3787,7 +3766,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -3807,7 +3786,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -3827,7 +3806,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -3843,7 +3822,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -3863,7 +3842,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -3945,7 +3924,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -3961,7 +3940,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -4003,7 +3982,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -4019,7 +3998,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -4039,7 +4018,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -4059,7 +4038,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -4075,7 +4054,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -4095,7 +4074,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -4115,7 +4094,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -4131,7 +4110,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -4151,7 +4130,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -4171,7 +4150,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -4187,7 +4166,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -4207,7 +4186,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -4225,7 +4204,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -4239,7 +4218,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -4257,7 +4236,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -4275,7 +4254,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -4289,7 +4268,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -4307,7 +4286,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -4325,7 +4304,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -4339,7 +4318,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -4357,7 +4336,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -4375,7 +4354,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -4389,7 +4368,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -4407,7 +4386,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -4425,7 +4404,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -4439,7 +4418,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -4457,7 +4436,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -4726,7 +4705,7 @@ trait Mixin
      * @param string|object|null       $classOrObject
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return string|object|null
      *
      * @throws InvalidArgumentException
      */
@@ -4743,7 +4722,7 @@ trait Mixin
      * @param iterable<string|object>  $classOrObject
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string|object>
      *
      * @throws InvalidArgumentException
      */
@@ -4764,7 +4743,7 @@ trait Mixin
      * @param iterable<string|object|null> $classOrObject
      * @param string|callable():string     $message
      *
-     * @return mixed
+     * @return iterable<string|object|null>
      *
      * @throws InvalidArgumentException
      */
@@ -4782,12 +4761,10 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|object|null       $classOrObject
+     * @param class-string|object|null $classOrObject
      * @param string|callable():string $message
      *
-     * @psalm-param class-string|object|null $classOrObject
-     *
-     * @return mixed
+     * @return class-string|object|null
      *
      * @throws InvalidArgumentException
      */
@@ -4801,12 +4778,10 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param iterable<string|object>  $classOrObject
-     * @param string|callable():string $message
+     * @param iterable<class-string|object> $classOrObject
+     * @param string|callable():string      $message
      *
-     * @psalm-param iterable<class-string|object> $classOrObject
-     *
-     * @return mixed
+     * @return iterable<class-string|object>
      *
      * @throws InvalidArgumentException
      */
@@ -4824,12 +4799,10 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param iterable<string|object|null> $classOrObject
-     * @param string|callable():string     $message
+     * @param iterable<class-string|object|null> $classOrObject
+     * @param string|callable():string           $message
      *
-     * @psalm-param iterable<class-string|object|null> $classOrObject
-     *
-     * @return mixed
+     * @return iterable<class-string|object|null>
      *
      * @throws InvalidArgumentException
      */
@@ -4847,12 +4820,10 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|object|null       $classOrObject
+     * @param class-string|object|null $classOrObject
      * @param string|callable():string $message
      *
-     * @psalm-param class-string|object|null $classOrObject
-     *
-     * @return mixed
+     * @return class-string|object|null
      *
      * @throws InvalidArgumentException
      */
@@ -4866,12 +4837,10 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param iterable<string|object>  $classOrObject
-     * @param string|callable():string $message
+     * @param iterable<class-string|object> $classOrObject
+     * @param string|callable():string      $message
      *
-     * @psalm-param iterable<class-string|object> $classOrObject
-     *
-     * @return mixed
+     * @return iterable<class-string|object>
      *
      * @throws InvalidArgumentException
      */
@@ -4889,12 +4858,10 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param iterable<string|object|null> $classOrObject
-     * @param string|callable():string     $message
+     * @param iterable<class-string|object|null> $classOrObject
+     * @param string|callable():string           $message
      *
-     * @psalm-param iterable<class-string|object|null> $classOrObject
-     *
-     * @return mixed
+     * @return iterable<class-string|object|null>
      *
      * @throws InvalidArgumentException
      */
@@ -4912,12 +4879,10 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param string|object|null       $classOrObject
+     * @param class-string|object|null $classOrObject
      * @param string|callable():string $message
      *
-     * @psalm-param class-string|object|null $classOrObject
-     *
-     * @return mixed
+     * @return class-string|object|null
      *
      * @throws InvalidArgumentException
      */
@@ -4931,12 +4896,10 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param iterable<string|object>  $classOrObject
-     * @param string|callable():string $message
+     * @param iterable<class-string|object> $classOrObject
+     * @param string|callable():string      $message
      *
-     * @psalm-param iterable<class-string|object> $classOrObject
-     *
-     * @return mixed
+     * @return iterable<class-string|object>
      *
      * @throws InvalidArgumentException
      */
@@ -4954,12 +4917,10 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param iterable<string|object|null> $classOrObject
-     * @param string|callable():string     $message
+     * @param iterable<class-string|object|null> $classOrObject
+     * @param string|callable():string           $message
      *
-     * @psalm-param iterable<class-string|object|null> $classOrObject
-     *
-     * @return mixed
+     * @return iterable<class-string|object|null>
      *
      * @throws InvalidArgumentException
      */
@@ -4980,7 +4941,7 @@ trait Mixin
      * @param string|int               $key
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return array|null
      *
      * @throws InvalidArgumentException
      */
@@ -4997,7 +4958,7 @@ trait Mixin
      * @param string|int               $key
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<array>
      *
      * @throws InvalidArgumentException
      */
@@ -5018,7 +4979,7 @@ trait Mixin
      * @param string|int               $key
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<array|null>
      *
      * @throws InvalidArgumentException
      */
@@ -5039,7 +5000,7 @@ trait Mixin
      * @param string|int               $key
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return array|null
      *
      * @throws InvalidArgumentException
      */
@@ -5056,7 +5017,7 @@ trait Mixin
      * @param string|int               $key
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<array>
      *
      * @throws InvalidArgumentException
      */
@@ -5077,7 +5038,7 @@ trait Mixin
      * @param string|int               $key
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<array|null>
      *
      * @throws InvalidArgumentException
      */
@@ -5157,7 +5118,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return Countable|array|null
      *
      * @throws InvalidArgumentException
      */
@@ -5171,7 +5132,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<Countable|array>
      *
      * @throws InvalidArgumentException
      */
@@ -5189,7 +5150,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<Countable|array|null>
      *
      * @throws InvalidArgumentException
      */
@@ -5207,7 +5168,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return Countable|array|null
      *
      * @throws InvalidArgumentException
      */
@@ -5221,7 +5182,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<Countable|array>
      *
      * @throws InvalidArgumentException
      */
@@ -5239,7 +5200,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<Countable|array|null>
      *
      * @throws InvalidArgumentException
      */
@@ -5257,7 +5218,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return Countable|array|null
      *
      * @throws InvalidArgumentException
      */
@@ -5271,7 +5232,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<Countable|array>
      *
      * @throws InvalidArgumentException
      */
@@ -5289,7 +5250,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<Countable|array|null>
      *
      * @throws InvalidArgumentException
      */
@@ -5307,7 +5268,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return Countable|array|null
      *
      * @throws InvalidArgumentException
      */
@@ -5321,7 +5282,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<Countable|array>
      *
      * @throws InvalidArgumentException
      */
@@ -5339,7 +5300,7 @@ trait Mixin
     /**
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<Countable|array|null>
      *
      * @throws InvalidArgumentException
      */
@@ -5547,11 +5508,10 @@ trait Mixin
     }
 
     /**
-     * @psalm-param callable|null $callable
-     *
+     * @param callable|null            $callable
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return Closure|callable-string|null
      *
      * @throws InvalidArgumentException
      */
@@ -5563,11 +5523,10 @@ trait Mixin
     }
 
     /**
-     * @psalm-param iterable<callable> $callable
-     *
+     * @param iterable<callable>       $callable
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<Closure|callable-string>
      *
      * @throws InvalidArgumentException
      */
@@ -5583,11 +5542,10 @@ trait Mixin
     }
 
     /**
-     * @psalm-param iterable<callable|null> $callable
-     *
+     * @param iterable<callable|null>  $callable
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<Closure|callable-string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -5603,11 +5561,10 @@ trait Mixin
     }
 
     /**
-     * @psalm-param callable|null $callable
-     *
+     * @param callable|null            $callable
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return Closure|callable-string|null
      *
      * @throws InvalidArgumentException
      */
@@ -5619,11 +5576,10 @@ trait Mixin
     }
 
     /**
-     * @psalm-param iterable<callable> $callable
-     *
+     * @param iterable<callable>       $callable
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<Closure|callable-string>
      *
      * @throws InvalidArgumentException
      */
@@ -5639,11 +5595,10 @@ trait Mixin
     }
 
     /**
-     * @psalm-param iterable<callable|null> $callable
-     *
+     * @param iterable<callable|null>  $callable
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<Closure|callable-string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -5666,7 +5621,7 @@ trait Mixin
      * @param array<string, T>|null    $array
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return non-empty-array<string, T>|null
      *
      * @throws InvalidArgumentException
      */
@@ -5685,7 +5640,7 @@ trait Mixin
      * @param iterable<array<string, T>> $array
      * @param string|callable():string   $message
      *
-     * @return mixed
+     * @return iterable<non-empty-array<string, T>>
      *
      * @throws InvalidArgumentException
      */
@@ -5710,7 +5665,7 @@ trait Mixin
      * @param iterable<array<string, T>|null> $array
      * @param string|callable():string        $message
      *
-     * @return iterable<!empty|null>
+     * @return iterable<non-empty-array<string, T>|null>
      *
      * @throws InvalidArgumentException
      */
@@ -5730,7 +5685,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -5746,7 +5701,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -5766,7 +5721,7 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -5783,10 +5738,9 @@ trait Mixin
 
     /**
      * @param string|callable():string $message
+     * @param class-string<Throwable>  $class
      *
-     * @psalm-param class-string<Throwable> $class
-     *
-     * @return mixed
+     * @return callable|null
      *
      * @throws InvalidArgumentException
      */
@@ -5799,10 +5753,9 @@ trait Mixin
 
     /**
      * @param string|callable():string $message
+     * @param class-string<Throwable>  $class
      *
-     * @psalm-param class-string<Throwable> $class
-     *
-     * @return mixed
+     * @return iterable<callable>
      *
      * @throws InvalidArgumentException
      */
@@ -5819,10 +5772,9 @@ trait Mixin
 
     /**
      * @param string|callable():string $message
+     * @param class-string<Throwable>  $class
      *
-     * @psalm-param class-string<Throwable> $class
-     *
-     * @return mixed
+     * @return iterable<callable|null>
      *
      * @throws InvalidArgumentException
      */

--- a/src/Mixin.php
+++ b/src/Mixin.php
@@ -1526,6 +1526,8 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
+     * @psalm-param class-string<T> $class
+     *
      * @return T|class-string<T>|null
      *
      * @throws InvalidArgumentException
@@ -1544,6 +1546,8 @@ trait Mixin
      * @psalm-assert iterable<T|class-string<T>> $value
      *
      * @param string|callable():string $message
+     *
+     * @psalm-param class-string<T> $class
      *
      * @return iterable<T|class-string<T>>
      *
@@ -1567,6 +1571,8 @@ trait Mixin
      * @psalm-assert iterable<T|class-string<T>|null> $value
      *
      * @param string|callable():string $message
+     *
+     * @psalm-param class-string<T> $class
      *
      * @return iterable<T|class-string<T>|null>
      *
@@ -1863,6 +1869,10 @@ trait Mixin
      * @psalm-pure
      *
      * @param string|callable():string $message
+     * @param iterable<T|null>         $value
+     *
+     * @template T
+     *
      *
      * @return mixed
      *
@@ -2007,6 +2017,10 @@ trait Mixin
      * @psalm-pure
      *
      * @param string|callable():string $message
+     * @param T|false|null             $value
+     *
+     * @template T
+     *
      *
      * @return mixed
      *
@@ -2023,6 +2037,10 @@ trait Mixin
      * @psalm-pure
      *
      * @param string|callable():string $message
+     * @param iterable<T|false>        $value
+     *
+     * @template T
+     *
      *
      * @return mixed
      *
@@ -2045,6 +2063,10 @@ trait Mixin
      * @psalm-assert iterable<!false|null> $value
      *
      * @param string|callable():string $message
+     * @param iterable<T|false|null>   $value
+     *
+     * @template T
+     *
      *
      * @return iterable<!false|null>
      *
@@ -4639,9 +4661,8 @@ trait Mixin
      * @template ExpectedType of object
      * @psalm-assert class-string<ExpectedType>|ExpectedType|null $value
      *
-     * @param class-string<ExpectedType>|ExpectedType|null $value
-     * @param class-string<ExpectedType>                   $interface
-     * @param string|callable():string                     $message
+     * @param class-string<ExpectedType> $interface
+     * @param string|callable():string   $message
      *
      * @return class-string<ExpectedType>|ExpectedType|null
      *
@@ -4660,9 +4681,8 @@ trait Mixin
      * @template ExpectedType of object
      * @psalm-assert iterable<class-string<ExpectedType>|ExpectedType> $value
      *
-     * @param iterable<class-string<ExpectedType>|ExpectedType> $value
-     * @param class-string<ExpectedType>                        $interface
-     * @param string|callable():string                          $message
+     * @param class-string<ExpectedType> $interface
+     * @param string|callable():string   $message
      *
      * @return iterable<class-string<ExpectedType>|ExpectedType>
      *
@@ -4685,9 +4705,8 @@ trait Mixin
      * @template ExpectedType of object
      * @psalm-assert iterable<class-string<ExpectedType>|ExpectedType|null> $value
      *
-     * @param iterable<class-string<ExpectedType>|ExpectedType|null> $value
-     * @param class-string<ExpectedType>                             $interface
-     * @param string|callable():string                               $message
+     * @param class-string<ExpectedType> $interface
+     * @param string|callable():string   $message
      *
      * @return iterable<class-string<ExpectedType>|ExpectedType|null>
      *

--- a/src/Mixin.php
+++ b/src/Mixin.php
@@ -1398,7 +1398,7 @@ trait Mixin
      * @template T of object
      * @psalm-assert T|null $value
      *
-     * @param T|null                   $value
+     * @param array<class-string<T>>   $classes
      * @param string|callable():string $message
      *
      * @return T|null
@@ -1416,7 +1416,7 @@ trait Mixin
      * @template T of object
      * @psalm-assert iterable<T> $value
      *
-     * @param iterable<T>              $value
+     * @param array<class-string<T>>   $classes
      * @param string|callable():string $message
      *
      * @return iterable<T>
@@ -1438,7 +1438,7 @@ trait Mixin
      * @template T of object
      * @psalm-assert iterable<T|null> $value
      *
-     * @param iterable<T|null>         $value
+     * @param array<class-string<T>>   $classes
      * @param string|callable():string $message
      *
      * @return iterable<T|null>
@@ -1458,12 +1458,12 @@ trait Mixin
 
     /**
      * @template T
-     * @psalm-assert T|null $value
+     * @psalm-assert object|class-string|null $value
      *
      * @param T|null                   $value
      * @param string|callable():string $message
      *
-     * @return T|null
+     * @return object|class-string|null
      *
      * @throws InvalidArgumentException
      */
@@ -1476,12 +1476,11 @@ trait Mixin
 
     /**
      * @template T
-     * @psalm-assert iterable<T> $value
      *
      * @param iterable<T>              $value
      * @param string|callable():string $message
      *
-     * @return iterable<T>
+     * @return mixed
      *
      * @throws InvalidArgumentException
      */
@@ -1498,12 +1497,11 @@ trait Mixin
 
     /**
      * @template T
-     * @psalm-assert iterable<T|null> $value
      *
      * @param iterable<T|null>         $value
      * @param string|callable():string $message
      *
-     * @return iterable<T|null>
+     * @return mixed
      *
      * @throws InvalidArgumentException
      */
@@ -1658,13 +1656,14 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param object|string|null       $value
-     * @param string[]                 $classes
+     * @psalm-assert T|null $value
+     *
+     * @template T as object
+     *
+     * @param array<class-string<T>>   $classes
      * @param string|callable():string $message
      *
-     * @psalm-param array<class-string> $classes
-     *
-     * @return mixed
+     * @return T|null
      *
      * @throws InvalidArgumentException
      */
@@ -1678,13 +1677,14 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param iterable<object|string>  $value
-     * @param string[]                 $classes
+     * @psalm-assert iterable<T> $value
+     *
+     * @template T as object
+     *
+     * @param array<class-string<T>>   $classes
      * @param string|callable():string $message
      *
-     * @psalm-param array<class-string> $classes
-     *
-     * @return mixed
+     * @return iterable<T>
      *
      * @throws InvalidArgumentException
      */
@@ -1702,13 +1702,14 @@ trait Mixin
     /**
      * @psalm-pure
      *
-     * @param iterable<object|string|null> $value
-     * @param string[]                     $classes
-     * @param string|callable():string     $message
+     * @psalm-assert iterable<T|null> $value
      *
-     * @psalm-param array<class-string> $classes
+     * @template T as object
      *
-     * @return mixed
+     * @param array<class-string<T>>   $classes
+     * @param string|callable():string $message
+     *
+     * @return iterable<T|null>
      *
      * @throws InvalidArgumentException
      */
@@ -1873,7 +1874,6 @@ trait Mixin
      *
      * @template T
      *
-     *
      * @return mixed
      *
      * @throws InvalidArgumentException
@@ -2021,7 +2021,6 @@ trait Mixin
      *
      * @template T
      *
-     *
      * @return mixed
      *
      * @throws InvalidArgumentException
@@ -2040,7 +2039,6 @@ trait Mixin
      * @param iterable<T|false>        $value
      *
      * @template T
-     *
      *
      * @return mixed
      *
@@ -2067,7 +2065,6 @@ trait Mixin
      *
      * @template T
      *
-     *
      * @return iterable<!false|null>
      *
      * @throws InvalidArgumentException
@@ -2088,9 +2085,9 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @psalm-param string|null $value
+     * @psalm-assert string|null $value
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -2106,9 +2103,9 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @psalm-param iterable<string> $value
+     * @psalm-assert iterable<string> $value
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -2128,9 +2125,9 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @psalm-param iterable<string|null> $value
+     * @psalm-assert iterable<string|null> $value
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -2150,9 +2147,9 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @psalm-param string|null $value
+     * @psalm-assert string|null $value
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -2168,9 +2165,9 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @psalm-param iterable<string> $value
+     * @psalm-assert iterable<string> $value
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -2190,9 +2187,9 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @psalm-param iterable<string|null> $value
+     * @psalm-assert iterable<string|null> $value
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -2212,9 +2209,9 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @psalm-param string|null $value
+     * @psalm-assert string|null $value
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -2230,9 +2227,9 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @psalm-param iterable<string> $value
+     * @psalm-assert iterable<string> $value
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -2252,9 +2249,9 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @psalm-param iterable<string|null> $value
+     * @psalm-assert iterable<string|null> $value
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -2274,9 +2271,9 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @psalm-param string|null $value
+     * @psalm-assert string|null $value
      *
-     * @return mixed
+     * @return string|null
      *
      * @throws InvalidArgumentException
      */
@@ -2292,9 +2289,9 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @psalm-param iterable<string> $value
+     * @psalm-assert iterable<string> $value
      *
-     * @return mixed
+     * @return iterable<string>
      *
      * @throws InvalidArgumentException
      */
@@ -2314,9 +2311,9 @@ trait Mixin
      *
      * @param string|callable():string $message
      *
-     * @psalm-param iterable<string|null> $value
+     * @psalm-assert iterable<string|null> $value
      *
-     * @return mixed
+     * @return iterable<string|null>
      *
      * @throws InvalidArgumentException
      */
@@ -5552,7 +5549,6 @@ trait Mixin
     /**
      * @psalm-assert callable|null $callable
      *
-     * @param Closure|callable|null    $callable
      * @param string|callable():string $message
      *
      * @return callable|null
@@ -5569,8 +5565,7 @@ trait Mixin
     /**
      * @psalm-assert iterable<callable> $callable
      *
-     * @param iterable<Closure|callable> $callable
-     * @param string|callable():string   $message
+     * @param string|callable():string $message
      *
      * @return iterable<callable>
      *
@@ -5590,8 +5585,7 @@ trait Mixin
     /**
      * @psalm-assert iterable<callable|null> $callable
      *
-     * @param iterable<Closure|callable|null> $callable
-     * @param string|callable():string        $message
+     * @param string|callable():string $message
      *
      * @return iterable<callable|null>
      *
@@ -5611,7 +5605,6 @@ trait Mixin
     /**
      * @psalm-assert callable|null $callable
      *
-     * @param Closure|callable|null    $callable
      * @param string|callable():string $message
      *
      * @return callable|null
@@ -5628,8 +5621,7 @@ trait Mixin
     /**
      * @psalm-assert iterable<callable> $callable
      *
-     * @param iterable<Closure|callable> $callable
-     * @param string|callable():string   $message
+     * @param string|callable():string $message
      *
      * @return iterable<callable>
      *
@@ -5649,8 +5641,7 @@ trait Mixin
     /**
      * @psalm-assert iterable<callable|null> $callable
      *
-     * @param iterable<Closure|callable|null> $callable
-     * @param string|callable():string        $message
+     * @param string|callable():string $message
      *
      * @return iterable<callable|null>
      *

--- a/src/Mixin.php
+++ b/src/Mixin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webmozart\Assert;
 
+use Closure;
 use ArrayAccess;
 use Countable;
 use Throwable;
@@ -2308,13 +2309,15 @@ trait Mixin
     }
 
     /**
+     * @psalm-assert array|null $values
+     *
      * @param string|callable():string $message
      *
      * @return array|null
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrUniqueValues(mixed $values, callable|string $message = ''): mixed
+    public static function nullOrUniqueValues(mixed $values, callable|string $message = ''): array|null
     {
         null === $values || static::uniqueValues($values, $message);
 
@@ -2322,13 +2325,15 @@ trait Mixin
     }
 
     /**
+     * @psalm-assert iterable<array> $values
+     *
      * @param string|callable():string $message
      *
      * @return iterable<array>
      *
      * @throws InvalidArgumentException
      */
-    public static function allUniqueValues(mixed $values, callable|string $message = ''): mixed
+    public static function allUniqueValues(mixed $values, callable|string $message = ''): iterable
     {
         static::isIterable($values);
 
@@ -2340,13 +2345,15 @@ trait Mixin
     }
 
     /**
+     * @psalm-assert iterable<array|null> $values
+     *
      * @param string|callable():string $message
      *
      * @return iterable<array|null>
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrUniqueValues(mixed $values, callable|string $message = ''): mixed
+    public static function allNullOrUniqueValues(mixed $values, callable|string $message = ''): iterable
     {
         static::isIterable($values);
 
@@ -4709,7 +4716,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrPropertyExists(mixed $classOrObject, mixed $property, callable|string $message = ''): mixed
+    public static function nullOrPropertyExists(mixed $classOrObject, mixed $property, callable|string $message = ''): object|string|null
     {
         null === $classOrObject || static::propertyExists($classOrObject, $property, $message);
 
@@ -4726,7 +4733,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allPropertyExists(mixed $classOrObject, mixed $property, callable|string $message = ''): mixed
+    public static function allPropertyExists(mixed $classOrObject, mixed $property, callable|string $message = ''): iterable
     {
         static::isIterable($classOrObject);
 
@@ -4747,7 +4754,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrPropertyExists(mixed $classOrObject, mixed $property, callable|string $message = ''): mixed
+    public static function allNullOrPropertyExists(mixed $classOrObject, mixed $property, callable|string $message = ''): iterable
     {
         static::isIterable($classOrObject);
 
@@ -4785,7 +4792,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allPropertyNotExists(mixed $classOrObject, mixed $property, callable|string $message = ''): mixed
+    public static function allPropertyNotExists(mixed $classOrObject, mixed $property, callable|string $message = ''): iterable
     {
         static::isIterable($classOrObject);
 
@@ -4806,7 +4813,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrPropertyNotExists(mixed $classOrObject, mixed $property, callable|string $message = ''): mixed
+    public static function allNullOrPropertyNotExists(mixed $classOrObject, mixed $property, callable|string $message = ''): iterable
     {
         static::isIterable($classOrObject);
 
@@ -4827,7 +4834,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrMethodExists(mixed $classOrObject, mixed $method, callable|string $message = ''): mixed
+    public static function nullOrMethodExists(mixed $classOrObject, mixed $method, callable|string $message = ''): object|string|null
     {
         null === $classOrObject || static::methodExists($classOrObject, $method, $message);
 
@@ -4844,7 +4851,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allMethodExists(mixed $classOrObject, mixed $method, callable|string $message = ''): mixed
+    public static function allMethodExists(mixed $classOrObject, mixed $method, callable|string $message = ''): iterable
     {
         static::isIterable($classOrObject);
 
@@ -4865,7 +4872,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrMethodExists(mixed $classOrObject, mixed $method, callable|string $message = ''): mixed
+    public static function allNullOrMethodExists(mixed $classOrObject, mixed $method, callable|string $message = ''): iterable
     {
         static::isIterable($classOrObject);
 
@@ -4903,7 +4910,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allMethodNotExists(mixed $classOrObject, mixed $method, callable|string $message = ''): mixed
+    public static function allMethodNotExists(mixed $classOrObject, mixed $method, callable|string $message = ''): iterable
     {
         static::isIterable($classOrObject);
 
@@ -4924,7 +4931,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrMethodNotExists(mixed $classOrObject, mixed $method, callable|string $message = ''): mixed
+    public static function allNullOrMethodNotExists(mixed $classOrObject, mixed $method, callable|string $message = ''): iterable
     {
         static::isIterable($classOrObject);
 
@@ -4945,7 +4952,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrKeyExists(mixed $array, string|int $key, callable|string $message = ''): mixed
+    public static function nullOrKeyExists(mixed $array, string|int $key, callable|string $message = ''): array|null
     {
         null === $array || static::keyExists($array, $key, $message);
 
@@ -4962,7 +4969,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allKeyExists(mixed $array, string|int $key, callable|string $message = ''): mixed
+    public static function allKeyExists(mixed $array, string|int $key, callable|string $message = ''): iterable
     {
         static::isIterable($array);
 
@@ -4983,7 +4990,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrKeyExists(mixed $array, string|int $key, callable|string $message = ''): mixed
+    public static function allNullOrKeyExists(mixed $array, string|int $key, callable|string $message = ''): iterable
     {
         static::isIterable($array);
 
@@ -5004,7 +5011,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrKeyNotExists(mixed $array, string|int $key, callable|string $message = ''): mixed
+    public static function nullOrKeyNotExists(mixed $array, string|int $key, callable|string $message = ''): array|null
     {
         null === $array || static::keyNotExists($array, $key, $message);
 
@@ -5021,7 +5028,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allKeyNotExists(mixed $array, string|int $key, callable|string $message = ''): mixed
+    public static function allKeyNotExists(mixed $array, string|int $key, callable|string $message = ''): iterable
     {
         static::isIterable($array);
 
@@ -5042,7 +5049,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrKeyNotExists(mixed $array, string|int $key, callable|string $message = ''): mixed
+    public static function allNullOrKeyNotExists(mixed $array, string|int $key, callable|string $message = ''): iterable
     {
         static::isIterable($array);
 
@@ -5122,7 +5129,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrCount(mixed $array, mixed $number, callable|string $message = ''): mixed
+    public static function nullOrCount(mixed $array, mixed $number, callable|string $message = ''): Countable|array|null
     {
         null === $array || static::count($array, $number, $message);
 
@@ -5136,7 +5143,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allCount(mixed $array, mixed $number, callable|string $message = ''): mixed
+    public static function allCount(mixed $array, mixed $number, callable|string $message = ''): iterable
     {
         static::isIterable($array);
 
@@ -5154,7 +5161,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrCount(mixed $array, mixed $number, callable|string $message = ''): mixed
+    public static function allNullOrCount(mixed $array, mixed $number, callable|string $message = ''): iterable
     {
         static::isIterable($array);
 
@@ -5172,7 +5179,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrMinCount(mixed $array, mixed $min, callable|string $message = ''): mixed
+    public static function nullOrMinCount(mixed $array, mixed $min, callable|string $message = ''): Countable|array|null
     {
         null === $array || static::minCount($array, $min, $message);
 
@@ -5186,7 +5193,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allMinCount(mixed $array, mixed $min, callable|string $message = ''): mixed
+    public static function allMinCount(mixed $array, mixed $min, callable|string $message = ''): iterable
     {
         static::isIterable($array);
 
@@ -5204,7 +5211,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrMinCount(mixed $array, mixed $min, callable|string $message = ''): mixed
+    public static function allNullOrMinCount(mixed $array, mixed $min, callable|string $message = ''): iterable
     {
         static::isIterable($array);
 
@@ -5222,7 +5229,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrMaxCount(mixed $array, mixed $max, callable|string $message = ''): mixed
+    public static function nullOrMaxCount(mixed $array, mixed $max, callable|string $message = ''): Countable|array|null
     {
         null === $array || static::maxCount($array, $max, $message);
 
@@ -5236,7 +5243,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allMaxCount(mixed $array, mixed $max, callable|string $message = ''): mixed
+    public static function allMaxCount(mixed $array, mixed $max, callable|string $message = ''): iterable
     {
         static::isIterable($array);
 
@@ -5254,7 +5261,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrMaxCount(mixed $array, mixed $max, callable|string $message = ''): mixed
+    public static function allNullOrMaxCount(mixed $array, mixed $max, callable|string $message = ''): iterable
     {
         static::isIterable($array);
 
@@ -5272,7 +5279,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrCountBetween(mixed $array, mixed $min, mixed $max, callable|string $message = ''): mixed
+    public static function nullOrCountBetween(mixed $array, mixed $min, mixed $max, callable|string $message = ''): Countable|array|null
     {
         null === $array || static::countBetween($array, $min, $max, $message);
 
@@ -5286,7 +5293,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allCountBetween(mixed $array, mixed $min, mixed $max, callable|string $message = ''): mixed
+    public static function allCountBetween(mixed $array, mixed $min, mixed $max, callable|string $message = ''): iterable
     {
         static::isIterable($array);
 
@@ -5304,7 +5311,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrCountBetween(mixed $array, mixed $min, mixed $max, callable|string $message = ''): mixed
+    public static function allNullOrCountBetween(mixed $array, mixed $min, mixed $max, callable|string $message = ''): iterable
     {
         static::isIterable($array);
 
@@ -5326,7 +5333,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsList(mixed $array, callable|string $message = ''): mixed
+    public static function nullOrIsList(mixed $array, callable|string $message = ''): array|null
     {
         null === $array || static::isList($array, $message);
 
@@ -5344,7 +5351,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allIsList(mixed $array, callable|string $message = ''): mixed
+    public static function allIsList(mixed $array, callable|string $message = ''): iterable
     {
         static::isIterable($array);
 
@@ -5366,7 +5373,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrIsList(mixed $array, callable|string $message = ''): mixed
+    public static function allNullOrIsList(mixed $array, callable|string $message = ''): iterable
     {
         static::isIterable($array);
 
@@ -5388,7 +5395,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsNonEmptyList(mixed $array, callable|string $message = ''): mixed
+    public static function nullOrIsNonEmptyList(mixed $array, callable|string $message = ''): array|null
     {
         null === $array || static::isNonEmptyList($array, $message);
 
@@ -5406,7 +5413,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allIsNonEmptyList(mixed $array, callable|string $message = ''): mixed
+    public static function allIsNonEmptyList(mixed $array, callable|string $message = ''): iterable
     {
         static::isIterable($array);
 
@@ -5428,7 +5435,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrIsNonEmptyList(mixed $array, callable|string $message = ''): mixed
+    public static function allNullOrIsNonEmptyList(mixed $array, callable|string $message = ''): iterable
     {
         static::isIterable($array);
 
@@ -5452,7 +5459,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsMap(mixed $array, callable|string $message = ''): mixed
+    public static function nullOrIsMap(mixed $array, callable|string $message = ''): array|null
     {
         null === $array || static::isMap($array, $message);
 
@@ -5472,7 +5479,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allIsMap(mixed $array, callable|string $message = ''): mixed
+    public static function allIsMap(mixed $array, callable|string $message = ''): iterable
     {
         static::isIterable($array);
 
@@ -5496,7 +5503,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrIsMap(mixed $array, callable|string $message = ''): mixed
+    public static function allNullOrIsMap(mixed $array, callable|string $message = ''): iterable
     {
         static::isIterable($array);
 
@@ -5515,7 +5522,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsStatic(mixed $callable, callable|string $message = ''): mixed
+    public static function nullOrIsStatic(mixed $callable, callable|string $message = ''): Closure|string|null
     {
         null === $callable || static::isStatic($callable, $message);
 
@@ -5530,7 +5537,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allIsStatic(mixed $callable, callable|string $message = ''): mixed
+    public static function allIsStatic(mixed $callable, callable|string $message = ''): iterable
     {
         static::isIterable($callable);
 
@@ -5549,7 +5556,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrIsStatic(mixed $callable, callable|string $message = ''): mixed
+    public static function allNullOrIsStatic(mixed $callable, callable|string $message = ''): iterable
     {
         static::isIterable($callable);
 
@@ -5568,7 +5575,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrNotStatic(mixed $callable, callable|string $message = ''): mixed
+    public static function nullOrNotStatic(mixed $callable, callable|string $message = ''): Closure|string|null
     {
         null === $callable || static::notStatic($callable, $message);
 
@@ -5583,7 +5590,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allNotStatic(mixed $callable, callable|string $message = ''): mixed
+    public static function allNotStatic(mixed $callable, callable|string $message = ''): iterable
     {
         static::isIterable($callable);
 
@@ -5602,7 +5609,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrNotStatic(mixed $callable, callable|string $message = ''): mixed
+    public static function allNullOrNotStatic(mixed $callable, callable|string $message = ''): iterable
     {
         static::isIterable($callable);
 
@@ -5625,7 +5632,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrIsNonEmptyMap(mixed $array, callable|string $message = ''): mixed
+    public static function nullOrIsNonEmptyMap(mixed $array, callable|string $message = ''): array|null
     {
         null === $array || static::isNonEmptyMap($array, $message);
 
@@ -5644,7 +5651,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allIsNonEmptyMap(mixed $array, callable|string $message = ''): mixed
+    public static function allIsNonEmptyMap(mixed $array, callable|string $message = ''): iterable
     {
         static::isIterable($array);
 
@@ -5669,7 +5676,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrIsNonEmptyMap(mixed $array, callable|string $message = ''): mixed
+    public static function allNullOrIsNonEmptyMap(mixed $array, callable|string $message = ''): iterable
     {
         static::isIterable($array);
 
@@ -5744,7 +5751,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function nullOrThrows(mixed $expression, string $class = 'Throwable', callable|string $message = ''): mixed
+    public static function nullOrThrows(mixed $expression, string $class = 'Throwable', callable|string $message = ''): callable|null
     {
         null === $expression || static::throws($expression, $class, $message);
 
@@ -5759,7 +5766,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allThrows(mixed $expression, string $class = 'Throwable', callable|string $message = ''): mixed
+    public static function allThrows(mixed $expression, string $class = 'Throwable', callable|string $message = ''): iterable
     {
         static::isIterable($expression);
 
@@ -5778,7 +5785,7 @@ trait Mixin
      *
      * @throws InvalidArgumentException
      */
-    public static function allNullOrThrows(mixed $expression, string $class = 'Throwable', callable|string $message = ''): mixed
+    public static function allNullOrThrows(mixed $expression, string $class = 'Throwable', callable|string $message = ''): iterable
     {
         static::isIterable($expression);
 

--- a/src/PsalmPlugin.php
+++ b/src/PsalmPlugin.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert;
+
+use Psalm\Internal\Analyzer\Statements\Expression\ExpressionIdentifier;
+use Psalm\Plugin\EventHandler\AfterMethodCallAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterMethodCallAnalysisEvent;
+use Psalm\Plugin\PluginEntryPointInterface;
+use Psalm\PluginRegistrationSocket;
+use SimpleXMLElement;
+
+final class PsalmPlugin implements PluginEntryPointInterface, AfterMethodCallAnalysisInterface
+{
+    public function __invoke(PluginRegistrationSocket $registration, ?SimpleXMLElement $config = null): void
+    {
+        $registration->registerHooksFromClass(self::class);
+    }
+
+    public static function afterMethodCallAnalysis(AfterMethodCallAnalysisEvent $event): void
+    {
+        if (!str_starts_with($event->getMethodId(), Assert::class.'::')) {
+            return;
+        }
+
+        $firstArg = $event->getExpr()->getArgs()[0] ?? null;
+        if ($firstArg === null) {
+            return;
+        }
+
+        $varId = ExpressionIdentifier::getExtendedVarId(
+            $firstArg->value,
+            $event->getContext()->self,
+            $event->getStatementsSource()
+        );
+
+        if ($varId === null || !isset($event->getContext()->vars_in_scope[$varId])) {
+            return;
+        }
+
+        $candidateType = $event->getContext()->vars_in_scope[$varId];
+
+        $event->setReturnTypeCandidate($candidateType);
+    }
+}

--- a/tests/ProjectCodeTest.php
+++ b/tests/ProjectCodeTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ReflectionMethod;
 use Webmozart\Assert\Bin\MixinGenerator;
+use Webmozart\Assert\Bin\StaticAnalysisNonReturnGenerator;
 
 #[CoversNothing]
 class ProjectCodeTest extends TestCase
@@ -149,6 +150,21 @@ class ProjectCodeTest extends TestCase
         );
     }
 
+    #[DataProvider('provideMethods')]
+    public function testHasCorrespondingStaticAnalysisReturnTest(ReflectionMethod $method): void
+    {
+        $file = __DIR__.'/static-analysis/assert-'.$method->getName().'.php';
+
+        $this->assertFileExists($file);
+
+        $contents = file_get_contents($file);
+        $this->assertIsString($contents);
+        $this->assertMatchesRegularExpression(
+            '/return Assert::'.preg_quote($method->getName(), '/').'\(/',
+            $contents
+        );
+    }
+
     public function testMixinIsUpToDateVersion(): void
     {
         if (PHP_OS_FAMILY === 'Windows') {
@@ -164,6 +180,31 @@ class ProjectCodeTest extends TestCase
         $actual = file_get_contents(__DIR__.'/../src/Mixin.php');
 
         $this->assertEquals($generator->generate(), $actual, 'please regenerate Mixin with `php bin/generate.php` command in the project root');
+    }
+
+    public function testNonReturnStaticAnalysisTestsAreUpToDate(): void
+    {
+        if (PHP_OS_FAMILY === 'Windows') {
+            $this->markTestSkipped('non-return static analysis generator is not expected to run on Windows');
+
+            return;
+        }
+
+        require_once __DIR__.'/../bin/src/StaticAnalysisNonReturnGenerator.php';
+
+        $generator = new StaticAnalysisNonReturnGenerator(__DIR__.'/static-analysis');
+
+        foreach ($generator->generatedFiles() as $targetFile => $expectedContent) {
+            $this->assertFileExists($targetFile);
+
+            $actualContent = file_get_contents($targetFile);
+            $this->assertIsString($actualContent);
+            $this->assertEquals(
+                $expectedContent,
+                $actualContent,
+                'please regenerate static analysis tests with `php bin/generate.php` command in the project root'
+            );
+        }
     }
 
     /**

--- a/tests/static-analysis/assert-alnum.php
+++ b/tests/static-analysis/assert-alnum.php
@@ -11,9 +11,7 @@ use Webmozart\Assert\Assert;
  */
 function alnum(string $value): string
 {
-    Assert::alnum($value);
-
-    return $value;
+    return Assert::alnum($value);
 }
 
 /**
@@ -21,9 +19,7 @@ function alnum(string $value): string
  */
 function nullOrAlnum(?string $value): ?string
 {
-    Assert::nullOrAlnum($value);
-
-    return $value;
+    return Assert::nullOrAlnum($value);
 }
 
 /**
@@ -33,9 +29,7 @@ function nullOrAlnum(?string $value): ?string
  */
 function allAlnum(iterable $value): iterable
 {
-    Assert::allAlnum($value);
-
-    return $value;
+    return Assert::allAlnum($value);
 }
 
 /**
@@ -45,7 +39,5 @@ function allAlnum(iterable $value): iterable
  */
 function allNullOrAlnum(iterable $value): iterable
 {
-    Assert::allNullOrAlnum($value);
-
-    return $value;
+    return Assert::allNullOrAlnum($value);
 }

--- a/tests/static-analysis/assert-alpha.php
+++ b/tests/static-analysis/assert-alpha.php
@@ -8,48 +8,32 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function alpha(mixed $value): mixed
 {
-    Assert::alpha($value);
-
-    return $value;
+    return Assert::alpha($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function nullOrAlpha(mixed $value): mixed
 {
-    Assert::nullOrAlpha($value);
-
-    return $value;
+    return Assert::nullOrAlpha($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allAlpha(mixed $value): mixed
 {
-    Assert::allAlpha($value);
-
-    return $value;
+    return Assert::allAlpha($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrAlpha(mixed $value): mixed
 {
-    Assert::allNullOrAlpha($value);
-
-    return $value;
+    return Assert::allNullOrAlpha($value);
 }

--- a/tests/static-analysis/assert-boolean.php
+++ b/tests/static-analysis/assert-boolean.php
@@ -8,48 +8,32 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function boolean(mixed $value): bool
 {
-    Assert::boolean($value);
-
-    return $value;
+    return Assert::boolean($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function nullOrBoolean(mixed $value): ?bool
 {
-    Assert::nullOrBoolean($value);
-
-    return $value;
+    return Assert::nullOrBoolean($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allBoolean(mixed $value): iterable
 {
-    Assert::allBoolean($value);
-
-    return $value;
+    return Assert::allBoolean($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrBoolean(mixed $value): iterable
 {
-    Assert::allNullOrBoolean($value);
-
-    return $value;
+    return Assert::allNullOrBoolean($value);
 }

--- a/tests/static-analysis/assert-classExists.php
+++ b/tests/static-analysis/assert-classExists.php
@@ -7,45 +7,37 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
- * @param mixed $value
+ * 
  *
  * @return class-string
  */
 function classExists(mixed $value): string
 {
-    Assert::classExists($value);
-
-    return $value;
+    return Assert::classExists($value);
 }
 
 /**
- * @param mixed $value
+ * 
  *
  * @return class-string|null
  */
 function nullOrClassExists(mixed $value): ?string
 {
-    Assert::nullOrClassExists($value);
-
-    return $value;
+    return Assert::nullOrClassExists($value);
 }
 
 /**
- * @param mixed $value
+ * 
  */
 function allClassExists(mixed $value): iterable
 {
-    Assert::allClassExists($value);
-
-    return $value;
+    return Assert::allClassExists($value);
 }
 
 /**
- * @param mixed $value
+ * 
  */
 function allNullOrClassExists(mixed $value): iterable
 {
-    Assert::allNullOrClassExists($value);
-
-    return $value;
+    return Assert::allNullOrClassExists($value);
 }

--- a/tests/static-analysis/assert-contains.php
+++ b/tests/static-analysis/assert-contains.php
@@ -11,9 +11,7 @@ use Webmozart\Assert\Assert;
  */
 function contains(string $value, string $subString): string
 {
-    Assert::contains($value, $subString);
-
-    return $value;
+    return Assert::contains($value, $subString);
 }
 
 /**
@@ -21,9 +19,7 @@ function contains(string $value, string $subString): string
  */
 function nullOrContains(?string $value, string $subString): ?string
 {
-    Assert::nullOrContains($value, $subString);
-
-    return $value;
+    return Assert::nullOrContains($value, $subString);
 }
 
 /**
@@ -33,9 +29,7 @@ function nullOrContains(?string $value, string $subString): ?string
  */
 function allContains(iterable $value, string $subString): iterable
 {
-    Assert::allContains($value, $subString);
-
-    return $value;
+    return Assert::allContains($value, $subString);
 }
 
 /**
@@ -45,7 +39,5 @@ function allContains(iterable $value, string $subString): iterable
  */
 function allNullOrContains(iterable $value, string $subString): iterable
 {
-    Assert::allNullOrContains($value, $subString);
-
-    return $value;
+    return Assert::allNullOrContains($value, $subString);
 }

--- a/tests/static-analysis/assert-count.php
+++ b/tests/static-analysis/assert-count.php
@@ -12,9 +12,7 @@ use Webmozart\Assert\Assert;
  */
 function count(Countable|array $value, int $number): Countable|array
 {
-    Assert::count($value, $number);
-
-    return $value;
+    return Assert::count($value, $number);
 }
 
 /**
@@ -22,9 +20,7 @@ function count(Countable|array $value, int $number): Countable|array
  */
 function nullOrCount(Countable|array|null $value, int $number): Countable|array|null
 {
-    Assert::nullOrCount($value, $number);
-
-    return $value;
+    return Assert::nullOrCount($value, $number);
 }
 
 /**
@@ -32,9 +28,7 @@ function nullOrCount(Countable|array|null $value, int $number): Countable|array|
  */
 function allCount(iterable $value, int $number): iterable
 {
-    Assert::allCount($value, $number);
-
-    return $value;
+    return Assert::allCount($value, $number);
 }
 
 /**
@@ -42,7 +36,5 @@ function allCount(iterable $value, int $number): iterable
  */
 function allNullOrCount(iterable $value, int $number): iterable
 {
-    Assert::allCount($value, $number);
-
-    return $value;
+    return Assert::allCount($value, $number);
 }

--- a/tests/static-analysis/assert-countBetween.php
+++ b/tests/static-analysis/assert-countBetween.php
@@ -12,7 +12,7 @@ use Webmozart\Assert\Assert;
  * @param int|float $min
  * @param int|float $max
  */
-function countBetween($value, $min, $max): Countable|array
+function countBetween(mixed $value, $min, $max): Countable|array
 {
     return Assert::countBetween($value, $min, $max);
 }
@@ -22,7 +22,7 @@ function countBetween($value, $min, $max): Countable|array
  * @param int|float $min
  * @param int|float $max
  */
-function nullOrCountBetween($value, $min, $max): Countable|array|null
+function nullOrCountBetween(mixed $value, $min, $max): Countable|array|null
 {
     return Assert::nullOrCountBetween($value, $min, $max);
 }

--- a/tests/static-analysis/assert-countBetween.php
+++ b/tests/static-analysis/assert-countBetween.php
@@ -14,9 +14,7 @@ use Webmozart\Assert\Assert;
  */
 function countBetween($value, $min, $max): Countable|array
 {
-    Assert::countBetween($value, $min, $max);
-
-    return $value;
+    return Assert::countBetween($value, $min, $max);
 }
 
 /**
@@ -26,9 +24,7 @@ function countBetween($value, $min, $max): Countable|array
  */
 function nullOrCountBetween($value, $min, $max): Countable|array|null
 {
-    Assert::nullOrCountBetween($value, $min, $max);
-
-    return $value;
+    return Assert::nullOrCountBetween($value, $min, $max);
 }
 
 /**
@@ -38,9 +34,7 @@ function nullOrCountBetween($value, $min, $max): Countable|array|null
  */
 function allCountBetween(iterable $value, $min, $max): iterable
 {
-    Assert::allCountBetween($value, $min, $max);
-
-    return $value;
+    return Assert::allCountBetween($value, $min, $max);
 }
 
 /**
@@ -50,7 +44,5 @@ function allCountBetween(iterable $value, $min, $max): iterable
  */
 function allNullOrCountBetween(iterable $value, $min, $max): iterable
 {
-    Assert::allNullOrCountBetween($value, $min, $max);
-
-    return $value;
+    return Assert::allNullOrCountBetween($value, $min, $max);
 }

--- a/tests/static-analysis/assert-digits.php
+++ b/tests/static-analysis/assert-digits.php
@@ -11,9 +11,7 @@ use Webmozart\Assert\Assert;
  */
 function digits(string $value): string
 {
-    Assert::digits($value);
-
-    return $value;
+    return Assert::digits($value);
 }
 
 /**
@@ -21,9 +19,7 @@ function digits(string $value): string
  */
 function nullOrDigits(?string $value): ?string
 {
-    Assert::nullOrDigits($value);
-
-    return $value;
+    return Assert::nullOrDigits($value);
 }
 
 /**
@@ -33,9 +29,7 @@ function nullOrDigits(?string $value): ?string
  */
 function allDigits(iterable $value): iterable
 {
-    Assert::allDigits($value);
-
-    return $value;
+    return Assert::allDigits($value);
 }
 
 /**
@@ -45,7 +39,5 @@ function allDigits(iterable $value): iterable
  */
 function allNullOrDigits(iterable $value): iterable
 {
-    Assert::allNullOrDigits($value);
-
-    return $value;
+    return Assert::allNullOrDigits($value);
 }

--- a/tests/static-analysis/assert-directory.php
+++ b/tests/static-analysis/assert-directory.php
@@ -7,41 +7,33 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
- * @param mixed $value
+ * 
  */
 function directory(mixed $value): mixed
 {
-    Assert::directory($value);
-
-    return $value;
+    return Assert::directory($value);
 }
 
 /**
- * @param mixed $value
+ * 
  */
 function nullOrDirectory(mixed $value): mixed
 {
-    Assert::nullOrDirectory($value);
-
-    return $value;
+    return Assert::nullOrDirectory($value);
 }
 
 /**
- * @param mixed $value
+ * 
  */
 function allDirectory(mixed $value): mixed
 {
-    Assert::allDirectory($value);
-
-    return $value;
+    return Assert::allDirectory($value);
 }
 
 /**
- * @param mixed $value
+ * 
  */
 function allNullOrDirectory(mixed $value): mixed
 {
-    Assert::allNullOrDirectory($value);
-
-    return $value;
+    return Assert::allNullOrDirectory($value);
 }

--- a/tests/static-analysis/assert-email.php
+++ b/tests/static-analysis/assert-email.php
@@ -6,42 +6,28 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 
 use Webmozart\Assert\Assert;
 
-/**
- * @param mixed $value
- */
-function email(mixed $value): mixed
+function email(mixed $value): string
 {
-    Assert::email($value);
+    return Assert::email($value);
+}
 
-    return $value;
+function nullOrEmail(mixed $value): ?string
+{
+    return Assert::nullOrEmail($value);
 }
 
 /**
- * @param mixed $value
+ * @return iterable<string>
  */
-function nullOrEmail(mixed $value): mixed
+function allEmail(mixed $value): iterable
 {
-    Assert::nullOrEmail($value);
-
-    return $value;
+    return Assert::allEmail($value);
 }
 
 /**
- * @param mixed $value
+ * @return iterable<string|null>
  */
-function allEmail(mixed $value): mixed
+function allNullOrEmail(mixed $value): iterable
 {
-    Assert::allEmail($value);
-
-    return $value;
-}
-
-/**
- * @param mixed $value
- */
-function allNullOrEmail(mixed $value): mixed
-{
-    Assert::allNullOrEmail($value);
-
-    return $value;
+    return Assert::allNullOrEmail($value);
 }

--- a/tests/static-analysis/assert-email.php
+++ b/tests/static-analysis/assert-email.php
@@ -6,17 +6,18 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 
 use Webmozart\Assert\Assert;
 
-function email(mixed $value): string
+function email(string $value): string
 {
     return Assert::email($value);
 }
 
-function nullOrEmail(mixed $value): ?string
+function nullOrEmail(?string $value): ?string
 {
     return Assert::nullOrEmail($value);
 }
 
 /**
+ * @param iterable<string> $value
  * @return iterable<string>
  */
 function allEmail(mixed $value): iterable
@@ -25,6 +26,7 @@ function allEmail(mixed $value): iterable
 }
 
 /**
+ * @param iterable<string|null> $value
  * @return iterable<string|null>
  */
 function allNullOrEmail(mixed $value): iterable

--- a/tests/static-analysis/assert-endsWith.php
+++ b/tests/static-analysis/assert-endsWith.php
@@ -11,9 +11,7 @@ use Webmozart\Assert\Assert;
  */
 function endsWith(string $value, string $suffix): string
 {
-    Assert::endsWith($value, $suffix);
-
-    return $value;
+    return Assert::endsWith($value, $suffix);
 }
 
 /**
@@ -21,9 +19,7 @@ function endsWith(string $value, string $suffix): string
  */
 function nullOrEndsWith(?string $value, string $suffix): ?string
 {
-    Assert::nullOrEndsWith($value, $suffix);
-
-    return $value;
+    return Assert::nullOrEndsWith($value, $suffix);
 }
 
 /**
@@ -33,9 +29,7 @@ function nullOrEndsWith(?string $value, string $suffix): ?string
  */
 function allEndsWith(iterable $value, string $suffix): iterable
 {
-    Assert::allEndsWith($value, $suffix);
-
-    return $value;
+    return Assert::allEndsWith($value, $suffix);
 }
 
 /**
@@ -45,7 +39,5 @@ function allEndsWith(iterable $value, string $suffix): iterable
  */
 function allNullOrEndsWith(iterable $value, string $suffix): iterable
 {
-    Assert::allNullOrEndsWith($value, $suffix);
-
-    return $value;
+    return Assert::allNullOrEndsWith($value, $suffix);
 }

--- a/tests/static-analysis/assert-eq.php
+++ b/tests/static-analysis/assert-eq.php
@@ -7,45 +7,37 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
- * @param mixed $value
+ * 
  * @param mixed $expect
  */
 function eq($value, $expect): mixed
 {
-    Assert::eq($value, $expect);
-
-    return $value;
+    return Assert::eq($value, $expect);
 }
 
 /**
- * @param mixed $value
+ * 
  * @param mixed $expect
  */
 function nullOrEq($value, $expect): mixed
 {
-    Assert::nullOrEq($value, $expect);
-
-    return $value;
+    return Assert::nullOrEq($value, $expect);
 }
 
 /**
- * @param mixed $value
+ * 
  * @param mixed $expect
  */
 function allEq($value, $expect): mixed
 {
-    Assert::allEq($value, $expect);
-
-    return $value;
+    return Assert::allEq($value, $expect);
 }
 
 /**
- * @param mixed $value
+ * 
  * @param mixed $expect
  */
 function allNullOrEq($value, $expect): mixed
 {
-    Assert::allNullOrEq($value, $expect);
-
-    return $value;
+    return Assert::allNullOrEq($value, $expect);
 }

--- a/tests/static-analysis/assert-eq.php
+++ b/tests/static-analysis/assert-eq.php
@@ -10,7 +10,7 @@ use Webmozart\Assert\Assert;
  * 
  * @param mixed $expect
  */
-function eq($value, $expect): mixed
+function eq(mixed $value, mixed $expect): mixed
 {
     return Assert::eq($value, $expect);
 }
@@ -19,7 +19,7 @@ function eq($value, $expect): mixed
  * 
  * @param mixed $expect
  */
-function nullOrEq($value, $expect): mixed
+function nullOrEq(mixed $value, mixed $expect): mixed
 {
     return Assert::nullOrEq($value, $expect);
 }
@@ -28,7 +28,7 @@ function nullOrEq($value, $expect): mixed
  * 
  * @param mixed $expect
  */
-function allEq($value, $expect): mixed
+function allEq(mixed $value, mixed $expect): mixed
 {
     return Assert::allEq($value, $expect);
 }
@@ -37,7 +37,7 @@ function allEq($value, $expect): mixed
  * 
  * @param mixed $expect
  */
-function allNullOrEq($value, $expect): mixed
+function allNullOrEq(mixed $value, mixed $expect): mixed
 {
     return Assert::allNullOrEq($value, $expect);
 }

--- a/tests/static-analysis/assert-false.php
+++ b/tests/static-analysis/assert-false.php
@@ -9,51 +9,35 @@ use Webmozart\Assert\Assert;
 /**
  * @psalm-pure
  *
- * @param mixed $value
- *
  * @return false
  */
 function false(mixed $value): bool
 {
-    Assert::false($value);
-
-    return $value;
+    return Assert::false($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  *
  * @return null|false
  */
 function nullOrFalse(mixed $value): ?bool
 {
-    Assert::nullOrFalse($value);
-
-    return $value;
+    return Assert::nullOrFalse($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allFalse(mixed $value): iterable
 {
-    Assert::allFalse($value);
-
-    return $value;
+    return Assert::allFalse($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrFalse(mixed $value): iterable
 {
-    Assert::allFalse($value);
-
-    return $value;
+    return Assert::allFalse($value);
 }

--- a/tests/static-analysis/assert-file.php
+++ b/tests/static-analysis/assert-file.php
@@ -7,41 +7,33 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
- * @param mixed $value
+ * 
  */
 function file(mixed $value): mixed
 {
-    Assert::file($value);
-
-    return $value;
+    return Assert::file($value);
 }
 
 /**
- * @param mixed $value
+ * 
  */
 function nullOrFile(mixed $value): mixed
 {
-    Assert::nullOrFile($value);
-
-    return $value;
+    return Assert::nullOrFile($value);
 }
 
 /**
- * @param mixed $value
+ * 
  */
 function allFile(mixed $value): mixed
 {
-    Assert::allFile($value);
-
-    return $value;
+    return Assert::allFile($value);
 }
 
 /**
- * @param mixed $value
+ * 
  */
 function allNullOrFile(mixed $value): mixed
 {
-    Assert::allNullOrFile($value);
-
-    return $value;
+    return Assert::allNullOrFile($value);
 }

--- a/tests/static-analysis/assert-fileExists.php
+++ b/tests/static-analysis/assert-fileExists.php
@@ -7,41 +7,33 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
- * @param mixed $value
+ * 
  */
 function fileExists(mixed $value): mixed
 {
-    Assert::fileExists($value);
-
-    return $value;
+    return Assert::fileExists($value);
 }
 
 /**
- * @param mixed $value
+ * 
  */
 function nullOrFileExists(mixed $value): mixed
 {
-    Assert::nullOrFileExists($value);
-
-    return $value;
+    return Assert::nullOrFileExists($value);
 }
 
 /**
- * @param mixed $value
+ * 
  */
 function allFileExists(mixed $value): mixed
 {
-    Assert::allFileExists($value);
-
-    return $value;
+    return Assert::allFileExists($value);
 }
 
 /**
- * @param mixed $value
+ * 
  */
 function allNullOrFileExists(mixed $value): mixed
 {
-    Assert::allNullOrFileExists($value);
-
-    return $value;
+    return Assert::allNullOrFileExists($value);
 }

--- a/tests/static-analysis/assert-float.php
+++ b/tests/static-analysis/assert-float.php
@@ -8,48 +8,32 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function float(mixed $value): float
 {
-    Assert::float($value);
-
-    return $value;
+    return Assert::float($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function nullOrFloat(mixed $value): ?float
 {
-    Assert::nullOrFloat($value);
-
-    return $value;
+    return Assert::nullOrFloat($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allFloat(mixed $value): iterable
 {
-    Assert::allFloat($value);
-
-    return $value;
+    return Assert::allFloat($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrFloat(mixed $value): iterable
 {
-    Assert::allNullOrFloat($value);
-
-    return $value;
+    return Assert::allNullOrFloat($value);
 }

--- a/tests/static-analysis/assert-greaterThan.php
+++ b/tests/static-analysis/assert-greaterThan.php
@@ -10,7 +10,7 @@ use Webmozart\Assert\Assert;
  * @psalm-pure
  * @param mixed $limit
  */
-function greaterThan($value, $limit): mixed
+function greaterThan(mixed $value, $limit): mixed
 {
     return Assert::greaterThan($value, $limit);
 }
@@ -19,7 +19,7 @@ function greaterThan($value, $limit): mixed
  * @psalm-pure
  * @param mixed $limit
  */
-function nullOrGreaterThan($value, $limit): mixed
+function nullOrGreaterThan(mixed $value, mixed $limit): mixed
 {
     return Assert::nullOrGreaterThan($value, $limit);
 }
@@ -28,7 +28,7 @@ function nullOrGreaterThan($value, $limit): mixed
  * @psalm-pure
  * @param mixed $limit
  */
-function allGreaterThan($value, $limit): mixed
+function allGreaterThan(mixed $value, mixed $limit): mixed
 {
     return Assert::allGreaterThan($value, $limit);
 }
@@ -37,7 +37,7 @@ function allGreaterThan($value, $limit): mixed
  * @psalm-pure
  * @param mixed $limit
  */
-function allNullOrGreaterThan($value, $limit): mixed
+function allNullOrGreaterThan(mixed $value, mixed $limit): mixed
 {
     return Assert::allNullOrGreaterThan($value, $limit);
 }

--- a/tests/static-analysis/assert-greaterThan.php
+++ b/tests/static-analysis/assert-greaterThan.php
@@ -8,52 +8,36 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $limit
  */
 function greaterThan($value, $limit): mixed
 {
-    Assert::greaterThan($value, $limit);
-
-    return $value;
+    return Assert::greaterThan($value, $limit);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $limit
  */
 function nullOrGreaterThan($value, $limit): mixed
 {
-    Assert::nullOrGreaterThan($value, $limit);
-
-    return $value;
+    return Assert::nullOrGreaterThan($value, $limit);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $limit
  */
 function allGreaterThan($value, $limit): mixed
 {
-    Assert::allGreaterThan($value, $limit);
-
-    return $value;
+    return Assert::allGreaterThan($value, $limit);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $limit
  */
 function allNullOrGreaterThan($value, $limit): mixed
 {
-    Assert::allNullOrGreaterThan($value, $limit);
-
-    return $value;
+    return Assert::allNullOrGreaterThan($value, $limit);
 }

--- a/tests/static-analysis/assert-greaterThanEq.php
+++ b/tests/static-analysis/assert-greaterThanEq.php
@@ -8,9 +8,8 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- * @param mixed $limit
  */
-function greaterThanEq($value, $limit): mixed
+function greaterThanEq(mixed $value, mixed $limit): mixed
 {
     return Assert::greaterThanEq($value, $limit);
 }
@@ -19,7 +18,7 @@ function greaterThanEq($value, $limit): mixed
  * @psalm-pure
  * @param mixed $limit
  */
-function nullOrGreaterThanEq($value, $limit): mixed
+function nullOrGreaterThanEq(mixed $value, mixed $limit): mixed
 {
     return Assert::nullOrGreaterThanEq($value, $limit);
 }
@@ -28,7 +27,7 @@ function nullOrGreaterThanEq($value, $limit): mixed
  * @psalm-pure
  * @param mixed $limit
  */
-function allGreaterThanEq($value, $limit): mixed
+function allGreaterThanEq(mixed $value, mixed $limit): mixed
 {
     return Assert::allGreaterThanEq($value, $limit);
 }
@@ -37,7 +36,7 @@ function allGreaterThanEq($value, $limit): mixed
  * @psalm-pure
  * @param mixed $limit
  */
-function allNullOrGreaterThanEq($value, $limit): mixed
+function allNullOrGreaterThanEq(mixed $value, mixed $limit): mixed
 {
     return Assert::allNullOrGreaterThanEq($value, $limit);
 }

--- a/tests/static-analysis/assert-greaterThanEq.php
+++ b/tests/static-analysis/assert-greaterThanEq.php
@@ -8,52 +8,36 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $limit
  */
 function greaterThanEq($value, $limit): mixed
 {
-    Assert::greaterThanEq($value, $limit);
-
-    return $value;
+    return Assert::greaterThanEq($value, $limit);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $limit
  */
 function nullOrGreaterThanEq($value, $limit): mixed
 {
-    Assert::nullOrGreaterThanEq($value, $limit);
-
-    return $value;
+    return Assert::nullOrGreaterThanEq($value, $limit);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $limit
  */
 function allGreaterThanEq($value, $limit): mixed
 {
-    Assert::allGreaterThanEq($value, $limit);
-
-    return $value;
+    return Assert::allGreaterThanEq($value, $limit);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $limit
  */
 function allNullOrGreaterThanEq($value, $limit): mixed
 {
-    Assert::allNullOrGreaterThanEq($value, $limit);
-
-    return $value;
+    return Assert::allNullOrGreaterThanEq($value, $limit);
 }

--- a/tests/static-analysis/assert-implementsInterface.php
+++ b/tests/static-analysis/assert-implementsInterface.php
@@ -10,51 +10,35 @@ use Webmozart\Assert\Assert;
 /**
  * @psalm-pure
  *
- * @param mixed $value
- *
  * @return Serializable|class-string<Serializable>
  */
 function implementsInterface(mixed $value)
 {
-    Assert::implementsInterface($value, Serializable::class);
-
-    return $value;
+    return Assert::implementsInterface($value, Serializable::class);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  *
  * @return Serializable|class-string<Serializable>|null
  */
 function nullOrImplementsInterface(mixed $value)
 {
-    Assert::nullOrImplementsInterface($value, Serializable::class);
-
-    return $value;
+    return Assert::nullOrImplementsInterface($value, Serializable::class);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allImplementsInterface(mixed $value): iterable
 {
-    Assert::allImplementsInterface($value, Serializable::class);
-
-    return $value;
+    return Assert::allImplementsInterface($value, Serializable::class);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrImplementsInterface(mixed $value): iterable
 {
-    Assert::allNullOrImplementsInterface($value, Serializable::class);
-
-    return $value;
+    return Assert::allNullOrImplementsInterface($value, Serializable::class);
 }

--- a/tests/static-analysis/assert-inArray.php
+++ b/tests/static-analysis/assert-inArray.php
@@ -9,7 +9,7 @@ use Webmozart\Assert\Assert;
 /**
  * @psalm-pure
  */
-function inArray($value, array $values): mixed
+function inArray(mixed $value, array $values): mixed
 {
     return Assert::inArray($value, $values);
 }
@@ -17,7 +17,7 @@ function inArray($value, array $values): mixed
 /**
  * @psalm-pure
  */
-function nullOrInArray($value, array $values): mixed
+function nullOrInArray(mixed $value, array $values): mixed
 {
     return Assert::nullOrInArray($value, $values);
 }
@@ -25,7 +25,7 @@ function nullOrInArray($value, array $values): mixed
 /**
  * @psalm-pure
  */
-function allInArray($value, array $values): mixed
+function allInArray(mixed $value, array $values): mixed
 {
     return Assert::allInArray($value, $values);
 }
@@ -33,7 +33,7 @@ function allInArray($value, array $values): mixed
 /**
  * @psalm-pure
  */
-function allNullOrInArray($value, array $values): mixed
+function allNullOrInArray(mixed $value, array $values): mixed
 {
     return Assert::allNullOrInArray($value, $values);
 }

--- a/tests/static-analysis/assert-inArray.php
+++ b/tests/static-analysis/assert-inArray.php
@@ -8,48 +8,32 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function inArray($value, array $values): mixed
 {
-    Assert::inArray($value, $values);
-
-    return $value;
+    return Assert::inArray($value, $values);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function nullOrInArray($value, array $values): mixed
 {
-    Assert::nullOrInArray($value, $values);
-
-    return $value;
+    return Assert::nullOrInArray($value, $values);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allInArray($value, array $values): mixed
 {
-    Assert::allInArray($value, $values);
-
-    return $value;
+    return Assert::allInArray($value, $values);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrInArray($value, array $values): mixed
 {
-    Assert::allNullOrInArray($value, $values);
-
-    return $value;
+    return Assert::allNullOrInArray($value, $values);
 }

--- a/tests/static-analysis/assert-integer.php
+++ b/tests/static-analysis/assert-integer.php
@@ -8,48 +8,32 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function integer(mixed $value): int
 {
-    Assert::integer($value);
-
-    return $value;
+    return Assert::integer($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function nullOrInteger(mixed $value): ?int
 {
-    Assert::nullOrInteger($value);
-
-    return $value;
+    return Assert::nullOrInteger($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allInteger(mixed $value): iterable
 {
-    Assert::allInteger($value);
-
-    return $value;
+    return Assert::allInteger($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrInteger(mixed $value): iterable
 {
-    Assert::allNullOrInteger($value);
-
-    return $value;
+    return Assert::allNullOrInteger($value);
 }

--- a/tests/static-analysis/assert-integerish.php
+++ b/tests/static-analysis/assert-integerish.php
@@ -9,51 +9,35 @@ use Webmozart\Assert\Assert;
 /**
  * @psalm-pure
  *
- * @param mixed $value
- *
  * @return numeric
  */
 function integerish(mixed $value)
 {
-    Assert::integerish($value);
-
-    return $value;
+    return Assert::integerish($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  *
  * @return null|numeric
  */
 function nullOrIntegerish(mixed $value)
 {
-    Assert::nullOrIntegerish($value);
-
-    return $value;
+    return Assert::nullOrIntegerish($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allIntegerish(mixed $value): iterable
 {
-    Assert::allIntegerish($value);
-
-    return $value;
+    return Assert::allIntegerish($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrIntegerish(mixed $value): iterable
 {
-    Assert::allNullOrIntegerish($value);
-
-    return $value;
+    return Assert::allNullOrIntegerish($value);
 }

--- a/tests/static-analysis/assert-interfaceExists.php
+++ b/tests/static-analysis/assert-interfaceExists.php
@@ -7,45 +7,37 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
- * @param mixed $value
+ * 
  *
  * @return class-string
  */
 function interfaceExists(mixed $value): string
 {
-    Assert::interfaceExists($value);
-
-    return $value;
+    return Assert::interfaceExists($value);
 }
 
 /**
- * @param mixed $value
+ * 
  *
  * @return null|class-string
  */
 function nullOrInterfaceExists(mixed $value): ?string
 {
-    Assert::nullOrInterfaceExists($value);
-
-    return $value;
+    return Assert::nullOrInterfaceExists($value);
 }
 
 /**
- * @param mixed $value
+ * 
  */
 function allInterfaceExists(mixed $value): iterable
 {
-    Assert::allInterfaceExists($value);
-
-    return $value;
+    return Assert::allInterfaceExists($value);
 }
 
 /**
- * @param mixed $value
+ * 
  */
 function allNullOrInterfaceExists(mixed $value): iterable
 {
-    Assert::allNullOrInterfaceExists($value);
-
-    return $value;
+    return Assert::allNullOrInterfaceExists($value);
 }

--- a/tests/static-analysis/assert-ip.php
+++ b/tests/static-analysis/assert-ip.php
@@ -6,42 +6,28 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 
 use Webmozart\Assert\Assert;
 
-/**
- * @param mixed $value
- */
-function ip(mixed $value): mixed
+function ip(string $value): string
 {
-    Assert::ip($value);
+    return Assert::ip($value);
+}
 
-    return $value;
+function nullOrIp(?string $value): ?string
+{
+    return Assert::nullOrIp($value);
 }
 
 /**
- * @param mixed $value
+ * @param iterable<string> $value
  */
-function nullOrIp(mixed $value): mixed
+function allIp(iterable $value): iterable
 {
-    Assert::nullOrIp($value);
-
-    return $value;
+    return Assert::allIp($value);
 }
 
 /**
- * @param mixed $value
+ * @param iterable<string|null> $value
  */
-function allIp(mixed $value): mixed
+function allNullOrIp(iterable $value): iterable
 {
-    Assert::allIp($value);
-
-    return $value;
-}
-
-/**
- * @param mixed $value
- */
-function allNullOrIp(mixed $value): mixed
-{
-    Assert::allNullOrIp($value);
-
-    return $value;
+    return Assert::allNullOrIp($value);
 }

--- a/tests/static-analysis/assert-ipv4.php
+++ b/tests/static-analysis/assert-ipv4.php
@@ -6,42 +6,28 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 
 use Webmozart\Assert\Assert;
 
-/**
- * @param mixed $value
- */
-function ipv4($value): mixed
+function ipv4(string $value): string
 {
-    Assert::ipv4($value);
+    return Assert::ipv4($value);
+}
 
-    return $value;
+function nullOrIpv4(?string $value): ?string
+{
+    return Assert::nullOrIpv4($value);
 }
 
 /**
- * @param mixed $value
+ * @param iterable<string> $value
  */
-function nullOrIpv4($value): mixed
+function allIpv4(iterable $value): iterable
 {
-    Assert::nullOrIpv4($value);
-
-    return $value;
+    return Assert::allIpv4($value);
 }
 
 /**
- * @param mixed $value
+ * @param iterable<string|null> $value
  */
-function allIpv4($value): mixed
+function allNullOrIpv4(iterable $value): iterable
 {
-    Assert::allIpv4($value);
-
-    return $value;
-}
-
-/**
- * @param mixed $value
- */
-function allNullOrIpv4($value): mixed
-{
-    Assert::allNullOrIpv4($value);
-
-    return $value;
+    return Assert::allNullOrIpv4($value);
 }

--- a/tests/static-analysis/assert-ipv6.php
+++ b/tests/static-analysis/assert-ipv6.php
@@ -6,42 +6,28 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 
 use Webmozart\Assert\Assert;
 
-/**
- * @param mixed $value
- */
-function ipv6($value): mixed
+function ipv6(string $value): string
 {
-    Assert::ipv6($value);
+    return Assert::ipv6($value);
+}
 
-    return $value;
+function nullOrIpv6(?string $value): ?string
+{
+    return Assert::nullOrIpv6($value);
 }
 
 /**
- * @param mixed $value
+ * @param iterable<string> $value
  */
-function nullOrIpv6($value): mixed
+function allIpv6(iterable $value): iterable
 {
-    Assert::nullOrIpv6($value);
-
-    return $value;
+    return Assert::allIpv6($value);
 }
 
 /**
- * @param mixed $value
+ * @param iterable<string|null> $value
  */
-function allIpv6($value): mixed
+function allNullOrIpv6(iterable $value): iterable
 {
-    Assert::allIpv6($value);
-
-    return $value;
-}
-
-/**
- * @param mixed $value
- */
-function allNullOrIpv6($value): mixed
-{
-    Assert::allNullOrIpv6($value);
-
-    return $value;
+    return Assert::allNullOrIpv6($value);
 }

--- a/tests/static-analysis/assert-isAOf.php
+++ b/tests/static-analysis/assert-isAOf.php
@@ -16,9 +16,7 @@ use Webmozart\Assert\Assert;
  */
 function isAOf(mixed $value): mixed
 {
-    Assert::isAOf($value, Serializable::class);
-
-    return $value;
+    return Assert::isAOf($value, Serializable::class);
 }
 
 /**
@@ -30,9 +28,7 @@ function isAOf(mixed $value): mixed
  */
 function nullOrIsAOf(mixed $value): mixed
 {
-    Assert::nullOrIsAOf($value, Serializable::class);
-
-    return $value;
+    return Assert::nullOrIsAOf($value, Serializable::class);
 }
 
 /**
@@ -44,9 +40,7 @@ function nullOrIsAOf(mixed $value): mixed
  */
 function allIsAOf(mixed $value): iterable
 {
-    Assert::allIsAOf($value, Serializable::class);
-
-    return $value;
+    return Assert::allIsAOf($value, Serializable::class);
 }
 
 /**
@@ -58,7 +52,5 @@ function allIsAOf(mixed $value): iterable
  */
 function allNullOrIsAOf(mixed $value): iterable
 {
-    Assert::allNullOrIsAOf($value, Serializable::class);
-
-    return $value;
+    return Assert::allNullOrIsAOf($value, Serializable::class);
 }

--- a/tests/static-analysis/assert-isAnyOf.php
+++ b/tests/static-analysis/assert-isAnyOf.php
@@ -14,9 +14,7 @@ use Webmozart\Assert\Assert;
  */
 function isAnyOf($value, array $classes): object|string
 {
-    Assert::isAnyOf($value, $classes);
-
-    return $value;
+    return Assert::isAnyOf($value, $classes);
 }
 
 /**
@@ -27,9 +25,7 @@ function isAnyOf($value, array $classes): object|string
  */
 function nullOrIsAnyOf($value, array $classes): object|string|null
 {
-    Assert::nullOrIsAnyOf($value, $classes);
-
-    return $value;
+    return Assert::nullOrIsAnyOf($value, $classes);
 }
 
 /**
@@ -40,9 +36,7 @@ function nullOrIsAnyOf($value, array $classes): object|string|null
  */
 function allIsAnyOf($value, array $classes): iterable
 {
-    Assert::allIsAnyOf($value, $classes);
-
-    return $value;
+    return Assert::allIsAnyOf($value, $classes);
 }
 
 /**
@@ -53,7 +47,5 @@ function allIsAnyOf($value, array $classes): iterable
  */
 function allNullOrIsAnyOf($value, array $classes): iterable
 {
-    Assert::allNullOrIsAnyOf($value, $classes);
-
-    return $value;
+    return Assert::allNullOrIsAnyOf($value, $classes);
 }

--- a/tests/static-analysis/assert-isAnyOf.php
+++ b/tests/static-analysis/assert-isAnyOf.php
@@ -12,7 +12,7 @@ use Webmozart\Assert\Assert;
  * @param object|string $value
  * @param array<class-string> $classes
  */
-function isAnyOf($value, array $classes): object|string
+function isAnyOf(mixed $value, array $classes): object|string
 {
     return Assert::isAnyOf($value, $classes);
 }
@@ -23,7 +23,7 @@ function isAnyOf($value, array $classes): object|string
  * @param null|object|string $value
  * @param array<class-string> $classes
  */
-function nullOrIsAnyOf($value, array $classes): object|string|null
+function nullOrIsAnyOf(mixed $value, array $classes): object|string|null
 {
     return Assert::nullOrIsAnyOf($value, $classes);
 }
@@ -34,7 +34,7 @@ function nullOrIsAnyOf($value, array $classes): object|string|null
  * @param iterable<object|string> $value
  * @param array<class-string> $classes
  */
-function allIsAnyOf($value, array $classes): iterable
+function allIsAnyOf(mixed $value, array $classes): iterable
 {
     return Assert::allIsAnyOf($value, $classes);
 }
@@ -45,7 +45,7 @@ function allIsAnyOf($value, array $classes): iterable
  * @param iterable<object|string|null> $value
  * @param array<class-string> $classes
  */
-function allNullOrIsAnyOf($value, array $classes): iterable
+function allNullOrIsAnyOf(mixed $value, array $classes): iterable
 {
     return Assert::allNullOrIsAnyOf($value, $classes);
 }

--- a/tests/static-analysis/assert-isArray.php
+++ b/tests/static-analysis/assert-isArray.php
@@ -8,48 +8,32 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function isArray(mixed $value): array
 {
-    Assert::isArray($value);
-
-    return $value;
+    return Assert::isArray($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function nullOrIsArray(mixed $value): ?array
 {
-    Assert::nullOrIsArray($value);
-
-    return $value;
+    return Assert::nullOrIsArray($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allIsArray(mixed $value): iterable
 {
-    Assert::allIsArray($value);
-
-    return $value;
+    return Assert::allIsArray($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrIsArray(mixed $value): iterable
 {
-    Assert::allNullOrIsArray($value);
-
-    return $value;
+    return Assert::allNullOrIsArray($value);
 }

--- a/tests/static-analysis/assert-isArrayAccessible.php
+++ b/tests/static-analysis/assert-isArrayAccessible.php
@@ -9,48 +9,32 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function isArrayAccessible(mixed $value): array|ArrayAccess
 {
-    Assert::isArrayAccessible($value);
-
-    return $value;
+    return Assert::isArrayAccessible($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function nullOrIsArrayAccessible(mixed $value): array|ArrayAccess|null
 {
-    Assert::nullOrIsArrayAccessible($value);
-
-    return $value;
+    return Assert::nullOrIsArrayAccessible($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allIsArrayAccessible(mixed $value): iterable
 {
-    Assert::allIsArrayAccessible($value);
-
-    return $value;
+    return Assert::allIsArrayAccessible($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrIsArrayAccessible(mixed $value): iterable
 {
-    Assert::allNullOrIsArrayAccessible($value);
-
-    return $value;
+    return Assert::allNullOrIsArrayAccessible($value);
 }

--- a/tests/static-analysis/assert-isCallable.php
+++ b/tests/static-analysis/assert-isCallable.php
@@ -8,48 +8,32 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function isCallable(mixed $value): callable
 {
-    Assert::isCallable($value);
-
-    return $value;
+    return Assert::isCallable($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function nullOrIsCallable(mixed $value): ?callable
 {
-    Assert::nullOrIsCallable($value);
-
-    return $value;
+    return Assert::nullOrIsCallable($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allIsCallable(mixed $value): iterable
 {
-    Assert::allIsCallable($value);
-
-    return $value;
+    return Assert::allIsCallable($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrIsCallable(mixed $value): iterable
 {
-    Assert::allNullOrIsCallable($value);
-
-    return $value;
+    return Assert::allNullOrIsCallable($value);
 }

--- a/tests/static-analysis/assert-isCountable.php
+++ b/tests/static-analysis/assert-isCountable.php
@@ -4,57 +4,41 @@ declare(strict_types=1);
 
 namespace Webmozart\Assert\Tests\StaticAnalysis;
 
-use countable;
+use Countable;
 use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function isCountable(mixed $value): Countable
 {
-    Assert::isCountable($value);
-
-    return $value;
+    return Assert::isCountable($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function nullOrIsCountable(mixed $value): ?Countable
 {
-    Assert::nullOrIsCountable($value);
-
-    return $value;
+    return Assert::nullOrIsCountable($value);
 }
 
 /**
  * @psalm-pure
  *
- * @param mixed $value
- *
- * @return iterable<countable>
+ * @return iterable<Countable>
  */
 function allIsCountable(mixed $value)
 {
-    Assert::allIsCountable($value);
-
-    return $value;
+    return Assert::allIsCountable($value);
 }
 
 /**
  * @psalm-pure
  *
- * @param mixed $value
- *
- * @return iterable<countable|null>
+ * @return iterable<Countable|null>
  */
 function allNullOrIsCountable(mixed $value)
 {
-    Assert::allNullOrIsCountable($value);
-
-    return $value;
+    return Assert::allNullOrIsCountable($value);
 }

--- a/tests/static-analysis/assert-isEmpty.php
+++ b/tests/static-analysis/assert-isEmpty.php
@@ -11,9 +11,7 @@ use Webmozart\Assert\Assert;
  */
 function isEmptyNullableObject(?object $value): null
 {
-    Assert::isEmpty($value);
-
-    return $value;
+    return Assert::isEmpty($value);
 }
 
 /**
@@ -23,9 +21,7 @@ function isEmptyNullableObject(?object $value): null
  */
 function isEmptyString(string $value)
 {
-    Assert::isEmpty($value);
-
-    return $value;
+    return Assert::isEmpty($value);
 }
 
 /**
@@ -35,9 +31,7 @@ function isEmptyString(string $value)
  */
 function isEmptyInt(int $value)
 {
-    Assert::isEmpty($value);
-
-    return $value;
+    return Assert::isEmpty($value);
 }
 
 /**
@@ -47,9 +41,7 @@ function isEmptyInt(int $value)
  */
 function isEmptyBool(bool $value)
 {
-    Assert::isEmpty($value);
-
-    return $value;
+    return Assert::isEmpty($value);
 }
 
 /**
@@ -59,43 +51,31 @@ function isEmptyBool(bool $value)
  */
 function isEmptyArray(array $value)
 {
-    Assert::isEmpty($value);
-
-    return $value;
+    return Assert::isEmpty($value);
 }
 
 /**
  * @psalm-pure
  *
- * @return null|empty
+ * @return null
  */
-function nullOrIsEmpty(?object $value)
+function nullOrIsEmpty(?object $value): null
 {
-    Assert::nullOrIsEmpty($value);
-
-    return $value;
+    return Assert::nullOrIsEmpty($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allIsEmpty(mixed $value): iterable
 {
-    Assert::allIsEmpty($value);
-
-    return $value;
+    return Assert::allIsEmpty($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrIsEmpty(mixed $value): iterable
 {
-    Assert::allNullOrIsEmpty($value);
-
-    return $value;
+    return Assert::allNullOrIsEmpty($value);
 }

--- a/tests/static-analysis/assert-isInitialized.php
+++ b/tests/static-analysis/assert-isInitialized.php
@@ -8,12 +8,8 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param object $value
  */
 function isInitialized(mixed $value, string $property): object
 {
-    Assert::isInitialized($value, $property);
-
-    return $value;
+    return Assert::isInitialized($value, $property);
 }

--- a/tests/static-analysis/assert-isInstanceOf.php
+++ b/tests/static-analysis/assert-isInstanceOf.php
@@ -9,48 +9,32 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function isInstanceOf(mixed $value): Serializable
 {
-    Assert::isInstanceOf($value, Serializable::class);
-
-    return $value;
+    return Assert::isInstanceOf($value, Serializable::class);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function nullOrIsInstanceOf(mixed $value): ?Serializable
 {
-    Assert::nullOrIsInstanceOf($value, Serializable::class);
-
-    return $value;
+    return Assert::nullOrIsInstanceOf($value, Serializable::class);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allIsInstanceOf(mixed $value): iterable
 {
-    Assert::allIsInstanceOf($value, Serializable::class);
-
-    return $value;
+    return Assert::allIsInstanceOf($value, Serializable::class);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrIsInstanceOf(mixed $value): iterable
 {
-    Assert::allNullOrIsInstanceOf($value, Serializable::class);
-
-    return $value;
+    return Assert::allNullOrIsInstanceOf($value, Serializable::class);
 }

--- a/tests/static-analysis/assert-isInstanceOfAny.php
+++ b/tests/static-analysis/assert-isInstanceOfAny.php
@@ -7,45 +7,37 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
- * @param mixed $value
+ * @param object $value
  * @param array<class-string> $classes
  */
-function isInstanceOfAny($value, array $classes): mixed
+function isInstanceOfAny(object $value, array $classes): object
 {
-    Assert::isInstanceOfAny($value, $classes);
-
-    return $value;
+    return Assert::isInstanceOfAny($value, $classes);
 }
 
 /**
- * @param mixed $value
+ * @param object|null $value
  * @param array<class-string> $classes
  */
-function nullOrIsInstanceOfAny($value, array $classes): mixed
+function nullOrIsInstanceOfAny(?object $value, array $classes): ?object
 {
-    Assert::nullOrIsInstanceOfAny($value, $classes);
-
-    return $value;
+    return Assert::nullOrIsInstanceOfAny($value, $classes);
 }
 
 /**
- * @param mixed $value
+ * @param iterable<object> $value
  * @param array<class-string> $classes
  */
-function allIsInstanceOfAny($value, array $classes): mixed
+function allIsInstanceOfAny(iterable $value, array $classes): iterable
 {
-    Assert::allIsInstanceOfAny($value, $classes);
-
-    return $value;
+    return Assert::allIsInstanceOfAny($value, $classes);
 }
 
 /**
- * @param mixed $value
+ * @param iterable<object|null> $value
  * @param array<class-string> $classes
  */
-function allNullOrIsInstanceOfAny($value, array $classes): mixed
+function allNullOrIsInstanceOfAny(iterable $value, array $classes): iterable
 {
-    Assert::allNullOrIsInstanceOfAny($value, $classes);
-
-    return $value;
+    return Assert::allNullOrIsInstanceOfAny($value, $classes);
 }

--- a/tests/static-analysis/assert-isIterable.php
+++ b/tests/static-analysis/assert-isIterable.php
@@ -8,48 +8,32 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function isIterable(mixed $value): iterable
 {
-    Assert::isIterable($value);
-
-    return $value;
+    return Assert::isIterable($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function nullOrIsIterable(mixed $value): ?iterable
 {
-    Assert::nullOrIsIterable($value);
-
-    return $value;
+    return Assert::nullOrIsIterable($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allIsIterable(mixed $value): iterable
 {
-    Assert::allIsIterable($value);
-
-    return $value;
+    return Assert::allIsIterable($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrIsIterable(mixed $value): iterable
 {
-    Assert::allNullOrIsIterable($value);
-
-    return $value;
+    return Assert::allNullOrIsIterable($value);
 }

--- a/tests/static-analysis/assert-isList.php
+++ b/tests/static-analysis/assert-isList.php
@@ -10,15 +10,11 @@ use Webmozart\Assert\Assert;
 /**
  * @psalm-pure
  *
- * @param mixed $value
- *
  * @return list<mixed>
  */
 function isList(mixed $value): array
 {
-    Assert::isList($value);
-
-    return $value;
+    return Assert::isList($value);
 }
 
 /**
@@ -30,45 +26,31 @@ function isList(mixed $value): array
  */
 function isListWithKnownType(array $value): array
 {
-    Assert::isList($value);
-
-    return $value;
+    return Assert::isList($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  *
  * @return null|list<mixed>
  */
 function nullOrIsList(mixed $value): ?array
 {
-    Assert::nullOrIsList($value);
-
-    return $value;
+    return Assert::nullOrIsList($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allIsList(mixed $value): iterable
 {
-    Assert::allIsList($value);
-
-    return $value;
+    return Assert::allIsList($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrIsList(mixed $value): iterable
 {
-    Assert::allNullOrIsList($value);
-
-    return $value;
+    return Assert::allNullOrIsList($value);
 }

--- a/tests/static-analysis/assert-isMap.php
+++ b/tests/static-analysis/assert-isMap.php
@@ -10,15 +10,11 @@ use Webmozart\Assert\Assert;
 /**
  * @psalm-pure
  *
- * @param mixed $value
- *
  * @return array<string, mixed>
  */
 function isMap(mixed $value): array
 {
-    Assert::isMap($value);
-
-    return $value;
+    return Assert::isMap($value);
 }
 
 /**
@@ -32,38 +28,29 @@ function isMap(mixed $value): array
  */
 function isMapWithKnownType(array $value): array
 {
-    Assert::isMap($value);
-
-    return $value;
+    return Assert::isMap($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param array<int|string, mixed> $value
  *
  * @return array<empty, empty>
  */
-function isMapWithEmptyArray(array $value): array
+function isMapWithEmptyArray(): array
 {
-    Assert::isMap($value);
-    Assert::isEmpty($value);
+    $value = [];
 
-    return $value;
+    return Assert::isMap($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  *
  * @return null|array<string, mixed>
  */
 function nullOrIsMap(mixed $value): ?array
 {
-    Assert::nullOrIsMap($value);
-
-    return $value;
+    return Assert::nullOrIsMap($value);
 }
 
 /**
@@ -73,9 +60,7 @@ function nullOrIsMap(mixed $value): ?array
  */
 function allIsMap(iterable $value): iterable
 {
-    Assert::allIsMap($value);
-
-    return $value;
+    return Assert::allIsMap($value);
 }
 
 /**
@@ -85,7 +70,5 @@ function allIsMap(iterable $value): iterable
  */
 function allNullOrIsMap(iterable $value): iterable
 {
-    Assert::allNullOrIsMap($value);
-
-    return $value;
+    return Assert::allNullOrIsMap($value);
 }

--- a/tests/static-analysis/assert-isNonEmptyList.php
+++ b/tests/static-analysis/assert-isNonEmptyList.php
@@ -9,63 +9,45 @@ use Webmozart\Assert\Assert;
 /**
  * @psalm-pure
  *
- * @param mixed $value
- *
  * @return non-empty-list<mixed>
  */
 function isNonEmptyList(mixed $value): array
 {
-    Assert::isNonEmptyList($value);
-
-    return $value;
-}
-
-/**
- * @psalm-pure
- */
-function isNonEmptyListWithRange(): mixed
-{
-    $value = range(1, 100);
-
-    Assert::isNonEmptyList($value);
-
-    return $value[0];
+    return Assert::isNonEmptyList($value);
 }
 
 /**
  * @psalm-pure
  *
- * @param mixed $value
+ * @param array<int> $value
+ */
+function isNonEmptyListWithRange(array $value): array
+{
+    return Assert::isNonEmptyList($value);
+}
+
+/**
+ * @psalm-pure
  *
  * @return null|non-empty-list<mixed>
  */
 function nullOrIsNonEmptyList(mixed $value): ?array
 {
-    Assert::nullOrIsNonEmptyList($value);
-
-    return $value;
+    return Assert::nullOrIsNonEmptyList($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allIsNonEmptyList(mixed $value): iterable
 {
-    Assert::allIsNonEmptyList($value);
-
-    return $value;
+    return Assert::allIsNonEmptyList($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrIsNonEmptyList(mixed $value): iterable
 {
-    Assert::allNullOrIsNonEmptyList($value);
-
-    return $value;
+    return Assert::allNullOrIsNonEmptyList($value);
 }

--- a/tests/static-analysis/assert-isNonEmptyMap.php
+++ b/tests/static-analysis/assert-isNonEmptyMap.php
@@ -10,15 +10,13 @@ use Webmozart\Assert\Assert;
 /**
  * @psalm-pure
  *
- * @param mixed $value
+ * @param array<string, mixed> $value
  *
  * @return non-empty-array<string, mixed>
  */
-function isNonEmptyMap(mixed $value): array
+function isNonEmptyMap(array $value): array
 {
-    Assert::isNonEmptyMap($value);
-
-    return $value;
+    return Assert::isNonEmptyMap($value);
 }
 
 /**
@@ -26,49 +24,41 @@ function isNonEmptyMap(mixed $value): array
  *
  * @psalm-pure
  *
- * @param array<int|string, stdClass> $value
+ * @param array<string, stdClass> $value
  *
- * @return array<string, stdClass>
+ * @return non-empty-array<string, stdClass>
  */
 function isNonEmptyMapWithKnownType(array $value): array
 {
-    Assert::isNonEmptyMap($value);
-
-    return $value;
+    return Assert::isNonEmptyMap($value);
 }
 
 /**
  * @psalm-pure
  *
- * @param mixed $value
+ * @param array<string, mixed>|null $value
  */
-function nullOrIsNonEmptyMap(mixed $value): mixed
+function nullOrIsNonEmptyMap(?array $value): ?array
 {
-    Assert::nullOrIsNonEmptyMap($value);
-
-    return $value;
+    return Assert::nullOrIsNonEmptyMap($value);
 }
 
 /**
  * @psalm-pure
  *
- * @param iterable<mixed|array<mixed>> $value
+ * @param iterable<array<string, mixed>> $value
  */
 function allIsNonEmptyMap(iterable $value): iterable
 {
-    Assert::allIsNonEmptyMap($value);
-
-    return $value;
+    return Assert::allIsNonEmptyMap($value);
 }
 
 /**
  * @psalm-pure
  *
- * @param iterable<mixed|array<mixed>> $value
+ * @param iterable<array<string, mixed>|null> $value
  */
 function allNullOrIsNonEmptyMap(iterable $value): iterable
 {
-    Assert::allNullOrIsNonEmptyMap($value);
-
-    return $value;
+    return Assert::allNullOrIsNonEmptyMap($value);
 }

--- a/tests/static-analysis/assert-isNotA.php
+++ b/tests/static-analysis/assert-isNotA.php
@@ -5,19 +5,16 @@ declare(strict_types=1);
 namespace Webmozart\Assert\Tests\StaticAnalysis;
 
 use DateTime;
-use stdClass;
 use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
  *
- * @param stdClass|DateTime $value
+ * @psalm-return object|class-string
  */
-function isNotA(object $value): stdClass
+function isNotA(mixed $value): object|string
 {
-    Assert::isNotA($value, DateTime::class);
-
-    return $value;
+    return Assert::isNotA($value, DateTime::class);
 }
 
 /**
@@ -28,9 +25,7 @@ function isNotA(object $value): stdClass
  */
 function nullOrIsNotA($value, $class): object|string|null
 {
-    Assert::nullOrIsNotA($value, $class);
-
-    return $value;
+    return Assert::nullOrIsNotA($value, $class);
 }
 
 /**
@@ -41,9 +36,7 @@ function nullOrIsNotA($value, $class): object|string|null
  */
 function allIsNotA($value, $class): iterable
 {
-    Assert::allIsNotA($value, $class);
-
-    return $value;
+    return Assert::allIsNotA($value, $class);
 }
 
 /**
@@ -54,7 +47,5 @@ function allIsNotA($value, $class): iterable
  */
 function allNullOrIsNotA($value, $class): iterable
 {
-    Assert::allNullOrIsNotA($value, $class);
-
-    return $value;
+    return Assert::allNullOrIsNotA($value, $class);
 }

--- a/tests/static-analysis/assert-isNotA.php
+++ b/tests/static-analysis/assert-isNotA.php
@@ -23,7 +23,7 @@ function isNotA(mixed $value): object|string
  * @param null|object|string $value
  * @param class-string $class
  */
-function nullOrIsNotA($value, $class): object|string|null
+function nullOrIsNotA(mixed $value, $class): object|string|null
 {
     return Assert::nullOrIsNotA($value, $class);
 }
@@ -34,7 +34,7 @@ function nullOrIsNotA($value, $class): object|string|null
  * @param iterable<object|string> $value
  * @param class-string $class
  */
-function allIsNotA($value, $class): iterable
+function allIsNotA(mixed $value, $class): iterable
 {
     return Assert::allIsNotA($value, $class);
 }
@@ -45,7 +45,7 @@ function allIsNotA($value, $class): iterable
  * @param iterable<object|string|null> $value
  * @param class-string $class
  */
-function allNullOrIsNotA($value, $class): iterable
+function allNullOrIsNotA(mixed $value, $class): iterable
 {
     return Assert::allNullOrIsNotA($value, $class);
 }

--- a/tests/static-analysis/assert-isNotA.php
+++ b/tests/static-analysis/assert-isNotA.php
@@ -24,7 +24,7 @@ function isNotA(object $value): stdClass
  * @psalm-pure
  *
  * @param null|object|string $value
- * @param class-string<object> $class
+ * @param class-string $class
  */
 function nullOrIsNotA($value, $class): object|string|null
 {
@@ -37,7 +37,7 @@ function nullOrIsNotA($value, $class): object|string|null
  * @psalm-pure
  *
  * @param iterable<object|string> $value
- * @param class-string<object> $class
+ * @param class-string $class
  */
 function allIsNotA($value, $class): iterable
 {
@@ -50,7 +50,7 @@ function allIsNotA($value, $class): iterable
  * @psalm-pure
  *
  * @param iterable<object|string|null> $value
- * @param class-string<object> $class
+ * @param class-string $class
  */
 function allNullOrIsNotA($value, $class): iterable
 {

--- a/tests/static-analysis/assert-isNotInstanceOfAny.php
+++ b/tests/static-analysis/assert-isNotInstanceOfAny.php
@@ -7,45 +7,37 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 use Webmozart\Assert\Assert;
 
 /**
- * @param mixed $value
+ * 
  * @param array<class-string> $classes
  */
 function isNotInstanceOfAny($value, array $classes): mixed
 {
-    Assert::isNotInstanceOfAny($value, $classes);
-
-    return $value;
+    return Assert::isNotInstanceOfAny($value, $classes);
 }
 
 /**
- * @param mixed $value
+ * 
  * @param array<class-string> $classes
  */
 function nullOrIsNotInstanceOfAny($value, array $classes): mixed
 {
-    Assert::nullOrIsNotInstanceOfAny($value, $classes);
-
-    return $value;
+    return Assert::nullOrIsNotInstanceOfAny($value, $classes);
 }
 
 /**
- * @param mixed $value
+ * @param iterable<mixed> $value
  * @param array<class-string> $classes
  */
-function allIsNotInstanceOfAny($value, array $classes): mixed
+function allIsNotInstanceOfAny(iterable $value, array $classes): iterable
 {
-    Assert::allIsNotInstanceOfAny($value, $classes);
-
-    return $value;
+    return Assert::allIsNotInstanceOfAny($value, $classes);
 }
 
 /**
- * @param mixed $value
+ * @param iterable<mixed|null> $value
  * @param array<class-string> $classes
  */
-function allNullOrIsNotInstanceOfAny($value, array $classes): mixed
+function allNullOrIsNotInstanceOfAny(iterable $value, array $classes): iterable
 {
-    Assert::allNullOrIsNotInstanceOfAny($value, $classes);
-
-    return $value;
+    return Assert::allNullOrIsNotInstanceOfAny($value, $classes);
 }

--- a/tests/static-analysis/assert-isNotInstanceOfAny.php
+++ b/tests/static-analysis/assert-isNotInstanceOfAny.php
@@ -10,7 +10,7 @@ use Webmozart\Assert\Assert;
  * 
  * @param array<class-string> $classes
  */
-function isNotInstanceOfAny($value, array $classes): mixed
+function isNotInstanceOfAny(mixed $value, array $classes): mixed
 {
     return Assert::isNotInstanceOfAny($value, $classes);
 }
@@ -19,7 +19,7 @@ function isNotInstanceOfAny($value, array $classes): mixed
  * 
  * @param array<class-string> $classes
  */
-function nullOrIsNotInstanceOfAny($value, array $classes): mixed
+function nullOrIsNotInstanceOfAny(mixed $value, array $classes): mixed
 {
     return Assert::nullOrIsNotInstanceOfAny($value, $classes);
 }

--- a/tests/static-analysis/assert-isStatic.php
+++ b/tests/static-analysis/assert-isStatic.php
@@ -2,13 +2,9 @@
 
 namespace Webmozart\Assert\Tests\StaticAnalysis;
 
-use Closure;
 use Webmozart\Assert\Assert;
 
-/**
- * @return Closure|callable-string
- */
-function isStatic(mixed $closure): Closure|string
+function isStatic(mixed $closure): callable
 {
     return Assert::isStatic($closure);
 }

--- a/tests/static-analysis/assert-isStatic.php
+++ b/tests/static-analysis/assert-isStatic.php
@@ -4,7 +4,7 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 
 use Webmozart\Assert\Assert;
 
-function isStatic(mixed $closure): callable
+function isStatic(callable $closure): callable
 {
     return Assert::isStatic($closure);
 }

--- a/tests/static-analysis/assert-keyExists.php
+++ b/tests/static-analysis/assert-keyExists.php
@@ -13,9 +13,7 @@ use Webmozart\Assert\Assert;
  */
 function keyExists(array $array, $key): array
 {
-    Assert::keyExists($array, $key);
-
-    return $array;
+    return Assert::keyExists($array, $key);
 }
 
 /**
@@ -25,9 +23,7 @@ function keyExists(array $array, $key): array
  */
 function nullOrKeyExists(?array $array, $key): ?array
 {
-    Assert::nullOrKeyExists($array, $key);
-
-    return $array;
+    return Assert::nullOrKeyExists($array, $key);
 }
 
 /**
@@ -38,9 +34,7 @@ function nullOrKeyExists(?array $array, $key): ?array
  */
 function allKeyExists(iterable $array, $key): iterable
 {
-    Assert::allKeyExists($array, $key);
-
-    return $array;
+    return Assert::allKeyExists($array, $key);
 }
 
 /**
@@ -51,7 +45,5 @@ function allKeyExists(iterable $array, $key): iterable
  */
 function allNullOrKeyExists(iterable $array, $key): iterable
 {
-    Assert::allNullOrKeyExists($array, $key);
-
-    return $array;
+    return Assert::allNullOrKeyExists($array, $key);
 }

--- a/tests/static-analysis/assert-keyNotExists.php
+++ b/tests/static-analysis/assert-keyNotExists.php
@@ -13,9 +13,7 @@ use Webmozart\Assert\Assert;
  */
 function keyNotExists(array $array, $key): array
 {
-    Assert::keyNotExists($array, $key);
-
-    return $array;
+    return Assert::keyNotExists($array, $key);
 }
 
 /**
@@ -25,9 +23,7 @@ function keyNotExists(array $array, $key): array
  */
 function nullOrKeyNotExists(?array $array, $key): ?array
 {
-    Assert::nullOrKeyNotExists($array, $key);
-
-    return $array;
+    return Assert::nullOrKeyNotExists($array, $key);
 }
 
 /**
@@ -38,9 +34,7 @@ function nullOrKeyNotExists(?array $array, $key): ?array
  */
 function allKeyNotExists(iterable $array, $key): iterable
 {
-    Assert::allKeyNotExists($array, $key);
-
-    return $array;
+    return Assert::allKeyNotExists($array, $key);
 }
 
 /**
@@ -51,7 +45,5 @@ function allKeyNotExists(iterable $array, $key): iterable
  */
 function allNullOrKeyNotExists(iterable $array, $key): iterable
 {
-    Assert::allNullOrKeyNotExists($array, $key);
-
-    return $array;
+    return Assert::allNullOrKeyNotExists($array, $key);
 }

--- a/tests/static-analysis/assert-length.php
+++ b/tests/static-analysis/assert-length.php
@@ -11,9 +11,7 @@ use Webmozart\Assert\Assert;
  */
 function length(string $value, int $length): string
 {
-    Assert::length($value, $length);
-
-    return $value;
+    return Assert::length($value, $length);
 }
 
 /**
@@ -21,9 +19,7 @@ function length(string $value, int $length): string
  */
 function nullOrLength(?string $value, int $length): ?string
 {
-    Assert::nullOrLength($value, $length);
-
-    return $value;
+    return Assert::nullOrLength($value, $length);
 }
 
 /**
@@ -33,9 +29,7 @@ function nullOrLength(?string $value, int $length): ?string
  */
 function allLength(iterable $value, int $length): iterable
 {
-    Assert::allLength($value, $length);
-
-    return $value;
+    return Assert::allLength($value, $length);
 }
 
 /**
@@ -45,7 +39,5 @@ function allLength(iterable $value, int $length): iterable
  */
 function allNullOrLength(iterable $value, int $length): iterable
 {
-    Assert::allNullOrLength($value, $length);
-
-    return $value;
+    return Assert::allNullOrLength($value, $length);
 }

--- a/tests/static-analysis/assert-lengthBetween.php
+++ b/tests/static-analysis/assert-lengthBetween.php
@@ -11,9 +11,7 @@ use Webmozart\Assert\Assert;
  */
 function lengthBetween(string $value, int $min, int $max): string
 {
-    Assert::lengthBetween($value, $min, $max);
-
-    return $value;
+    return Assert::lengthBetween($value, $min, $max);
 }
 
 /**
@@ -21,9 +19,7 @@ function lengthBetween(string $value, int $min, int $max): string
  */
 function nullOrLengthBetween(?string $value, int $min, int $max): ?string
 {
-    Assert::nullOrLengthBetween($value, $min, $max);
-
-    return $value;
+    return Assert::nullOrLengthBetween($value, $min, $max);
 }
 
 /**
@@ -35,9 +31,7 @@ function nullOrLengthBetween(?string $value, int $min, int $max): ?string
  */
 function allLengthBetween(iterable $value, int $min, int $max): iterable
 {
-    Assert::allLengthBetween($value, $min, $max);
-
-    return $value;
+    return Assert::allLengthBetween($value, $min, $max);
 }
 
 /**
@@ -49,7 +43,5 @@ function allLengthBetween(iterable $value, int $min, int $max): iterable
  */
 function allNullOrLengthBetween(iterable $value, int $min, int $max): iterable
 {
-    Assert::allNullOrLengthBetween($value, $min, $max);
-
-    return $value;
+    return Assert::allNullOrLengthBetween($value, $min, $max);
 }

--- a/tests/static-analysis/assert-lessThan.php
+++ b/tests/static-analysis/assert-lessThan.php
@@ -10,7 +10,7 @@ use Webmozart\Assert\Assert;
  * @psalm-pure
  * @param mixed $limit
  */
-function lessThan($value, $limit): mixed
+function lessThan(mixed $value, mixed $limit): mixed
 {
     return Assert::lessThan($value, $limit);
 }
@@ -19,7 +19,7 @@ function lessThan($value, $limit): mixed
  * @psalm-pure
  * @param mixed $limit
  */
-function nullOrLessThan($value, $limit): mixed
+function nullOrLessThan(mixed $value, mixed $limit): mixed
 {
     return Assert::nullOrLessThan($value, $limit);
 }
@@ -28,7 +28,7 @@ function nullOrLessThan($value, $limit): mixed
  * @psalm-pure
  * @param mixed $limit
  */
-function allLessThan($value, $limit): mixed
+function allLessThan(mixed $value, mixed $limit): mixed
 {
     return Assert::allLessThan($value, $limit);
 }
@@ -37,7 +37,7 @@ function allLessThan($value, $limit): mixed
  * @psalm-pure
  * @param mixed $limit
  */
-function allNullOrLessThan($value, $limit): mixed
+function allNullOrLessThan(mixed $value, mixed $limit): mixed
 {
     return Assert::allNullOrLessThan($value, $limit);
 }

--- a/tests/static-analysis/assert-lessThan.php
+++ b/tests/static-analysis/assert-lessThan.php
@@ -8,52 +8,36 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $limit
  */
 function lessThan($value, $limit): mixed
 {
-    Assert::lessThan($value, $limit);
-
-    return $value;
+    return Assert::lessThan($value, $limit);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $limit
  */
 function nullOrLessThan($value, $limit): mixed
 {
-    Assert::nullOrLessThan($value, $limit);
-
-    return $value;
+    return Assert::nullOrLessThan($value, $limit);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $limit
  */
 function allLessThan($value, $limit): mixed
 {
-    Assert::allLessThan($value, $limit);
-
-    return $value;
+    return Assert::allLessThan($value, $limit);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $limit
  */
 function allNullOrLessThan($value, $limit): mixed
 {
-    Assert::allNullOrLessThan($value, $limit);
-
-    return $value;
+    return Assert::allNullOrLessThan($value, $limit);
 }

--- a/tests/static-analysis/assert-lessThanEq.php
+++ b/tests/static-analysis/assert-lessThanEq.php
@@ -8,52 +8,36 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $limit
  */
 function lessThanEq($value, $limit): mixed
 {
-    Assert::lessThanEq($value, $limit);
-
-    return $value;
+    return Assert::lessThanEq($value, $limit);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $limit
  */
 function nullOrLessThanEq($value, $limit): mixed
 {
-    Assert::nullOrLessThanEq($value, $limit);
-
-    return $value;
+    return Assert::nullOrLessThanEq($value, $limit);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $limit
  */
 function allLessThanEq($value, $limit): mixed
 {
-    Assert::allLessThanEq($value, $limit);
-
-    return $value;
+    return Assert::allLessThanEq($value, $limit);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $limit
  */
 function allNullOrLessThanEq($value, $limit): mixed
 {
-    Assert::allNullOrLessThanEq($value, $limit);
-
-    return $value;
+    return Assert::allNullOrLessThanEq($value, $limit);
 }

--- a/tests/static-analysis/assert-lessThanEq.php
+++ b/tests/static-analysis/assert-lessThanEq.php
@@ -10,7 +10,7 @@ use Webmozart\Assert\Assert;
  * @psalm-pure
  * @param mixed $limit
  */
-function lessThanEq($value, $limit): mixed
+function lessThanEq(mixed $value, mixed $limit): mixed
 {
     return Assert::lessThanEq($value, $limit);
 }
@@ -19,7 +19,7 @@ function lessThanEq($value, $limit): mixed
  * @psalm-pure
  * @param mixed $limit
  */
-function nullOrLessThanEq($value, $limit): mixed
+function nullOrLessThanEq(mixed $value, mixed $limit): mixed
 {
     return Assert::nullOrLessThanEq($value, $limit);
 }
@@ -28,7 +28,7 @@ function nullOrLessThanEq($value, $limit): mixed
  * @psalm-pure
  * @param mixed $limit
  */
-function allLessThanEq($value, $limit): mixed
+function allLessThanEq(mixed $value, mixed $limit): mixed
 {
     return Assert::allLessThanEq($value, $limit);
 }
@@ -37,7 +37,7 @@ function allLessThanEq($value, $limit): mixed
  * @psalm-pure
  * @param mixed $limit
  */
-function allNullOrLessThanEq($value, $limit): mixed
+function allNullOrLessThanEq(mixed $value, mixed $limit): mixed
 {
     return Assert::allNullOrLessThanEq($value, $limit);
 }

--- a/tests/static-analysis/assert-lower.php
+++ b/tests/static-analysis/assert-lower.php
@@ -13,9 +13,7 @@ use Webmozart\Assert\Assert;
  */
 function lower(string $value): string
 {
-    Assert::lower($value);
-
-    return $value;
+    return Assert::lower($value);
 }
 
 /**
@@ -25,9 +23,7 @@ function lower(string $value): string
  */
 function nullOrLower(?string $value): ?string
 {
-    Assert::nullOrLower($value);
-
-    return $value;
+    return Assert::nullOrLower($value);
 }
 
 /**
@@ -37,9 +33,7 @@ function nullOrLower(?string $value): ?string
  */
 function allLower(iterable $value): iterable
 {
-    Assert::allLower($value);
-
-    return $value;
+    return Assert::allLower($value);
 }
 
 /**
@@ -49,7 +43,5 @@ function allLower(iterable $value): iterable
  */
 function allNullOrLower(iterable $value): iterable
 {
-    Assert::allNullOrLower($value);
-
-    return $value;
+    return Assert::allNullOrLower($value);
 }

--- a/tests/static-analysis/assert-maxCount.php
+++ b/tests/static-analysis/assert-maxCount.php
@@ -13,9 +13,7 @@ use Webmozart\Assert\Assert;
  */
 function maxCount($array, $max): Countable|array
 {
-    Assert::maxCount($array, $max);
-
-    return $array;
+    return Assert::maxCount($array, $max);
 }
 
 /**
@@ -24,9 +22,7 @@ function maxCount($array, $max): Countable|array
  */
 function nullOrMaxCount($array, $max): Countable|array|null
 {
-    Assert::nullOrMaxCount($array, $max);
-
-    return $array;
+    return Assert::nullOrMaxCount($array, $max);
 }
 
 /**
@@ -35,9 +31,7 @@ function nullOrMaxCount($array, $max): Countable|array|null
  */
 function allMaxCount(iterable $array, $max): iterable
 {
-    Assert::allMaxCount($array, $max);
-
-    return $array;
+    return Assert::allMaxCount($array, $max);
 }
 
 /**
@@ -46,7 +40,5 @@ function allMaxCount(iterable $array, $max): iterable
  */
 function allNullOrMaxCount(iterable $array, $max): iterable
 {
-    Assert::allNullOrMaxCount($array, $max);
-
-    return $array;
+    return Assert::allNullOrMaxCount($array, $max);
 }

--- a/tests/static-analysis/assert-maxCount.php
+++ b/tests/static-analysis/assert-maxCount.php
@@ -11,7 +11,7 @@ use Webmozart\Assert\Assert;
  * @param Countable|array $array
  * @param int|float $max
  */
-function maxCount($array, $max): Countable|array
+function maxCount(mixed $array, $max): Countable|array
 {
     return Assert::maxCount($array, $max);
 }
@@ -20,7 +20,7 @@ function maxCount($array, $max): Countable|array
  * @param null|Countable|array $array
  * @param int|float $max
  */
-function nullOrMaxCount($array, $max): Countable|array|null
+function nullOrMaxCount(mixed $array, $max): Countable|array|null
 {
     return Assert::nullOrMaxCount($array, $max);
 }

--- a/tests/static-analysis/assert-maxLength.php
+++ b/tests/static-analysis/assert-maxLength.php
@@ -11,9 +11,7 @@ use Webmozart\Assert\Assert;
  */
 function maxLength(string $value, int $max): string
 {
-    Assert::maxLength($value, $max);
-
-    return $value;
+    return Assert::maxLength($value, $max);
 }
 
 /**
@@ -21,9 +19,7 @@ function maxLength(string $value, int $max): string
  */
 function nullOrMaxLength(?string $value, int $max): ?string
 {
-    Assert::nullOrMaxLength($value, $max);
-
-    return $value;
+    return Assert::nullOrMaxLength($value, $max);
 }
 
 /**
@@ -35,9 +31,7 @@ function nullOrMaxLength(?string $value, int $max): ?string
  */
 function allMaxLength(iterable $value, int $max): iterable
 {
-    Assert::allMaxLength($value, $max);
-
-    return $value;
+    return Assert::allMaxLength($value, $max);
 }
 
 /**
@@ -49,7 +43,5 @@ function allMaxLength(iterable $value, int $max): iterable
  */
 function allNullOrMaxLength(iterable $value, int $max): iterable
 {
-    Assert::allMaxLength($value, $max);
-
-    return $value;
+    return Assert::allMaxLength($value, $max);
 }

--- a/tests/static-analysis/assert-methodExists.php
+++ b/tests/static-analysis/assert-methodExists.php
@@ -12,7 +12,7 @@ use Webmozart\Assert\Assert;
  * @param class-string|object $classOrObject
  * @param mixed $method
  */
-function methodExists($classOrObject, $method): string|object
+function methodExists(mixed $classOrObject, $method): string|object
 {
     return Assert::methodExists($classOrObject, $method);
 }
@@ -23,7 +23,7 @@ function methodExists($classOrObject, $method): string|object
  * @param null|class-string|object $classOrObject
  * @param mixed $method
  */
-function nullOrMethodExists($classOrObject, $method): string|object|null
+function nullOrMethodExists(mixed $classOrObject, $method): string|object|null
 {
     return Assert::nullOrMethodExists($classOrObject, $method);
 }

--- a/tests/static-analysis/assert-methodExists.php
+++ b/tests/static-analysis/assert-methodExists.php
@@ -14,9 +14,7 @@ use Webmozart\Assert\Assert;
  */
 function methodExists($classOrObject, $method): string|object
 {
-    Assert::methodExists($classOrObject, $method);
-
-    return $classOrObject;
+    return Assert::methodExists($classOrObject, $method);
 }
 
 /**
@@ -27,9 +25,7 @@ function methodExists($classOrObject, $method): string|object
  */
 function nullOrMethodExists($classOrObject, $method): string|object|null
 {
-    Assert::nullOrMethodExists($classOrObject, $method);
-
-    return $classOrObject;
+    return Assert::nullOrMethodExists($classOrObject, $method);
 }
 
 /**
@@ -40,9 +36,7 @@ function nullOrMethodExists($classOrObject, $method): string|object|null
  */
 function allMethodExists(iterable $classOrObject, $method): iterable
 {
-    Assert::allMethodExists($classOrObject, $method);
-
-    return $classOrObject;
+    return Assert::allMethodExists($classOrObject, $method);
 }
 
 /**
@@ -53,7 +47,5 @@ function allMethodExists(iterable $classOrObject, $method): iterable
  */
 function allNullOrMethodExists(iterable $classOrObject, $method): iterable
 {
-    Assert::allNullOrMethodExists($classOrObject, $method);
-
-    return $classOrObject;
+    return Assert::allNullOrMethodExists($classOrObject, $method);
 }

--- a/tests/static-analysis/assert-methodNotExists.php
+++ b/tests/static-analysis/assert-methodNotExists.php
@@ -12,7 +12,7 @@ use Webmozart\Assert\Assert;
  * @param class-string|object $classOrObject
  * @param mixed $method
  */
-function methodNotExists($classOrObject, $method): string|object
+function methodNotExists(mixed $classOrObject, $method): string|object
 {
     return Assert::methodNotExists($classOrObject, $method);
 }
@@ -23,7 +23,7 @@ function methodNotExists($classOrObject, $method): string|object
  * @param null|class-string|object $classOrObject
  * @param mixed $method
  */
-function nullOrMethodNotExists($classOrObject, $method): string|object|null
+function nullOrMethodNotExists(mixed $classOrObject, $method): string|object|null
 {
     return Assert::nullOrMethodNotExists($classOrObject, $method);
 }

--- a/tests/static-analysis/assert-methodNotExists.php
+++ b/tests/static-analysis/assert-methodNotExists.php
@@ -14,9 +14,7 @@ use Webmozart\Assert\Assert;
  */
 function methodNotExists($classOrObject, $method): string|object
 {
-    Assert::methodNotExists($classOrObject, $method);
-
-    return $classOrObject;
+    return Assert::methodNotExists($classOrObject, $method);
 }
 
 /**
@@ -27,9 +25,7 @@ function methodNotExists($classOrObject, $method): string|object
  */
 function nullOrMethodNotExists($classOrObject, $method): string|object|null
 {
-    Assert::nullOrMethodNotExists($classOrObject, $method);
-
-    return $classOrObject;
+    return Assert::nullOrMethodNotExists($classOrObject, $method);
 }
 
 /**
@@ -40,9 +36,7 @@ function nullOrMethodNotExists($classOrObject, $method): string|object|null
  */
 function allMethodNotExists(iterable $classOrObject, $method): iterable
 {
-    Assert::allMethodNotExists($classOrObject, $method);
-
-    return $classOrObject;
+    return Assert::allMethodNotExists($classOrObject, $method);
 }
 
 /**
@@ -53,7 +47,5 @@ function allMethodNotExists(iterable $classOrObject, $method): iterable
  */
 function allNullOrMethodNotExists(iterable $classOrObject, $method): iterable
 {
-    Assert::allNullOrMethodNotExists($classOrObject, $method);
-
-    return $classOrObject;
+    return Assert::allNullOrMethodNotExists($classOrObject, $method);
 }

--- a/tests/static-analysis/assert-minCount.php
+++ b/tests/static-analysis/assert-minCount.php
@@ -11,7 +11,7 @@ use Webmozart\Assert\Assert;
  * @param Countable|array $array
  * @param int|float $min
  */
-function minCount($array, $min): Countable|array
+function minCount(mixed $array, $min): Countable|array
 {
     return Assert::minCount($array, $min);
 }
@@ -20,7 +20,7 @@ function minCount($array, $min): Countable|array
  * @param null|Countable|array $array
  * @param int|float $min
  */
-function nullOrMinCount($array, $min): Countable|array|null
+function nullOrMinCount(mixed $array, $min): Countable|array|null
 {
     return Assert::nullOrMinCount($array, $min);
 }
@@ -31,7 +31,7 @@ function nullOrMinCount($array, $min): Countable|array|null
  *
  * @return iterable<Countable|array>
  */
-function allMinCount($array, $min)
+function allMinCount(mixed $array, $min)
 {
     return Assert::allMinCount($array, $min);
 }
@@ -42,7 +42,7 @@ function allMinCount($array, $min)
  *
  * @return iterable<Countable|array|null>
  */
-function allNullOrMinCount($array, $min)
+function allNullOrMinCount(mixed $array, $min)
 {
     return Assert::allNullOrMinCount($array, $min);
 }

--- a/tests/static-analysis/assert-minCount.php
+++ b/tests/static-analysis/assert-minCount.php
@@ -13,9 +13,7 @@ use Webmozart\Assert\Assert;
  */
 function minCount($array, $min): Countable|array
 {
-    Assert::minCount($array, $min);
-
-    return $array;
+    return Assert::minCount($array, $min);
 }
 
 /**
@@ -24,9 +22,7 @@ function minCount($array, $min): Countable|array
  */
 function nullOrMinCount($array, $min): Countable|array|null
 {
-    Assert::nullOrMinCount($array, $min);
-
-    return $array;
+    return Assert::nullOrMinCount($array, $min);
 }
 
 /**
@@ -37,9 +33,7 @@ function nullOrMinCount($array, $min): Countable|array|null
  */
 function allMinCount($array, $min)
 {
-    Assert::allMinCount($array, $min);
-
-    return $array;
+    return Assert::allMinCount($array, $min);
 }
 
 /**
@@ -50,7 +44,5 @@ function allMinCount($array, $min)
  */
 function allNullOrMinCount($array, $min)
 {
-    Assert::allNullOrMinCount($array, $min);
-
-    return $array;
+    return Assert::allNullOrMinCount($array, $min);
 }

--- a/tests/static-analysis/assert-minLength.php
+++ b/tests/static-analysis/assert-minLength.php
@@ -13,9 +13,7 @@ use Webmozart\Assert\Assert;
  */
 function minLength(string $value, $min): string
 {
-    Assert::minLength($value, $min);
-
-    return $value;
+    return Assert::minLength($value, $min);
 }
 
 /**
@@ -25,9 +23,7 @@ function minLength(string $value, $min): string
  */
 function nullOrMinLength(?string $value, $min): ?string
 {
-    Assert::nullOrMinLength($value, $min);
-
-    return $value;
+    return Assert::nullOrMinLength($value, $min);
 }
 
 /**
@@ -38,9 +34,7 @@ function nullOrMinLength(?string $value, $min): ?string
  */
 function allMinLength(iterable $value, $min): iterable
 {
-    Assert::allMinLength($value, $min);
-
-    return $value;
+    return Assert::allMinLength($value, $min);
 }
 
 /**
@@ -51,7 +45,5 @@ function allMinLength(iterable $value, $min): iterable
  */
 function allNullOrMinLength(iterable $value, $min): iterable
 {
-    Assert::allNullOrMinLength($value, $min);
-
-    return $value;
+    return Assert::allNullOrMinLength($value, $min);
 }

--- a/tests/static-analysis/assert-natural.php
+++ b/tests/static-analysis/assert-natural.php
@@ -9,57 +9,39 @@ use Webmozart\Assert\Assert;
 /**
  * @psalm-pure
  *
- * @param mixed $value
- *
  * @psalm-return positive-int|0
  */
 function natural(mixed $value): int
 {
-    Assert::natural($value);
-
-    return $value;
+    return Assert::natural($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  *
  * @psalm-return positive-int|0|null
  */
 function nullOrNatural(mixed $value): ?int
 {
-    Assert::nullOrNatural($value);
-
-    return $value;
+    return Assert::nullOrNatural($value);
 }
 
 /**
  * @psalm-pure
  *
- * @param mixed $value
- * *
- * @psalm-suppress MixedInferredReturnType https://github.com/vimeo/psalm/issues/5052
- * @psalm-suppress MixedReturnStatement https://github.com/vimeo/psalm/issues/5052
+ * @return iterable<positive-int|0>
  */
 function allNatural(mixed $value): iterable
 {
-    Assert::allNatural($value);
-
-    return $value;
+    return Assert::allNatural($value);
 }
 
 /**
  * @psalm-pure
  *
- * @param mixed $value
- * *
- * @psalm-suppress MixedInferredReturnType https://github.com/vimeo/psalm/issues/5052
- * @psalm-suppress MixedReturnStatement https://github.com/vimeo/psalm/issues/5052
+ * @return iterable<positive-int|0|null>
  */
 function allNullOrNatural(mixed $value): iterable
 {
-    Assert::allNullOrNatural($value);
-
-    return $value;
+    return Assert::allNullOrNatural($value);
 }

--- a/tests/static-analysis/assert-negativeInteger.php
+++ b/tests/static-analysis/assert-negativeInteger.php
@@ -9,55 +9,39 @@ use Webmozart\Assert\Assert;
 /**
  * @psalm-pure
  *
- * @param mixed $value
- *
  * @psalm-return negative-int
  */
 function negativeInteger(mixed $value): int
 {
-    Assert::negativeInteger($value);
-
-    return $value;
+    return Assert::negativeInteger($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  *
  * @psalm-return negative-int|null
  */
 function nullOrNegativeInteger(mixed $value): ?int
 {
-    Assert::nullOrNegativeInteger($value);
-
-    return $value;
+    return Assert::nullOrNegativeInteger($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  *
  * @return iterable<negative-int>
  */
 function allNegativeInteger(mixed $value): iterable
 {
-    Assert::allNegativeInteger($value);
-
-    return $value;
+    return Assert::allNegativeInteger($value);
 }
 
 /**
  * @psalm-pure
  *
- * @param mixed $value
- *
  * @return iterable<negative-int|null>
  */
 function allNullOrNegativeInteger(mixed $value): iterable
 {
-    Assert::allNullOrNegativeInteger($value);
-
-    return $value;
+    return Assert::allNullOrNegativeInteger($value);
 }

--- a/tests/static-analysis/assert-notContains.php
+++ b/tests/static-analysis/assert-notContains.php
@@ -11,9 +11,7 @@ use Webmozart\Assert\Assert;
  */
 function notContains(string $value, string $subString): string
 {
-    Assert::notContains($value, $subString);
-
-    return $value;
+    return Assert::notContains($value, $subString);
 }
 
 /**
@@ -21,9 +19,7 @@ function notContains(string $value, string $subString): string
  */
 function nullOrNotContains(?string $value, string $subString): ?string
 {
-    Assert::nullOrNotContains($value, $subString);
-
-    return $value;
+    return Assert::nullOrNotContains($value, $subString);
 }
 
 /**
@@ -33,9 +29,7 @@ function nullOrNotContains(?string $value, string $subString): ?string
  */
 function allNotContains(iterable $value, string $subString): iterable
 {
-    Assert::allNotContains($value, $subString);
-
-    return $value;
+    return Assert::allNotContains($value, $subString);
 }
 
 /**
@@ -45,7 +39,5 @@ function allNotContains(iterable $value, string $subString): iterable
  */
 function allNullOrNotContains(iterable $value, string $subString): iterable
 {
-    Assert::allNullOrNotContains($value, $subString);
-
-    return $value;
+    return Assert::allNullOrNotContains($value, $subString);
 }

--- a/tests/static-analysis/assert-notEmpty.php
+++ b/tests/static-analysis/assert-notEmpty.php
@@ -11,9 +11,7 @@ use Webmozart\Assert\Assert;
  */
 function notEmptyNullableObject(?object $value): object
 {
-    Assert::notEmpty($value);
-
-    return $value;
+    return Assert::notEmpty($value);
 }
 
 /**
@@ -23,9 +21,7 @@ function notEmptyNullableObject(?object $value): object
  */
 function notEmptyString(string $value)
 {
-    Assert::notEmpty($value);
-
-    return $value;
+    return Assert::notEmpty($value);
 }
 
 /**
@@ -35,9 +31,7 @@ function notEmptyString(string $value)
  */
 function notEmptyBool(bool $value)
 {
-    Assert::notEmpty($value);
-
-    return $value;
+    return Assert::notEmpty($value);
 }
 
 /**
@@ -47,43 +41,29 @@ function notEmptyBool(bool $value)
  */
 function notEmptyArray(array $value)
 {
-    Assert::notEmpty($value);
-
-    return $value;
+    return Assert::notEmpty($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function nullOrNotEmpty(mixed $value): mixed
 {
-    Assert::nullOrNotEmpty($value);
-
-    return $value;
+    return Assert::nullOrNotEmpty($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNotEmpty(mixed $value): mixed
 {
-    Assert::allNotEmpty($value);
-
-    return $value;
+    return Assert::allNotEmpty($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrNotEmpty(mixed $value): mixed
 {
-    Assert::allNullOrNotEmpty($value);
-
-    return $value;
+    return Assert::allNullOrNotEmpty($value);
 }

--- a/tests/static-analysis/assert-notEndsWith.php
+++ b/tests/static-analysis/assert-notEndsWith.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function notEndsWith(string $value, string $suffix): string
+{
+    return Assert::notEndsWith($value, $suffix);
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrNotEndsWith(?string $value, string $suffix): ?string
+{
+    return Assert::nullOrNotEndsWith($value, $suffix);
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string> $value
+ */
+function allNotEndsWith(iterable $value, string $suffix): iterable
+{
+    return Assert::allNotEndsWith($value, $suffix);
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ */
+function allNullOrNotEndsWith(iterable $value, string $suffix): iterable
+{
+    return Assert::allNullOrNotEndsWith($value, $suffix);
+}

--- a/tests/static-analysis/assert-notEq.php
+++ b/tests/static-analysis/assert-notEq.php
@@ -6,46 +6,22 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 
 use Webmozart\Assert\Assert;
 
-/**
- * @param mixed $value
- * @param mixed $expect
- */
-function notEq($value, $expect): mixed
+function notEq(mixed $value, mixed $expect): mixed
 {
-    Assert::notEq($value, $expect);
-
-    return $value;
+    return Assert::notEq($value, $expect);
 }
 
-/**
- * @param mixed $value
- * @param mixed $expect
- */
-function nullOrNotEq($value, $expect): mixed
+function nullOrNotEq(mixed $value, mixed $expect): mixed
 {
-    Assert::nullOrNotEq($value, $expect);
-
-    return $value;
+    return Assert::nullOrNotEq($value, $expect);
 }
 
-/**
- * @param mixed $value
- * @param mixed $expect
- */
-function allNotEq($value, $expect): mixed
+function allNotEq(mixed $value, mixed $expect): mixed
 {
-    Assert::allNotEq($value, $expect);
-
-    return $value;
+    return Assert::allNotEq($value, $expect);
 }
 
-/**
- * @param mixed $value
- * @param mixed $expect
- */
-function allNullOrNotEq($value, $expect): mixed
+function allNullOrNotEq(mixed $value, mixed $expect): mixed
 {
-    Assert::allNullOrNotEq($value, $expect);
-
-    return $value;
+    return Assert::allNullOrNotEq($value, $expect);
 }

--- a/tests/static-analysis/assert-notFalse.php
+++ b/tests/static-analysis/assert-notFalse.php
@@ -13,9 +13,7 @@ use Webmozart\Assert\Assert;
  */
 function notFalseBool(bool $value): bool
 {
-    Assert::notFalse($value);
-
-    return $value;
+    return Assert::notFalse($value);
 }
 
 /**
@@ -25,43 +23,33 @@ function notFalseBool(bool $value): bool
  */
 function notFalseUnion(mixed $value): string
 {
-    Assert::notFalse($value);
-
-    return $value;
+    return Assert::notFalse($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function nullOrNotFalse(mixed $value): mixed
 {
-    Assert::nullOrNotFalse($value);
-
-    return $value;
+    return Assert::nullOrNotFalse($value);
 }
 
 /**
  * @psalm-pure
  *
- * @param mixed $value
+ * @param iterable<mixed> $value
  */
-function allNotFalse(mixed $value): mixed
+function allNotFalse(iterable $value): iterable
 {
-    Assert::allNotFalse($value);
-
-    return $value;
+    return Assert::allNotFalse($value);
 }
 
 /**
  * @psalm-pure
  *
- * @param mixed $value
+ * @param iterable<mixed|null> $value
  */
-function allNullOrNotFalse(mixed $value): mixed
+function allNullOrNotFalse(iterable $value): iterable
 {
-    Assert::allNullOrNotFalse($value);
-
-    return $value;
+    return Assert::allNullOrNotFalse($value);
 }

--- a/tests/static-analysis/assert-notInArray.php
+++ b/tests/static-analysis/assert-notInArray.php
@@ -9,9 +9,7 @@ use Webmozart\Assert\Assert;
  */
 function notInArray(mixed $value, array $values): mixed
 {
-    Assert::notInArray($value, $values);
-
-    return $value;
+    return Assert::notInArray($value, $values);
 }
 
 /**
@@ -19,9 +17,7 @@ function notInArray(mixed $value, array $values): mixed
  */
 function nullOrNotInArray(mixed $value, array $values): mixed
 {
-    Assert::nullOrNotInArray($value, $values);
-
-    return $value;
+    return Assert::nullOrNotInArray($value, $values);
 }
 
 /**
@@ -29,7 +25,5 @@ function nullOrNotInArray(mixed $value, array $values): mixed
  */
 function allNotInArray(mixed $value, array $values): mixed
 {
-    Assert::allNotInArray($value, $values);
-
-    return $value;
+    return Assert::allNotInArray($value, $values);
 }

--- a/tests/static-analysis/assert-notInstanceOf.php
+++ b/tests/static-analysis/assert-notInstanceOf.php
@@ -4,55 +4,40 @@ declare(strict_types=1);
 
 namespace Webmozart\Assert\Tests\StaticAnalysis;
 
-use DateTime;
 use stdClass;
 use Webmozart\Assert\Assert;
 
 /**
- * @param stdClass|DateTime $value
+ * 
  */
-function notInstanceOf(mixed $value): DateTime
+function notInstanceOf(mixed $value): object
 {
-    Assert::notInstanceOf($value, stdClass::class);
-
-    return $value;
+    return Assert::notInstanceOf($value, stdClass::class);
 }
 
 /**
  * @psalm-template T of object
- *
- * @param mixed $value
  * @param class-string<T> $class
  */
 function nullOrNotInstanceOf($value, $class): mixed
 {
-    Assert::nullOrNotInstanceOf($value, $class);
-
-    return $value;
+    return Assert::nullOrNotInstanceOf($value, $class);
 }
 
 /**
  * @psalm-template T of object
- *
- * @param mixed $value
  * @param class-string<T> $class
  */
 function allNotInstanceOf($value, $class): mixed
 {
-    Assert::allNotInstanceOf($value, $class);
-
-    return $value;
+    return Assert::allNotInstanceOf($value, $class);
 }
 
 /**
  * @psalm-template T of object
- *
- * @param mixed $value
  * @param class-string<T> $class
  */
 function allNullOrNotInstanceOf($value, $class): mixed
 {
-    Assert::allNullOrNotInstanceOf($value, $class);
-
-    return $value;
+    return Assert::allNullOrNotInstanceOf($value, $class);
 }

--- a/tests/static-analysis/assert-notInstanceOf.php
+++ b/tests/static-analysis/assert-notInstanceOf.php
@@ -19,7 +19,7 @@ function notInstanceOf(mixed $value): object
  * @psalm-template T of object
  * @param class-string<T> $class
  */
-function nullOrNotInstanceOf($value, $class): mixed
+function nullOrNotInstanceOf(mixed $value, $class): mixed
 {
     return Assert::nullOrNotInstanceOf($value, $class);
 }
@@ -28,7 +28,7 @@ function nullOrNotInstanceOf($value, $class): mixed
  * @psalm-template T of object
  * @param class-string<T> $class
  */
-function allNotInstanceOf($value, $class): mixed
+function allNotInstanceOf(mixed $value, $class): mixed
 {
     return Assert::allNotInstanceOf($value, $class);
 }
@@ -37,7 +37,7 @@ function allNotInstanceOf($value, $class): mixed
  * @psalm-template T of object
  * @param class-string<T> $class
  */
-function allNullOrNotInstanceOf($value, $class): mixed
+function allNullOrNotInstanceOf(mixed $value, $class): mixed
 {
     return Assert::allNullOrNotInstanceOf($value, $class);
 }

--- a/tests/static-analysis/assert-notNegativeInteger.php
+++ b/tests/static-analysis/assert-notNegativeInteger.php
@@ -9,57 +9,39 @@ use Webmozart\Assert\Assert;
 /**
  * @psalm-pure
  *
- * @param mixed $value
- *
  * @psalm-return non-negative-int
  */
 function nonNegativeInteger(mixed $value): int
 {
-    Assert::notNegativeInteger($value);
-
-    $value *= -1;
-
-    return $value;
+    return Assert::notNegativeInteger($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  *
  * @psalm-return non-negative-int|null
  */
 function nullOrNonNegativeInteger(mixed $value): ?int
 {
-    Assert::nullOrNotNegativeInteger($value);
-
-    return $value;
+    return Assert::nullOrNotNegativeInteger($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  *
  * @return iterable<non-negative-int>
  */
 function allNonNegativeInteger(mixed $value): iterable
 {
-    Assert::allNotNegativeInteger($value);
-
-    return $value;
+    return Assert::allNotNegativeInteger($value);
 }
 
 /**
  * @psalm-pure
  *
- * @param mixed $value
- *
  * @return iterable<non-negative-int|null>
  */
 function allNullOrNonNegativeInteger(mixed $value): iterable
 {
-    Assert::allNullOrPositiveInteger($value);
-
-    return $value;
+    return Assert::allNullOrPositiveInteger($value);
 }

--- a/tests/static-analysis/assert-notNull.php
+++ b/tests/static-analysis/assert-notNull.php
@@ -11,19 +11,15 @@ use Webmozart\Assert\Assert;
  */
 function notNull(?object $value): object
 {
-    Assert::notNull($value);
-
-    return $value;
+    return Assert::notNull($value);
 }
 
 /**
  * @psalm-pure
  *
- * @param mixed $value
+ * @param iterable<mixed|null> $value
  */
-function allNotNull(mixed $value): mixed
+function allNotNull(iterable $value): iterable
 {
-    Assert::allNotNull($value);
-
-    return $value;
+    return Assert::allNotNull($value);
 }

--- a/tests/static-analysis/assert-notOneOf.php
+++ b/tests/static-analysis/assert-notOneOf.php
@@ -9,9 +9,7 @@ use Webmozart\Assert\Assert;
  */
 function notOneOf(mixed $value, array $values): mixed
 {
-    Assert::notOneOf($value, $values);
-
-    return $value;
+    return Assert::notOneOf($value, $values);
 }
 
 /**
@@ -19,9 +17,7 @@ function notOneOf(mixed $value, array $values): mixed
  */
 function nullOrNotOneOf(mixed $value, array $values): mixed
 {
-    Assert::nullOrNotOneOf($value, $values);
-
-    return $value;
+    return Assert::nullOrNotOneOf($value, $values);
 }
 
 /**
@@ -29,7 +25,5 @@ function nullOrNotOneOf(mixed $value, array $values): mixed
  */
 function allNotOneOf(mixed $value, array $values): mixed
 {
-    Assert::allNotOneOf($value, $values);
-
-    return $value;
+    return Assert::allNotOneOf($value, $values);
 }

--- a/tests/static-analysis/assert-notRegex.php
+++ b/tests/static-analysis/assert-notRegex.php
@@ -11,9 +11,7 @@ use Webmozart\Assert\Assert;
  */
 function notRegex(string $value, string $pattern): string
 {
-    Assert::notRegex($value, $pattern);
-
-    return $value;
+    return Assert::notRegex($value, $pattern);
 }
 
 /**
@@ -21,9 +19,7 @@ function notRegex(string $value, string $pattern): string
  */
 function nullOrNotRegex(?string $value, string $pattern): ?string
 {
-    Assert::nullOrNotRegex($value, $pattern);
-
-    return $value;
+    return Assert::nullOrNotRegex($value, $pattern);
 }
 
 /**
@@ -33,9 +29,7 @@ function nullOrNotRegex(?string $value, string $pattern): ?string
  */
 function allNotRegex(iterable $value, string $pattern): iterable
 {
-    Assert::allNotRegex($value, $pattern);
-
-    return $value;
+    return Assert::allNotRegex($value, $pattern);
 }
 
 /**
@@ -45,7 +39,5 @@ function allNotRegex(iterable $value, string $pattern): iterable
  */
 function allNullOrNotRegex(iterable $value, string $pattern): iterable
 {
-    Assert::allNotRegex($value, $pattern);
-
-    return $value;
+    return Assert::allNotRegex($value, $pattern);
 }

--- a/tests/static-analysis/assert-notSame.php
+++ b/tests/static-analysis/assert-notSame.php
@@ -10,7 +10,7 @@ use Webmozart\Assert\Assert;
  * @psalm-pure
  * @param mixed $expect
  */
-function notSame($value, $expect): mixed
+function notSame(mixed $value, $expect): mixed
 {
     return Assert::notSame($value, $expect);
 }
@@ -19,7 +19,7 @@ function notSame($value, $expect): mixed
  * @psalm-pure
  * @param mixed $expect
  */
-function nullOrNotSame($value, $expect): mixed
+function nullOrNotSame(mixed $value, $expect): mixed
 {
     return Assert::nullOrNotSame($value, $expect);
 }
@@ -28,7 +28,7 @@ function nullOrNotSame($value, $expect): mixed
  * @psalm-pure
  * @param mixed $expect
  */
-function allNotSame($value, $expect): mixed
+function allNotSame(mixed $value, $expect): mixed
 {
     return Assert::allNotSame($value, $expect);
 }
@@ -37,7 +37,7 @@ function allNotSame($value, $expect): mixed
  * @psalm-pure
  * @param mixed $expect
  */
-function allNullOrNotSame($value, $expect): mixed
+function allNullOrNotSame(mixed $value, $expect): mixed
 {
     return Assert::allNullOrNotSame($value, $expect);
 }

--- a/tests/static-analysis/assert-notSame.php
+++ b/tests/static-analysis/assert-notSame.php
@@ -8,52 +8,36 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $expect
  */
 function notSame($value, $expect): mixed
 {
-    Assert::notSame($value, $expect);
-
-    return $value;
+    return Assert::notSame($value, $expect);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $expect
  */
 function nullOrNotSame($value, $expect): mixed
 {
-    Assert::nullOrNotSame($value, $expect);
-
-    return $value;
+    return Assert::nullOrNotSame($value, $expect);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $expect
  */
 function allNotSame($value, $expect): mixed
 {
-    Assert::allNotSame($value, $expect);
-
-    return $value;
+    return Assert::allNotSame($value, $expect);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $expect
  */
 function allNullOrNotSame($value, $expect): mixed
 {
-    Assert::allNullOrNotSame($value, $expect);
-
-    return $value;
+    return Assert::allNullOrNotSame($value, $expect);
 }

--- a/tests/static-analysis/assert-notStartsWith.php
+++ b/tests/static-analysis/assert-notStartsWith.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function notStartsWith(string $value, string $prefix): string
+{
+    return Assert::notStartsWith($value, $prefix);
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrNotStartsWith(?string $value, string $prefix): ?string
+{
+    return Assert::nullOrNotStartsWith($value, $prefix);
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string> $value
+ */
+function allNotStartsWith(iterable $value, string $prefix): iterable
+{
+    return Assert::allNotStartsWith($value, $prefix);
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ */
+function allNullOrNotStartsWith(iterable $value, string $prefix): iterable
+{
+    return Assert::allNullOrNotStartsWith($value, $prefix);
+}

--- a/tests/static-analysis/assert-notStatic.php
+++ b/tests/static-analysis/assert-notStatic.php
@@ -2,13 +2,9 @@
 
 namespace Webmozart\Assert\Tests\StaticAnalysis;
 
-use Closure;
 use Webmozart\Assert\Assert;
 
-/**
- * @return Closure|callable-string
- */
-function notStatic(mixed $closure): Closure|string
+function notStatic(mixed $closure): callable
 {
     return Assert::notStatic($closure);
 }

--- a/tests/static-analysis/assert-notStatic.php
+++ b/tests/static-analysis/assert-notStatic.php
@@ -4,7 +4,7 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 
 use Webmozart\Assert\Assert;
 
-function notStatic(mixed $closure): callable
+function notStatic(callable $closure): callable
 {
     return Assert::notStatic($closure);
 }

--- a/tests/static-analysis/assert-notWhitespaceOnly.php
+++ b/tests/static-analysis/assert-notWhitespaceOnly.php
@@ -11,9 +11,7 @@ use Webmozart\Assert\Assert;
  */
 function notWhitespaceOnly(string $value): string
 {
-    Assert::notWhitespaceOnly($value);
-
-    return $value;
+    return Assert::notWhitespaceOnly($value);
 }
 
 /**
@@ -21,9 +19,7 @@ function notWhitespaceOnly(string $value): string
  */
 function nullOrNotWhitespaceOnly(?string $value): ?string
 {
-    Assert::nullOrNotWhitespaceOnly($value);
-
-    return $value;
+    return Assert::nullOrNotWhitespaceOnly($value);
 }
 
 /**
@@ -33,9 +29,7 @@ function nullOrNotWhitespaceOnly(?string $value): ?string
  */
 function allNotWhitespaceOnly(iterable $value): iterable
 {
-    Assert::allNotWhitespaceOnly($value);
-
-    return $value;
+    return Assert::allNotWhitespaceOnly($value);
 }
 
 /**
@@ -45,7 +39,5 @@ function allNotWhitespaceOnly(iterable $value): iterable
  */
 function allNullOrNotWhitespaceOnly(iterable $value): iterable
 {
-    Assert::allNullOrNotWhitespaceOnly($value);
-
-    return $value;
+    return Assert::allNullOrNotWhitespaceOnly($value);
 }

--- a/tests/static-analysis/assert-null.php
+++ b/tests/static-analysis/assert-null.php
@@ -8,24 +8,16 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function null(mixed $value): null
 {
-    Assert::null($value);
-
-    return $value;
+    return Assert::null($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNull(mixed $value): iterable
 {
-    Assert::allNull($value);
-
-    return $value;
+    return Assert::allNull($value);
 }

--- a/tests/static-analysis/assert-numeric.php
+++ b/tests/static-analysis/assert-numeric.php
@@ -9,51 +9,35 @@ use Webmozart\Assert\Assert;
 /**
  * @psalm-pure
  *
- * @param mixed $value
- *
  * @return numeric
  */
 function numeric(mixed $value)
 {
-    Assert::numeric($value);
-
-    return $value;
+    return Assert::numeric($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  *
  * @return null|numeric
  */
 function nullOrNumeric(mixed $value)
 {
-    Assert::nullOrNumeric($value);
-
-    return $value;
+    return Assert::nullOrNumeric($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNumeric(mixed $value): iterable
 {
-    Assert::allNumeric($value);
-
-    return $value;
+    return Assert::allNumeric($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrNumeric(mixed $value): iterable
 {
-    Assert::allNullOrNumeric($value);
-
-    return $value;
+    return Assert::allNullOrNumeric($value);
 }

--- a/tests/static-analysis/assert-object.php
+++ b/tests/static-analysis/assert-object.php
@@ -8,48 +8,32 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function object(mixed $value): object
 {
-    Assert::object($value);
-
-    return $value;
+    return Assert::object($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function nullOrObject(mixed $value): ?object
 {
-    Assert::nullOrObject($value);
-
-    return $value;
+    return Assert::nullOrObject($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allObject(mixed $value): iterable
 {
-    Assert::allObject($value);
-
-    return $value;
+    return Assert::allObject($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrObject(mixed $value): iterable
 {
-    Assert::allNullOrObject($value);
-
-    return $value;
+    return Assert::allNullOrObject($value);
 }

--- a/tests/static-analysis/assert-objectish.php
+++ b/tests/static-analysis/assert-objectish.php
@@ -8,48 +8,32 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function objectish(mixed $value): object|string
 {
-    Assert::objectish($value);
-
-    return $value;
+    return Assert::objectish($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function nullOrObjectish(mixed $value): object|string|null
 {
-    Assert::nullOrObjectish($value);
-
-    return $value;
+    return Assert::nullOrObjectish($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allObjectish(mixed $value): iterable
 {
-    Assert::allObjectish($value);
-
-    return $value;
+    return Assert::allObjectish($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrObjectish(mixed $value): iterable
 {
-    Assert::allNullOrObjectish($value);
-
-    return $value;
+    return Assert::allNullOrObjectish($value);
 }

--- a/tests/static-analysis/assert-oneOf.php
+++ b/tests/static-analysis/assert-oneOf.php
@@ -9,7 +9,7 @@ use Webmozart\Assert\Assert;
 /**
  * @psalm-pure
  */
-function oneOf($value, array $values): mixed
+function oneOf(mixed $value, array $values): mixed
 {
     return Assert::oneOf($value, $values);
 }
@@ -17,7 +17,7 @@ function oneOf($value, array $values): mixed
 /**
  * @psalm-pure
  */
-function nullOrOneOf($value, array $values): mixed
+function nullOrOneOf(mixed $value, array $values): mixed
 {
     return Assert::nullOrOneOf($value, $values);
 }
@@ -25,7 +25,7 @@ function nullOrOneOf($value, array $values): mixed
 /**
  * @psalm-pure
  */
-function allOneOf($value, array $values): mixed
+function allOneOf(mixed $value, array $values): mixed
 {
     return Assert::allOneOf($value, $values);
 }
@@ -33,7 +33,7 @@ function allOneOf($value, array $values): mixed
 /**
  * @psalm-pure
  */
-function allNullOrOneOf($value, array $values): mixed
+function allNullOrOneOf(mixed $value, array $values): mixed
 {
     return Assert::allNullOrOneOf($value, $values);
 }

--- a/tests/static-analysis/assert-oneOf.php
+++ b/tests/static-analysis/assert-oneOf.php
@@ -8,48 +8,32 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function oneOf($value, array $values): mixed
 {
-    Assert::oneOf($value, $values);
-
-    return $value;
+    return Assert::oneOf($value, $values);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function nullOrOneOf($value, array $values): mixed
 {
-    Assert::nullOrOneOf($value, $values);
-
-    return $value;
+    return Assert::nullOrOneOf($value, $values);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allOneOf($value, array $values): mixed
 {
-    Assert::allOneOf($value, $values);
-
-    return $value;
+    return Assert::allOneOf($value, $values);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrOneOf($value, array $values): mixed
 {
-    Assert::allNullOrOneOf($value, $values);
-
-    return $value;
+    return Assert::allNullOrOneOf($value, $values);
 }

--- a/tests/static-analysis/assert-positiveInteger.php
+++ b/tests/static-analysis/assert-positiveInteger.php
@@ -9,15 +9,11 @@ use Webmozart\Assert\Assert;
 /**
  * @psalm-pure
  *
- * @param mixed $value
- *
  * @psalm-return positive-int
  */
 function positiveInteger(mixed $value): int
 {
-    Assert::positiveInteger($value);
-
-    return $value;
+    return Assert::positiveInteger($value);
 }
 
 /**
@@ -29,45 +25,31 @@ function positiveInteger(mixed $value): int
  */
 function positiveIntegerFiltersOutZero(mixed $value): int
 {
-    Assert::positiveInteger($value);
-
-    return $value;
+    return Assert::positiveInteger($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  *
  * @psalm-return positive-int|null
  */
 function nullOrPositiveInteger(mixed $value): ?int
 {
-    Assert::nullOrPositiveInteger($value);
-
-    return $value;
+    return Assert::nullOrPositiveInteger($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allPositiveInteger(mixed $value): iterable
 {
-    Assert::allPositiveInteger($value);
-
-    return $value;
+    return Assert::allPositiveInteger($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrPositiveInteger(mixed $value): iterable
 {
-    Assert::allPositiveInteger($value);
-
-    return $value;
+    return Assert::allPositiveInteger($value);
 }

--- a/tests/static-analysis/assert-propertyExists.php
+++ b/tests/static-analysis/assert-propertyExists.php
@@ -12,7 +12,7 @@ use Webmozart\Assert\Assert;
  * @param class-string|object $classOrObject
  * @param mixed $property
  */
-function propertyExists($classOrObject, $property): string|object
+function propertyExists(mixed $classOrObject, $property): string|object
 {
     return Assert::propertyExists($classOrObject, $property);
 }
@@ -23,7 +23,7 @@ function propertyExists($classOrObject, $property): string|object
  * @param null|class-string|object $classOrObject
  * @param mixed $property
  */
-function nullOrPropertyExists($classOrObject, $property): string|object|null
+function nullOrPropertyExists(mixed $classOrObject, $property): string|object|null
 {
     return Assert::nullOrPropertyExists($classOrObject, $property);
 }

--- a/tests/static-analysis/assert-propertyExists.php
+++ b/tests/static-analysis/assert-propertyExists.php
@@ -14,9 +14,7 @@ use Webmozart\Assert\Assert;
  */
 function propertyExists($classOrObject, $property): string|object
 {
-    Assert::propertyExists($classOrObject, $property);
-
-    return $classOrObject;
+    return Assert::propertyExists($classOrObject, $property);
 }
 
 /**
@@ -27,9 +25,7 @@ function propertyExists($classOrObject, $property): string|object
  */
 function nullOrPropertyExists($classOrObject, $property): string|object|null
 {
-    Assert::nullOrPropertyExists($classOrObject, $property);
-
-    return $classOrObject;
+    return Assert::nullOrPropertyExists($classOrObject, $property);
 }
 
 /**
@@ -40,9 +36,7 @@ function nullOrPropertyExists($classOrObject, $property): string|object|null
  */
 function allPropertyExists(iterable $classOrObject, $property): iterable
 {
-    Assert::allPropertyExists($classOrObject, $property);
-
-    return $classOrObject;
+    return Assert::allPropertyExists($classOrObject, $property);
 }
 
 /**
@@ -53,7 +47,5 @@ function allPropertyExists(iterable $classOrObject, $property): iterable
  */
 function allNullOrPropertyExists(iterable $classOrObject, $property): iterable
 {
-    Assert::allPropertyExists($classOrObject, $property);
-
-    return $classOrObject;
+    return Assert::allNullOrPropertyExists($classOrObject, $property);
 }

--- a/tests/static-analysis/assert-propertyNotExists.php
+++ b/tests/static-analysis/assert-propertyNotExists.php
@@ -14,9 +14,7 @@ use Webmozart\Assert\Assert;
  */
 function propertyNotExists($classOrObject, $property): string|object
 {
-    Assert::propertyNotExists($classOrObject, $property);
-
-    return $classOrObject;
+    return Assert::propertyNotExists($classOrObject, $property);
 }
 
 /**
@@ -27,9 +25,7 @@ function propertyNotExists($classOrObject, $property): string|object
  */
 function nullOrPropertyNotExists($classOrObject, $property): string|object|null
 {
-    Assert::nullOrPropertyNotExists($classOrObject, $property);
-
-    return $classOrObject;
+    return Assert::nullOrPropertyNotExists($classOrObject, $property);
 }
 
 /**
@@ -40,9 +36,7 @@ function nullOrPropertyNotExists($classOrObject, $property): string|object|null
  */
 function allPropertyNotExists(iterable $classOrObject, $property): iterable
 {
-    Assert::allPropertyNotExists($classOrObject, $property);
-
-    return $classOrObject;
+    return Assert::allPropertyNotExists($classOrObject, $property);
 }
 
 /**
@@ -53,7 +47,5 @@ function allPropertyNotExists(iterable $classOrObject, $property): iterable
  */
 function allNullOrPropertyNotExists(iterable $classOrObject, $property): iterable
 {
-    Assert::allNullOrPropertyNotExists($classOrObject, $property);
-
-    return $classOrObject;
+    return Assert::allNullOrPropertyNotExists($classOrObject, $property);
 }

--- a/tests/static-analysis/assert-propertyNotExists.php
+++ b/tests/static-analysis/assert-propertyNotExists.php
@@ -12,7 +12,7 @@ use Webmozart\Assert\Assert;
  * @param class-string|object $classOrObject
  * @param mixed $property
  */
-function propertyNotExists($classOrObject, $property): string|object
+function propertyNotExists(mixed $classOrObject, $property): string|object
 {
     return Assert::propertyNotExists($classOrObject, $property);
 }
@@ -23,7 +23,7 @@ function propertyNotExists($classOrObject, $property): string|object
  * @param null|class-string|object $classOrObject
  * @param mixed $property
  */
-function nullOrPropertyNotExists($classOrObject, $property): string|object|null
+function nullOrPropertyNotExists(mixed $classOrObject, $property): string|object|null
 {
     return Assert::nullOrPropertyNotExists($classOrObject, $property);
 }

--- a/tests/static-analysis/assert-psalm-notRedundant.php
+++ b/tests/static-analysis/assert-psalm-notRedundant.php
@@ -9,15 +9,11 @@ use Webmozart\Assert\Assert;
 /**
  * @psalm-pure
  *
- * @param mixed $value
- *
  * @see https://github.com/webmozart/assert/pull/160#issuecomment-564491986
  * @see https://github.com/vimeo/psalm/commit/4b715cdbffea19a7eab6f72482027d2dd358aab2
  * @see https://github.com/vimeo/psalm/issues/2456
  */
-function stringWillNotBeRedundantIfAssertingAndNotUsingEither(mixed $value): bool
+function stringWillNotBeRedundantIfAssertingAndNotUsingEither(mixed $value): string
 {
-    Assert::string($value);
-
-    return true;
+    return Assert::string($value);
 }

--- a/tests/static-analysis/assert-psalm-plugin-return-type.php
+++ b/tests/static-analysis/assert-psalm-plugin-return-type.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @return numeric
+ */
+function returnedNumeric(mixed $value): int|float|string
+{
+    return Assert::numeric($value);
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return numeric
+ */
+function returnedIntegerish(mixed $value): int|float|string
+{
+    return Assert::integerish($value);
+}

--- a/tests/static-analysis/assert-psalm-preserveContainerType.php
+++ b/tests/static-analysis/assert-psalm-preserveContainerType.php
@@ -16,9 +16,7 @@ use Webmozart\Assert\Assert;
  */
 function preserveContainerAllArray(mixed $value): iterable
 {
-    Assert::allString($value);
-
-    return $value;
+    return Assert::allString($value);
 }
 
 /**
@@ -30,7 +28,5 @@ function preserveContainerAllArray(mixed $value): iterable
  */
 function preserveContainerAllArrayIterator(mixed $value)
 {
-    Assert::allString($value);
-
-    return $value;
+    return Assert::allString($value);
 }

--- a/tests/static-analysis/assert-psalm-preserveStringType.php
+++ b/tests/static-analysis/assert-psalm-preserveStringType.php
@@ -15,7 +15,5 @@ use Webmozart\Assert\Assert;
  */
 function lowerPreservesTypes(string $value): string
 {
-    Assert::lower($value);
-
-    return $value;
+    return Assert::lower($value);
 }

--- a/tests/static-analysis/assert-range.php
+++ b/tests/static-analysis/assert-range.php
@@ -8,56 +8,40 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $min
  * @param mixed $max
  */
 function range($value, $min, $max): mixed
 {
-    Assert::range($value, $min, $max);
-
-    return $value;
+    return Assert::range($value, $min, $max);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $min
  * @param mixed $max
  */
 function nullOrRange($value, $min, $max): mixed
 {
-    Assert::nullOrRange($value, $min, $max);
-
-    return $value;
+    return Assert::nullOrRange($value, $min, $max);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $min
  * @param mixed $max
  */
 function allRange($value, $min, $max): mixed
 {
-    Assert::allRange($value, $min, $max);
-
-    return $value;
+    return Assert::allRange($value, $min, $max);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $min
  * @param mixed $max
  */
 function allNullOrRange($value, $min, $max): mixed
 {
-    Assert::allNullOrRange($value, $min, $max);
-
-    return $value;
+    return Assert::allNullOrRange($value, $min, $max);
 }

--- a/tests/static-analysis/assert-range.php
+++ b/tests/static-analysis/assert-range.php
@@ -11,7 +11,7 @@ use Webmozart\Assert\Assert;
  * @param mixed $min
  * @param mixed $max
  */
-function range($value, $min, $max): mixed
+function range(mixed $value, $min, $max): mixed
 {
     return Assert::range($value, $min, $max);
 }
@@ -21,7 +21,7 @@ function range($value, $min, $max): mixed
  * @param mixed $min
  * @param mixed $max
  */
-function nullOrRange($value, $min, $max): mixed
+function nullOrRange(mixed $value, $min, $max): mixed
 {
     return Assert::nullOrRange($value, $min, $max);
 }
@@ -31,7 +31,7 @@ function nullOrRange($value, $min, $max): mixed
  * @param mixed $min
  * @param mixed $max
  */
-function allRange($value, $min, $max): mixed
+function allRange(mixed $value, $min, $max): mixed
 {
     return Assert::allRange($value, $min, $max);
 }
@@ -41,7 +41,7 @@ function allRange($value, $min, $max): mixed
  * @param mixed $min
  * @param mixed $max
  */
-function allNullOrRange($value, $min, $max): mixed
+function allNullOrRange(mixed $value, $min, $max): mixed
 {
     return Assert::allNullOrRange($value, $min, $max);
 }

--- a/tests/static-analysis/assert-readable.php
+++ b/tests/static-analysis/assert-readable.php
@@ -8,16 +8,12 @@ use Webmozart\Assert\Assert;
 
 function readable(string $value): string
 {
-    Assert::readable($value);
-
-    return $value;
+    return Assert::readable($value);
 }
 
 function nullOrReadable(?string $value): ?string
 {
-    Assert::nullOrReadable($value);
-
-    return $value;
+    return Assert::nullOrReadable($value);
 }
 
 /**
@@ -25,9 +21,7 @@ function nullOrReadable(?string $value): ?string
  */
 function allReadable(iterable $value): iterable
 {
-    Assert::allReadable($value);
-
-    return $value;
+    return Assert::allReadable($value);
 }
 
 /**
@@ -35,7 +29,5 @@ function allReadable(iterable $value): iterable
  */
 function allNullOrReadable(iterable $value): iterable
 {
-    Assert::allNullOrReadable($value);
-
-    return $value;
+    return Assert::allNullOrReadable($value);
 }

--- a/tests/static-analysis/assert-regex.php
+++ b/tests/static-analysis/assert-regex.php
@@ -11,9 +11,7 @@ use Webmozart\Assert\Assert;
  */
 function regex(string $value, string $pattern): string
 {
-    Assert::regex($value, $pattern);
-
-    return $value;
+    return Assert::regex($value, $pattern);
 }
 
 /**
@@ -21,9 +19,7 @@ function regex(string $value, string $pattern): string
  */
 function nullOrRegex(?string $value, string $pattern): ?string
 {
-    Assert::nullOrRegex($value, $pattern);
-
-    return $value;
+    return Assert::nullOrRegex($value, $pattern);
 }
 
 /**
@@ -33,9 +29,7 @@ function nullOrRegex(?string $value, string $pattern): ?string
  */
 function allRegex(iterable $value, string $pattern): iterable
 {
-    Assert::allRegex($value, $pattern);
-
-    return $value;
+    return Assert::allRegex($value, $pattern);
 }
 
 /**
@@ -45,7 +39,5 @@ function allRegex(iterable $value, string $pattern): iterable
  */
 function allNullOrRegex(iterable $value, string $pattern): iterable
 {
-    Assert::allRegex($value, $pattern);
-
-    return $value;
+    return Assert::allRegex($value, $pattern);
 }

--- a/tests/static-analysis/assert-resource.php
+++ b/tests/static-analysis/assert-resource.php
@@ -8,52 +8,36 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param null|string $type
  */
 function resource(mixed $value, ?string $type): mixed
 {
-    Assert::resource($value, $type);
-
-    return $value;
+    return Assert::resource($value, $type);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param null|string $type
  */
 function nullOrResource(mixed $value, ?string $type): mixed
 {
-    Assert::nullOrResource($value, $type);
-
-    return $value;
+    return Assert::nullOrResource($value, $type);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param null|string $type
  */
 function allResource($value, $type): iterable
 {
-    Assert::allResource($value, $type);
-
-    return $value;
+    return Assert::allResource($value, $type);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param null|string $type
  */
 function allNullOrResource($value, $type): iterable
 {
-    Assert::allNullOrResource($value, $type);
-
-    return $value;
+    return Assert::allNullOrResource($value, $type);
 }

--- a/tests/static-analysis/assert-resource.php
+++ b/tests/static-analysis/assert-resource.php
@@ -28,7 +28,7 @@ function nullOrResource(mixed $value, ?string $type): mixed
  * @psalm-pure
  * @param null|string $type
  */
-function allResource($value, $type): iterable
+function allResource(mixed $value, $type): iterable
 {
     return Assert::allResource($value, $type);
 }
@@ -37,7 +37,7 @@ function allResource($value, $type): iterable
  * @psalm-pure
  * @param null|string $type
  */
-function allNullOrResource($value, $type): iterable
+function allNullOrResource(mixed $value, $type): iterable
 {
     return Assert::allNullOrResource($value, $type);
 }

--- a/tests/static-analysis/assert-same.php
+++ b/tests/static-analysis/assert-same.php
@@ -10,7 +10,7 @@ use Webmozart\Assert\Assert;
  * @psalm-pure
  * @param mixed $expect
  */
-function same($value, $expect): mixed
+function same(mixed $value, $expect): mixed
 {
     return Assert::same($value, $expect);
 }
@@ -19,7 +19,7 @@ function same($value, $expect): mixed
  * @psalm-pure
  * @param mixed $expect
  */
-function nullOrSame($value, $expect): mixed
+function nullOrSame(mixed $value, $expect): mixed
 {
     return Assert::nullOrSame($value, $expect);
 }
@@ -28,7 +28,7 @@ function nullOrSame($value, $expect): mixed
  * @psalm-pure
  * @param mixed $expect
  */
-function allSame($value, $expect): mixed
+function allSame(mixed $value, $expect): mixed
 {
     return Assert::allSame($value, $expect);
 }
@@ -37,7 +37,7 @@ function allSame($value, $expect): mixed
  * @psalm-pure
  * @param mixed $expect
  */
-function allNullOrSame($value, $expect): mixed
+function allNullOrSame(mixed $value, $expect): mixed
 {
     return Assert::allNullOrSame($value, $expect);
 }

--- a/tests/static-analysis/assert-same.php
+++ b/tests/static-analysis/assert-same.php
@@ -8,52 +8,36 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $expect
  */
 function same($value, $expect): mixed
 {
-    Assert::same($value, $expect);
-
-    return $value;
+    return Assert::same($value, $expect);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $expect
  */
 function nullOrSame($value, $expect): mixed
 {
-    Assert::nullOrSame($value, $expect);
-
-    return $value;
+    return Assert::nullOrSame($value, $expect);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $expect
  */
 function allSame($value, $expect): mixed
 {
-    Assert::allSame($value, $expect);
-
-    return $value;
+    return Assert::allSame($value, $expect);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  * @param mixed $expect
  */
 function allNullOrSame($value, $expect): mixed
 {
-    Assert::allNullOrSame($value, $expect);
-
-    return $value;
+    return Assert::allNullOrSame($value, $expect);
 }

--- a/tests/static-analysis/assert-scalar.php
+++ b/tests/static-analysis/assert-scalar.php
@@ -8,48 +8,32 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function scalar(mixed $value): int|float|string|bool
 {
-    Assert::scalar($value);
-
-    return $value;
+    return Assert::scalar($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function nullOrScalar(mixed $value): int|float|string|bool|null
 {
-    Assert::nullOrScalar($value);
-
-    return $value;
+    return Assert::nullOrScalar($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allScalar(mixed $value): iterable
 {
-    Assert::allScalar($value);
-
-    return $value;
+    return Assert::allScalar($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrScalar(mixed $value): iterable
 {
-    Assert::allNullOrScalar($value);
-
-    return $value;
+    return Assert::allNullOrScalar($value);
 }

--- a/tests/static-analysis/assert-startsWith.php
+++ b/tests/static-analysis/assert-startsWith.php
@@ -11,9 +11,7 @@ use Webmozart\Assert\Assert;
  */
 function startsWith(string $value, string $prefix): string
 {
-    Assert::startsWith($value, $prefix);
-
-    return $value;
+    return Assert::startsWith($value, $prefix);
 }
 
 /**
@@ -21,9 +19,7 @@ function startsWith(string $value, string $prefix): string
  */
 function nullOrStartsWith(?string $value, string $prefix): ?string
 {
-    Assert::nullOrStartsWith($value, $prefix);
-
-    return $value;
+    return Assert::nullOrStartsWith($value, $prefix);
 }
 
 /**
@@ -33,9 +29,7 @@ function nullOrStartsWith(?string $value, string $prefix): ?string
  */
 function allStartsWith(iterable $value, string $prefix): iterable
 {
-    Assert::allStartsWith($value, $prefix);
-
-    return $value;
+    return Assert::allStartsWith($value, $prefix);
 }
 
 /**
@@ -45,7 +39,5 @@ function allStartsWith(iterable $value, string $prefix): iterable
  */
 function allNullOrStartsWith(iterable $value, string $prefix): iterable
 {
-    Assert::allNullOrStartsWith($value, $prefix);
-
-    return $value;
+    return Assert::allNullOrStartsWith($value, $prefix);
 }

--- a/tests/static-analysis/assert-startsWithLetter.php
+++ b/tests/static-analysis/assert-startsWithLetter.php
@@ -9,7 +9,7 @@ use Webmozart\Assert\Assert;
 /**
  * @psalm-pure
  */
-function startsWithLetter($value, string $prefix): mixed
+function startsWithLetter(mixed $value, string $prefix): mixed
 {
     return Assert::startsWithLetter($value, $prefix);
 }
@@ -17,7 +17,7 @@ function startsWithLetter($value, string $prefix): mixed
 /**
  * @psalm-pure
  */
-function nullOrStartsWithLetter($value, string $prefix): mixed
+function nullOrStartsWithLetter(mixed $value, string $prefix): mixed
 {
     return Assert::nullOrStartsWithLetter($value, $prefix);
 }
@@ -25,7 +25,7 @@ function nullOrStartsWithLetter($value, string $prefix): mixed
 /**
  * @psalm-pure
  */
-function allStartsWithLetter($value, string $prefix): mixed
+function allStartsWithLetter(mixed $value, string $prefix): mixed
 {
     return Assert::allStartsWithLetter($value, $prefix);
 }
@@ -33,7 +33,7 @@ function allStartsWithLetter($value, string $prefix): mixed
 /**
  * @psalm-pure
  */
-function allNullOrStartsWithLetter($value, string $prefix): mixed
+function allNullOrStartsWithLetter(mixed $value, string $prefix): mixed
 {
     return Assert::allNullOrStartsWithLetter($value, $prefix);
 }

--- a/tests/static-analysis/assert-startsWithLetter.php
+++ b/tests/static-analysis/assert-startsWithLetter.php
@@ -8,48 +8,32 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function startsWithLetter($value, string $prefix): mixed
 {
-    Assert::startsWithLetter($value, $prefix);
-
-    return $value;
+    return Assert::startsWithLetter($value, $prefix);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function nullOrStartsWithLetter($value, string $prefix): mixed
 {
-    Assert::nullOrStartsWithLetter($value, $prefix);
-
-    return $value;
+    return Assert::nullOrStartsWithLetter($value, $prefix);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allStartsWithLetter($value, string $prefix): mixed
 {
-    Assert::allStartsWithLetter($value, $prefix);
-
-    return $value;
+    return Assert::allStartsWithLetter($value, $prefix);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrStartsWithLetter($value, string $prefix): mixed
 {
-    Assert::allNullOrStartsWithLetter($value, $prefix);
-
-    return $value;
+    return Assert::allNullOrStartsWithLetter($value, $prefix);
 }

--- a/tests/static-analysis/assert-string.php
+++ b/tests/static-analysis/assert-string.php
@@ -8,48 +8,32 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function string(mixed $value): string
 {
-    Assert::string($value);
-
-    return $value;
+    return Assert::string($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function nullOrString(mixed $value): ?string
 {
-    Assert::nullOrString($value);
-
-    return $value;
+    return Assert::nullOrString($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allString(mixed $value): iterable
 {
-    Assert::allString($value);
-
-    return $value;
+    return Assert::allString($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrString(mixed $value): iterable
 {
-    Assert::allNullOrString($value);
-
-    return $value;
+    return Assert::allNullOrString($value);
 }

--- a/tests/static-analysis/assert-stringNotEmpty.php
+++ b/tests/static-analysis/assert-stringNotEmpty.php
@@ -9,51 +9,35 @@ use Webmozart\Assert\Assert;
 /**
  * @psalm-pure
  *
- * @param mixed $value
- *
  * @return non-empty-string
  */
 function stringNotEmpty(mixed $value): string
 {
-    Assert::stringNotEmpty($value);
-
-    return $value;
+    return Assert::stringNotEmpty($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  *
  * @return null|non-empty-string
  */
 function nullOrStringNotEmpty(mixed $value): ?string
 {
-    Assert::nullOrStringNotEmpty($value);
-
-    return $value;
+    return Assert::nullOrStringNotEmpty($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allStringNotEmpty(mixed $value): iterable
 {
-    Assert::allStringNotEmpty($value);
-
-    return $value;
+    return Assert::allStringNotEmpty($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrStringNotEmpty(mixed $value): iterable
 {
-    Assert::allNullOrStringNotEmpty($value);
-
-    return $value;
+    return Assert::allNullOrStringNotEmpty($value);
 }

--- a/tests/static-analysis/assert-subclassOf.php
+++ b/tests/static-analysis/assert-subclassOf.php
@@ -10,51 +10,35 @@ use Webmozart\Assert\Assert;
 /**
  * @psalm-pure
  *
- * @param mixed $value
- *
  * @return class-string<stdClass>|stdClass
  */
 function subclassOf(mixed $value)
 {
-    Assert::subclassOf($value, stdClass::class);
-
-    return $value;
+    return Assert::subclassOf($value, stdClass::class);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  *
  * @return null|class-string<stdClass>|stdClass
  */
 function nullOrSubclassOf(mixed $value)
 {
-    Assert::nullOrSubclassOf($value, stdClass::class);
-
-    return $value;
+    return Assert::nullOrSubclassOf($value, stdClass::class);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allSubclassOf(mixed $value): iterable
 {
-    Assert::allSubclassOf($value, stdClass::class);
-
-    return $value;
+    return Assert::allSubclassOf($value, stdClass::class);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrSubclassOf(mixed $value): iterable
 {
-    Assert::allNullOrSubclassOf($value, stdClass::class);
-
-    return $value;
+    return Assert::allNullOrSubclassOf($value, stdClass::class);
 }

--- a/tests/static-analysis/assert-throws.php
+++ b/tests/static-analysis/assert-throws.php
@@ -13,9 +13,7 @@ use Webmozart\Assert\Assert;
  */
 function throws(Closure $value, $class): Closure
 {
-    Assert::throws($value, $class);
-
-    return $value;
+    return Assert::throws($value, $class);
 }
 
 /**
@@ -23,9 +21,7 @@ function throws(Closure $value, $class): Closure
  */
 function nullOrThrows(?Closure $value, $class): ?Closure
 {
-    Assert::nullOrThrows($value, $class);
-
-    return $value;
+    return Assert::nullOrThrows($value, $class);
 }
 
 /**
@@ -34,9 +30,7 @@ function nullOrThrows(?Closure $value, $class): ?Closure
  */
 function allThrows(iterable $value, $class): iterable
 {
-    Assert::allThrows($value, $class);
-
-    return $value;
+    return Assert::allThrows($value, $class);
 }
 /**
  * @param iterable<Closure|null> $value
@@ -44,7 +38,5 @@ function allThrows(iterable $value, $class): iterable
  */
 function allNullOrThrows(iterable $value, $class): iterable
 {
-    Assert::allNullOrThrows($value, $class);
-
-    return $value;
+    return Assert::allNullOrThrows($value, $class);
 }

--- a/tests/static-analysis/assert-true.php
+++ b/tests/static-analysis/assert-true.php
@@ -9,51 +9,35 @@ use Webmozart\Assert\Assert;
 /**
  * @psalm-pure
  *
- * @param mixed $value
- *
  * @return true
  */
 function true(mixed $value): bool
 {
-    Assert::true($value);
-
-    return $value;
+    return Assert::true($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  *
  * @return null|true
  */
 function nullOrTrue(mixed $value): ?bool
 {
-    Assert::nullOrTrue($value);
-
-    return $value;
+    return Assert::nullOrTrue($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allTrue(mixed $value): iterable
 {
-    Assert::allTrue($value);
-
-    return $value;
+    return Assert::allTrue($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrTrue(mixed $value): iterable
 {
-    Assert::allNullOrTrue($value);
-
-    return $value;
+    return Assert::allNullOrTrue($value);
 }

--- a/tests/static-analysis/assert-unicodeLetters.php
+++ b/tests/static-analysis/assert-unicodeLetters.php
@@ -8,48 +8,32 @@ use Webmozart\Assert\Assert;
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function unicodeLetters(mixed $value): mixed
 {
-    Assert::unicodeLetters($value);
-
-    return $value;
+    return Assert::unicodeLetters($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function nullOrUnicodeLetters(mixed $value): mixed
 {
-    Assert::nullOrUnicodeLetters($value);
-
-    return $value;
+    return Assert::nullOrUnicodeLetters($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allUnicodeLetters(mixed $value): mixed
 {
-    Assert::allUnicodeLetters($value);
-
-    return $value;
+    return Assert::allUnicodeLetters($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrUnicodeLetters(mixed $value): mixed
 {
-    Assert::allNullOrUnicodeLetters($value);
-
-    return $value;
+    return Assert::allNullOrUnicodeLetters($value);
 }

--- a/tests/static-analysis/assert-uniqueValues.php
+++ b/tests/static-analysis/assert-uniqueValues.php
@@ -8,16 +8,12 @@ use Webmozart\Assert\Assert;
 
 function uniqueValues(array $values): array
 {
-    Assert::uniqueValues($values);
-
-    return $values;
+    return Assert::uniqueValues($values);
 }
 
 function nullOrUniqueValues(?array $values): ?array
 {
-    Assert::nullOrUniqueValues($values);
-
-    return $values;
+    return Assert::nullOrUniqueValues($values);
 }
 
 /**
@@ -25,9 +21,7 @@ function nullOrUniqueValues(?array $values): ?array
  */
 function allUniqueValues(iterable $values): iterable
 {
-    Assert::allUniqueValues($values);
-
-    return $values;
+    return Assert::allUniqueValues($values);
 }
 
 /**
@@ -35,7 +29,5 @@ function allUniqueValues(iterable $values): iterable
  */
 function allNullOrUniqueValues(iterable $values): iterable
 {
-    Assert::allNullOrUniqueValues($values);
-
-    return $values;
+    return Assert::allNullOrUniqueValues($values);
 }

--- a/tests/static-analysis/assert-uniqueValues.php
+++ b/tests/static-analysis/assert-uniqueValues.php
@@ -6,18 +6,18 @@ namespace Webmozart\Assert\Tests\StaticAnalysis;
 
 use Webmozart\Assert\Assert;
 
-function uniqueValues(array $values): array
+function uniqueValues(mixed $values): array
 {
     return Assert::uniqueValues($values);
 }
 
-function nullOrUniqueValues(?array $values): ?array
+function nullOrUniqueValues(mixed $values): ?array
 {
     return Assert::nullOrUniqueValues($values);
 }
 
 /**
- * @param iterable<array> $values
+ * @return iterable<array>
  */
 function allUniqueValues(iterable $values): iterable
 {
@@ -25,7 +25,7 @@ function allUniqueValues(iterable $values): iterable
 }
 
 /**
- * @param iterable<array|null> $values
+ * @return iterable<array|null>
  */
 function allNullOrUniqueValues(iterable $values): iterable
 {

--- a/tests/static-analysis/assert-upper.php
+++ b/tests/static-analysis/assert-upper.php
@@ -11,9 +11,7 @@ use Webmozart\Assert\Assert;
  */
 function upper(mixed $value): string
 {
-    Assert::upper($value);
-
-    return $value;
+    return Assert::upper($value);
 }
 
 /**
@@ -21,9 +19,7 @@ function upper(mixed $value): string
  */
 function nullOrUpper(?string $value): ?string
 {
-    Assert::nullOrUpper($value);
-
-    return $value;
+    return Assert::nullOrUpper($value);
 }
 
 /**
@@ -33,9 +29,7 @@ function nullOrUpper(?string $value): ?string
  */
 function allUpper(iterable $value): iterable
 {
-    Assert::allUpper($value);
-
-    return $value;
+    return Assert::allUpper($value);
 }
 
 /**
@@ -45,7 +39,5 @@ function allUpper(iterable $value): iterable
  */
 function allNullOrUpper(iterable $value): iterable
 {
-    Assert::allNullOrUpper($value);
-
-    return $value;
+    return Assert::allNullOrUpper($value);
 }

--- a/tests/static-analysis/assert-uuid.php
+++ b/tests/static-analysis/assert-uuid.php
@@ -11,9 +11,7 @@ use Webmozart\Assert\Assert;
  */
 function uuid(string $value): string
 {
-    Assert::uuid($value);
-
-    return $value;
+    return Assert::uuid($value);
 }
 
 /**
@@ -21,9 +19,7 @@ function uuid(string $value): string
  */
 function nullOrUuid(?string $value): ?string
 {
-    Assert::nullOrUuid($value);
-
-    return $value;
+    return Assert::nullOrUuid($value);
 }
 
 /**
@@ -33,9 +29,7 @@ function nullOrUuid(?string $value): ?string
  */
 function allUuid(iterable $value): iterable
 {
-    Assert::allUuid($value);
-
-    return $value;
+    return Assert::allUuid($value);
 }
 
 /**
@@ -45,7 +39,5 @@ function allUuid(iterable $value): iterable
  */
 function allNullOrUuid(iterable $value): iterable
 {
-    Assert::allNullOrUuid($value);
-
-    return $value;
+    return Assert::allNullOrUuid($value);
 }

--- a/tests/static-analysis/assert-validArrayKey.php
+++ b/tests/static-analysis/assert-validArrayKey.php
@@ -9,51 +9,35 @@ use Webmozart\Assert\Assert;
 /**
  * @psalm-pure
  *
- * @param mixed $value
- *
  * @return array-key
  */
 function validArrayKey(mixed $value)
 {
-    Assert::validArrayKey($value);
-
-    return $value;
+    return Assert::validArrayKey($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  *
  * @return null|array-key
  */
 function nullOrValidArrayKey(mixed $value)
 {
-    Assert::nullOrValidArrayKey($value);
-
-    return $value;
+    return Assert::nullOrValidArrayKey($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allValidArrayKey(mixed $value): iterable
 {
-    Assert::allValidArrayKey($value);
-
-    return $value;
+    return Assert::allValidArrayKey($value);
 }
 
 /**
  * @psalm-pure
- *
- * @param mixed $value
  */
 function allNullOrValidArrayKey(mixed $value): iterable
 {
-    Assert::allNullOrValidArrayKey($value);
-
-    return $value;
+    return Assert::allNullOrValidArrayKey($value);
 }

--- a/tests/static-analysis/assert-writable.php
+++ b/tests/static-analysis/assert-writable.php
@@ -8,16 +8,12 @@ use Webmozart\Assert\Assert;
 
 function writable(string $value): string
 {
-    Assert::writable($value);
-
-    return $value;
+    return Assert::writable($value);
 }
 
 function nullOrWritable(?string $value): ?string
 {
-    Assert::nullOrWritable($value);
-
-    return $value;
+    return Assert::nullOrWritable($value);
 }
 
 /**
@@ -25,9 +21,7 @@ function nullOrWritable(?string $value): ?string
  */
 function allWritable(iterable $value): iterable
 {
-    Assert::allWritable($value);
-
-    return $value;
+    return Assert::allWritable($value);
 }
 
 /**
@@ -35,7 +29,5 @@ function allWritable(iterable $value): iterable
  */
 function allNullOrWritable(iterable $value): iterable
 {
-    Assert::allNullOrWritable($value);
-
-    return $value;
+    return Assert::allNullOrWritable($value);
 }

--- a/tests/static-analysis/non-return/assert-alnum.php
+++ b/tests/static-analysis/non-return/assert-alnum.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function alnum(string $value): string
+{
+    Assert::alnum($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrAlnum(?string $value): ?string
+{
+    Assert::nullOrAlnum($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string> $value
+ */
+function allAlnum(iterable $value): iterable
+{
+    Assert::allAlnum($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ */
+function allNullOrAlnum(iterable $value): iterable
+{
+    Assert::allNullOrAlnum($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-alpha.php
+++ b/tests/static-analysis/non-return/assert-alpha.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function alpha(mixed $value): mixed
+{
+    Assert::alpha($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrAlpha(mixed $value): mixed
+{
+    Assert::nullOrAlpha($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allAlpha(mixed $value): mixed
+{
+    Assert::allAlpha($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrAlpha(mixed $value): mixed
+{
+    Assert::allNullOrAlpha($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-boolean.php
+++ b/tests/static-analysis/non-return/assert-boolean.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function boolean(mixed $value): bool
+{
+    Assert::boolean($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrBoolean(mixed $value): ?bool
+{
+    Assert::nullOrBoolean($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allBoolean(mixed $value): iterable
+{
+    Assert::allBoolean($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrBoolean(mixed $value): iterable
+{
+    Assert::allNullOrBoolean($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-classExists.php
+++ b/tests/static-analysis/non-return/assert-classExists.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * 
+ *
+ * @return class-string
+ */
+function classExists(mixed $value): string
+{
+    Assert::classExists($value);
+
+    return $value;
+}
+
+/**
+ * 
+ *
+ * @return class-string|null
+ */
+function nullOrClassExists(mixed $value): ?string
+{
+    Assert::nullOrClassExists($value);
+
+    return $value;
+}
+
+/**
+ * 
+ */
+function allClassExists(mixed $value): iterable
+{
+    Assert::allClassExists($value);
+
+    return $value;
+}
+
+/**
+ * 
+ */
+function allNullOrClassExists(mixed $value): iterable
+{
+    Assert::allNullOrClassExists($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-contains.php
+++ b/tests/static-analysis/non-return/assert-contains.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function contains(string $value, string $subString): string
+{
+    Assert::contains($value, $subString);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrContains(?string $value, string $subString): ?string
+{
+    Assert::nullOrContains($value, $subString);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string> $value
+ */
+function allContains(iterable $value, string $subString): iterable
+{
+    Assert::allContains($value, $subString);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ */
+function allNullOrContains(iterable $value, string $subString): iterable
+{
+    Assert::allNullOrContains($value, $subString);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-count.php
+++ b/tests/static-analysis/non-return/assert-count.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Countable;
+use Webmozart\Assert\Assert;
+
+/**
+ * @param Countable|array $value
+ */
+function count(Countable|array $value, int $number): Countable|array
+{
+    Assert::count($value, $number);
+
+    return $value;
+}
+
+/**
+ * @param null|Countable|array $value
+ */
+function nullOrCount(Countable|array|null $value, int $number): Countable|array|null
+{
+    Assert::nullOrCount($value, $number);
+
+    return $value;
+}
+
+/**
+ * @param iterable<Countable|array> $value
+ */
+function allCount(iterable $value, int $number): iterable
+{
+    Assert::allCount($value, $number);
+
+    return $value;
+}
+
+/**
+ * @param iterable<Countable|array|null> $value
+ */
+function allNullOrCount(iterable $value, int $number): iterable
+{
+    Assert::allCount($value, $number);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-countBetween.php
+++ b/tests/static-analysis/non-return/assert-countBetween.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Countable;
+use Webmozart\Assert\Assert;
+
+/**
+ * @param Countable|array $value
+ * @param int|float $min
+ * @param int|float $max
+ */
+function countBetween(mixed $value, $min, $max): Countable|array
+{
+    Assert::countBetween($value, $min, $max);
+
+    return $value;
+}
+
+/**
+ * @param null|Countable|array $value
+ * @param int|float $min
+ * @param int|float $max
+ */
+function nullOrCountBetween(mixed $value, $min, $max): Countable|array|null
+{
+    Assert::nullOrCountBetween($value, $min, $max);
+
+    return $value;
+}
+
+/**
+ * @param iterable<Countable|array> $value
+ * @param int|float $min
+ * @param int|float $max
+ */
+function allCountBetween(iterable $value, $min, $max): iterable
+{
+    Assert::allCountBetween($value, $min, $max);
+
+    return $value;
+}
+
+/**
+ * @param iterable<Countable|array|null> $value
+ * @param int|float $min
+ * @param int|float $max
+ */
+function allNullOrCountBetween(iterable $value, $min, $max): iterable
+{
+    Assert::allNullOrCountBetween($value, $min, $max);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-digits.php
+++ b/tests/static-analysis/non-return/assert-digits.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function digits(string $value): string
+{
+    Assert::digits($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrDigits(?string $value): ?string
+{
+    Assert::nullOrDigits($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string> $value
+ */
+function allDigits(iterable $value): iterable
+{
+    Assert::allDigits($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ */
+function allNullOrDigits(iterable $value): iterable
+{
+    Assert::allNullOrDigits($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-directory.php
+++ b/tests/static-analysis/non-return/assert-directory.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * 
+ */
+function directory(mixed $value): mixed
+{
+    Assert::directory($value);
+
+    return $value;
+}
+
+/**
+ * 
+ */
+function nullOrDirectory(mixed $value): mixed
+{
+    Assert::nullOrDirectory($value);
+
+    return $value;
+}
+
+/**
+ * 
+ */
+function allDirectory(mixed $value): mixed
+{
+    Assert::allDirectory($value);
+
+    return $value;
+}
+
+/**
+ * 
+ */
+function allNullOrDirectory(mixed $value): mixed
+{
+    Assert::allNullOrDirectory($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-email.php
+++ b/tests/static-analysis/non-return/assert-email.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+function email(string $value): string
+{
+    Assert::email($value);
+
+    return $value;
+}
+
+function nullOrEmail(?string $value): ?string
+{
+    Assert::nullOrEmail($value);
+
+    return $value;
+}
+
+/**
+ * @param iterable<string> $value
+ * @return iterable<string>
+ */
+function allEmail(mixed $value): iterable
+{
+    Assert::allEmail($value);
+
+    return $value;
+}
+
+/**
+ * @param iterable<string|null> $value
+ * @return iterable<string|null>
+ */
+function allNullOrEmail(mixed $value): iterable
+{
+    Assert::allNullOrEmail($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-endsWith.php
+++ b/tests/static-analysis/non-return/assert-endsWith.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function endsWith(string $value, string $suffix): string
+{
+    Assert::endsWith($value, $suffix);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrEndsWith(?string $value, string $suffix): ?string
+{
+    Assert::nullOrEndsWith($value, $suffix);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string> $value
+ */
+function allEndsWith(iterable $value, string $suffix): iterable
+{
+    Assert::allEndsWith($value, $suffix);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ */
+function allNullOrEndsWith(iterable $value, string $suffix): iterable
+{
+    Assert::allNullOrEndsWith($value, $suffix);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-eq.php
+++ b/tests/static-analysis/non-return/assert-eq.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * 
+ * @param mixed $expect
+ */
+function eq(mixed $value, mixed $expect): mixed
+{
+    Assert::eq($value, $expect);
+
+    return $value;
+}
+
+/**
+ * 
+ * @param mixed $expect
+ */
+function nullOrEq(mixed $value, mixed $expect): mixed
+{
+    Assert::nullOrEq($value, $expect);
+
+    return $value;
+}
+
+/**
+ * 
+ * @param mixed $expect
+ */
+function allEq(mixed $value, mixed $expect): mixed
+{
+    Assert::allEq($value, $expect);
+
+    return $value;
+}
+
+/**
+ * 
+ * @param mixed $expect
+ */
+function allNullOrEq(mixed $value, mixed $expect): mixed
+{
+    Assert::allNullOrEq($value, $expect);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-false.php
+++ b/tests/static-analysis/non-return/assert-false.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @return false
+ */
+function false(mixed $value): bool
+{
+    Assert::false($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return null|false
+ */
+function nullOrFalse(mixed $value): ?bool
+{
+    Assert::nullOrFalse($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allFalse(mixed $value): iterable
+{
+    Assert::allFalse($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrFalse(mixed $value): iterable
+{
+    Assert::allFalse($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-file.php
+++ b/tests/static-analysis/non-return/assert-file.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * 
+ */
+function file(mixed $value): mixed
+{
+    Assert::file($value);
+
+    return $value;
+}
+
+/**
+ * 
+ */
+function nullOrFile(mixed $value): mixed
+{
+    Assert::nullOrFile($value);
+
+    return $value;
+}
+
+/**
+ * 
+ */
+function allFile(mixed $value): mixed
+{
+    Assert::allFile($value);
+
+    return $value;
+}
+
+/**
+ * 
+ */
+function allNullOrFile(mixed $value): mixed
+{
+    Assert::allNullOrFile($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-fileExists.php
+++ b/tests/static-analysis/non-return/assert-fileExists.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * 
+ */
+function fileExists(mixed $value): mixed
+{
+    Assert::fileExists($value);
+
+    return $value;
+}
+
+/**
+ * 
+ */
+function nullOrFileExists(mixed $value): mixed
+{
+    Assert::nullOrFileExists($value);
+
+    return $value;
+}
+
+/**
+ * 
+ */
+function allFileExists(mixed $value): mixed
+{
+    Assert::allFileExists($value);
+
+    return $value;
+}
+
+/**
+ * 
+ */
+function allNullOrFileExists(mixed $value): mixed
+{
+    Assert::allNullOrFileExists($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-float.php
+++ b/tests/static-analysis/non-return/assert-float.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function float(mixed $value): float
+{
+    Assert::float($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrFloat(mixed $value): ?float
+{
+    Assert::nullOrFloat($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allFloat(mixed $value): iterable
+{
+    Assert::allFloat($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrFloat(mixed $value): iterable
+{
+    Assert::allNullOrFloat($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-greaterThan.php
+++ b/tests/static-analysis/non-return/assert-greaterThan.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ * @param mixed $limit
+ */
+function greaterThan(mixed $value, $limit): mixed
+{
+    Assert::greaterThan($value, $limit);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ * @param mixed $limit
+ */
+function nullOrGreaterThan(mixed $value, mixed $limit): mixed
+{
+    Assert::nullOrGreaterThan($value, $limit);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ * @param mixed $limit
+ */
+function allGreaterThan(mixed $value, mixed $limit): mixed
+{
+    Assert::allGreaterThan($value, $limit);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ * @param mixed $limit
+ */
+function allNullOrGreaterThan(mixed $value, mixed $limit): mixed
+{
+    Assert::allNullOrGreaterThan($value, $limit);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-greaterThanEq.php
+++ b/tests/static-analysis/non-return/assert-greaterThanEq.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function greaterThanEq(mixed $value, mixed $limit): mixed
+{
+    Assert::greaterThanEq($value, $limit);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ * @param mixed $limit
+ */
+function nullOrGreaterThanEq(mixed $value, mixed $limit): mixed
+{
+    Assert::nullOrGreaterThanEq($value, $limit);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ * @param mixed $limit
+ */
+function allGreaterThanEq(mixed $value, mixed $limit): mixed
+{
+    Assert::allGreaterThanEq($value, $limit);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ * @param mixed $limit
+ */
+function allNullOrGreaterThanEq(mixed $value, mixed $limit): mixed
+{
+    Assert::allNullOrGreaterThanEq($value, $limit);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-implementsInterface.php
+++ b/tests/static-analysis/non-return/assert-implementsInterface.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Serializable;
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @return Serializable|class-string<Serializable>
+ */
+function implementsInterface(mixed $value)
+{
+    Assert::implementsInterface($value, Serializable::class);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return Serializable|class-string<Serializable>|null
+ */
+function nullOrImplementsInterface(mixed $value)
+{
+    Assert::nullOrImplementsInterface($value, Serializable::class);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allImplementsInterface(mixed $value): iterable
+{
+    Assert::allImplementsInterface($value, Serializable::class);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrImplementsInterface(mixed $value): iterable
+{
+    Assert::allNullOrImplementsInterface($value, Serializable::class);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-inArray.php
+++ b/tests/static-analysis/non-return/assert-inArray.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function inArray(mixed $value, array $values): mixed
+{
+    Assert::inArray($value, $values);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrInArray(mixed $value, array $values): mixed
+{
+    Assert::nullOrInArray($value, $values);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allInArray(mixed $value, array $values): mixed
+{
+    Assert::allInArray($value, $values);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrInArray(mixed $value, array $values): mixed
+{
+    Assert::allNullOrInArray($value, $values);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-integer.php
+++ b/tests/static-analysis/non-return/assert-integer.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function integer(mixed $value): int
+{
+    Assert::integer($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrInteger(mixed $value): ?int
+{
+    Assert::nullOrInteger($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allInteger(mixed $value): iterable
+{
+    Assert::allInteger($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrInteger(mixed $value): iterable
+{
+    Assert::allNullOrInteger($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-integerish.php
+++ b/tests/static-analysis/non-return/assert-integerish.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @return numeric
+ */
+function integerish(mixed $value)
+{
+    Assert::integerish($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return null|numeric
+ */
+function nullOrIntegerish(mixed $value)
+{
+    Assert::nullOrIntegerish($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allIntegerish(mixed $value): iterable
+{
+    Assert::allIntegerish($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrIntegerish(mixed $value): iterable
+{
+    Assert::allNullOrIntegerish($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-interfaceExists.php
+++ b/tests/static-analysis/non-return/assert-interfaceExists.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * 
+ *
+ * @return class-string
+ */
+function interfaceExists(mixed $value): string
+{
+    Assert::interfaceExists($value);
+
+    return $value;
+}
+
+/**
+ * 
+ *
+ * @return null|class-string
+ */
+function nullOrInterfaceExists(mixed $value): ?string
+{
+    Assert::nullOrInterfaceExists($value);
+
+    return $value;
+}
+
+/**
+ * 
+ */
+function allInterfaceExists(mixed $value): iterable
+{
+    Assert::allInterfaceExists($value);
+
+    return $value;
+}
+
+/**
+ * 
+ */
+function allNullOrInterfaceExists(mixed $value): iterable
+{
+    Assert::allNullOrInterfaceExists($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-ip.php
+++ b/tests/static-analysis/non-return/assert-ip.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+function ip(string $value): string
+{
+    Assert::ip($value);
+
+    return $value;
+}
+
+function nullOrIp(?string $value): ?string
+{
+    Assert::nullOrIp($value);
+
+    return $value;
+}
+
+/**
+ * @param iterable<string> $value
+ */
+function allIp(iterable $value): iterable
+{
+    Assert::allIp($value);
+
+    return $value;
+}
+
+/**
+ * @param iterable<string|null> $value
+ */
+function allNullOrIp(iterable $value): iterable
+{
+    Assert::allNullOrIp($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-ipv4.php
+++ b/tests/static-analysis/non-return/assert-ipv4.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+function ipv4(string $value): string
+{
+    Assert::ipv4($value);
+
+    return $value;
+}
+
+function nullOrIpv4(?string $value): ?string
+{
+    Assert::nullOrIpv4($value);
+
+    return $value;
+}
+
+/**
+ * @param iterable<string> $value
+ */
+function allIpv4(iterable $value): iterable
+{
+    Assert::allIpv4($value);
+
+    return $value;
+}
+
+/**
+ * @param iterable<string|null> $value
+ */
+function allNullOrIpv4(iterable $value): iterable
+{
+    Assert::allNullOrIpv4($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-ipv6.php
+++ b/tests/static-analysis/non-return/assert-ipv6.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+function ipv6(string $value): string
+{
+    Assert::ipv6($value);
+
+    return $value;
+}
+
+function nullOrIpv6(?string $value): ?string
+{
+    Assert::nullOrIpv6($value);
+
+    return $value;
+}
+
+/**
+ * @param iterable<string> $value
+ */
+function allIpv6(iterable $value): iterable
+{
+    Assert::allIpv6($value);
+
+    return $value;
+}
+
+/**
+ * @param iterable<string|null> $value
+ */
+function allNullOrIpv6(iterable $value): iterable
+{
+    Assert::allNullOrIpv6($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-isAOf.php
+++ b/tests/static-analysis/non-return/assert-isAOf.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Serializable;
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @param object|string $value
+ *
+ * @psalm-return class-string<Serializable>|Serializable
+ */
+function isAOf(mixed $value): mixed
+{
+    Assert::isAOf($value, Serializable::class);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param null|object|string $value
+ *
+ * @psalm-return null|class-string<Serializable>|Serializable
+ */
+function nullOrIsAOf(mixed $value): mixed
+{
+    Assert::nullOrIsAOf($value, Serializable::class);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<object|string> $value
+ *
+ * @return iterable<class-string<Serializable>|Serializable>
+ */
+function allIsAOf(mixed $value): iterable
+{
+    Assert::allIsAOf($value, Serializable::class);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<object|string|null> $value
+ *
+ * @return iterable<class-string<Serializable>|Serializable|null>
+ */
+function allNullOrIsAOf(mixed $value): iterable
+{
+    Assert::allNullOrIsAOf($value, Serializable::class);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-isAnyOf.php
+++ b/tests/static-analysis/non-return/assert-isAnyOf.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @param object|string $value
+ * @param array<class-string> $classes
+ */
+function isAnyOf(mixed $value, array $classes): object|string
+{
+    Assert::isAnyOf($value, $classes);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param null|object|string $value
+ * @param array<class-string> $classes
+ */
+function nullOrIsAnyOf(mixed $value, array $classes): object|string|null
+{
+    Assert::nullOrIsAnyOf($value, $classes);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<object|string> $value
+ * @param array<class-string> $classes
+ */
+function allIsAnyOf(mixed $value, array $classes): iterable
+{
+    Assert::allIsAnyOf($value, $classes);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<object|string|null> $value
+ * @param array<class-string> $classes
+ */
+function allNullOrIsAnyOf(mixed $value, array $classes): iterable
+{
+    Assert::allNullOrIsAnyOf($value, $classes);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-isArray.php
+++ b/tests/static-analysis/non-return/assert-isArray.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function isArray(mixed $value): array
+{
+    Assert::isArray($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrIsArray(mixed $value): ?array
+{
+    Assert::nullOrIsArray($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allIsArray(mixed $value): iterable
+{
+    Assert::allIsArray($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrIsArray(mixed $value): iterable
+{
+    Assert::allNullOrIsArray($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-isArrayAccessible.php
+++ b/tests/static-analysis/non-return/assert-isArrayAccessible.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use ArrayAccess;
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function isArrayAccessible(mixed $value): array|ArrayAccess
+{
+    Assert::isArrayAccessible($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrIsArrayAccessible(mixed $value): array|ArrayAccess|null
+{
+    Assert::nullOrIsArrayAccessible($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allIsArrayAccessible(mixed $value): iterable
+{
+    Assert::allIsArrayAccessible($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrIsArrayAccessible(mixed $value): iterable
+{
+    Assert::allNullOrIsArrayAccessible($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-isCallable.php
+++ b/tests/static-analysis/non-return/assert-isCallable.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function isCallable(mixed $value): callable
+{
+    Assert::isCallable($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrIsCallable(mixed $value): ?callable
+{
+    Assert::nullOrIsCallable($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allIsCallable(mixed $value): iterable
+{
+    Assert::allIsCallable($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrIsCallable(mixed $value): iterable
+{
+    Assert::allNullOrIsCallable($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-isCountable.php
+++ b/tests/static-analysis/non-return/assert-isCountable.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Countable;
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function isCountable(mixed $value): Countable
+{
+    Assert::isCountable($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrIsCountable(mixed $value): ?Countable
+{
+    Assert::nullOrIsCountable($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return iterable<Countable>
+ */
+function allIsCountable(mixed $value)
+{
+    Assert::allIsCountable($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return iterable<Countable|null>
+ */
+function allNullOrIsCountable(mixed $value)
+{
+    Assert::allNullOrIsCountable($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-isEmpty.php
+++ b/tests/static-analysis/non-return/assert-isEmpty.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function isEmptyNullableObject(?object $value): null
+{
+    Assert::isEmpty($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return ""|"0"
+ */
+function isEmptyString(string $value)
+{
+    Assert::isEmpty($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return (0)
+ */
+function isEmptyInt(int $value)
+{
+    Assert::isEmpty($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return false
+ */
+function isEmptyBool(bool $value)
+{
+    Assert::isEmpty($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return array<empty, empty>
+ */
+function isEmptyArray(array $value)
+{
+    Assert::isEmpty($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return null
+ */
+function nullOrIsEmpty(?object $value): null
+{
+    Assert::nullOrIsEmpty($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allIsEmpty(mixed $value): iterable
+{
+    Assert::allIsEmpty($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrIsEmpty(mixed $value): iterable
+{
+    Assert::allNullOrIsEmpty($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-isInitialized.php
+++ b/tests/static-analysis/non-return/assert-isInitialized.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function isInitialized(mixed $value, string $property): object
+{
+    Assert::isInitialized($value, $property);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-isInstanceOf.php
+++ b/tests/static-analysis/non-return/assert-isInstanceOf.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Serializable;
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function isInstanceOf(mixed $value): Serializable
+{
+    Assert::isInstanceOf($value, Serializable::class);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrIsInstanceOf(mixed $value): ?Serializable
+{
+    Assert::nullOrIsInstanceOf($value, Serializable::class);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allIsInstanceOf(mixed $value): iterable
+{
+    Assert::allIsInstanceOf($value, Serializable::class);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrIsInstanceOf(mixed $value): iterable
+{
+    Assert::allNullOrIsInstanceOf($value, Serializable::class);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-isInstanceOfAny.php
+++ b/tests/static-analysis/non-return/assert-isInstanceOfAny.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @param object $value
+ * @param array<class-string> $classes
+ */
+function isInstanceOfAny(object $value, array $classes): object
+{
+    Assert::isInstanceOfAny($value, $classes);
+
+    return $value;
+}
+
+/**
+ * @param object|null $value
+ * @param array<class-string> $classes
+ */
+function nullOrIsInstanceOfAny(?object $value, array $classes): ?object
+{
+    Assert::nullOrIsInstanceOfAny($value, $classes);
+
+    return $value;
+}
+
+/**
+ * @param iterable<object> $value
+ * @param array<class-string> $classes
+ */
+function allIsInstanceOfAny(iterable $value, array $classes): iterable
+{
+    Assert::allIsInstanceOfAny($value, $classes);
+
+    return $value;
+}
+
+/**
+ * @param iterable<object|null> $value
+ * @param array<class-string> $classes
+ */
+function allNullOrIsInstanceOfAny(iterable $value, array $classes): iterable
+{
+    Assert::allNullOrIsInstanceOfAny($value, $classes);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-isIterable.php
+++ b/tests/static-analysis/non-return/assert-isIterable.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function isIterable(mixed $value): iterable
+{
+    Assert::isIterable($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrIsIterable(mixed $value): ?iterable
+{
+    Assert::nullOrIsIterable($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allIsIterable(mixed $value): iterable
+{
+    Assert::allIsIterable($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrIsIterable(mixed $value): iterable
+{
+    Assert::allNullOrIsIterable($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-isList.php
+++ b/tests/static-analysis/non-return/assert-isList.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use stdClass;
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @return list<mixed>
+ */
+function isList(mixed $value): array
+{
+    Assert::isList($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param array<stdClass> $value
+ *
+ * @return list<stdClass>
+ */
+function isListWithKnownType(array $value): array
+{
+    Assert::isList($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return null|list<mixed>
+ */
+function nullOrIsList(mixed $value): ?array
+{
+    Assert::nullOrIsList($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allIsList(mixed $value): iterable
+{
+    Assert::allIsList($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrIsList(mixed $value): iterable
+{
+    Assert::allNullOrIsList($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-isMap.php
+++ b/tests/static-analysis/non-return/assert-isMap.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use stdClass;
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @return array<string, mixed>
+ */
+function isMap(mixed $value): array
+{
+    Assert::isMap($value);
+
+    return $value;
+}
+
+/**
+ * Verifying that the type of the elements in the array is preserved by the assertion
+ *
+ * @psalm-pure
+ *
+ * @param array<int|string, stdClass> $value
+ *
+ * @return array<string, stdClass>
+ */
+function isMapWithKnownType(array $value): array
+{
+    Assert::isMap($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return array<empty, empty>
+ */
+function isMapWithEmptyArray(): array
+{
+    $value = [];
+
+    Assert::isMap($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return null|array<string, mixed>
+ */
+function nullOrIsMap(mixed $value): ?array
+{
+    Assert::nullOrIsMap($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<mixed|array<mixed>> $value
+ */
+function allIsMap(iterable $value): iterable
+{
+    Assert::allIsMap($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<mixed|array<mixed>> $value
+ */
+function allNullOrIsMap(iterable $value): iterable
+{
+    Assert::allNullOrIsMap($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-isNonEmptyList.php
+++ b/tests/static-analysis/non-return/assert-isNonEmptyList.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @return non-empty-list<mixed>
+ */
+function isNonEmptyList(mixed $value): array
+{
+    Assert::isNonEmptyList($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param array<int> $value
+ */
+function isNonEmptyListWithRange(array $value): array
+{
+    Assert::isNonEmptyList($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return null|non-empty-list<mixed>
+ */
+function nullOrIsNonEmptyList(mixed $value): ?array
+{
+    Assert::nullOrIsNonEmptyList($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allIsNonEmptyList(mixed $value): iterable
+{
+    Assert::allIsNonEmptyList($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrIsNonEmptyList(mixed $value): iterable
+{
+    Assert::allNullOrIsNonEmptyList($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-isNonEmptyMap.php
+++ b/tests/static-analysis/non-return/assert-isNonEmptyMap.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use stdClass;
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @param array<string, mixed> $value
+ *
+ * @return non-empty-array<string, mixed>
+ */
+function isNonEmptyMap(array $value): array
+{
+    Assert::isNonEmptyMap($value);
+
+    return $value;
+}
+
+/**
+ * Verifying that the type of the elements in the array is preserved by the assertion
+ *
+ * @psalm-pure
+ *
+ * @param array<string, stdClass> $value
+ *
+ * @return non-empty-array<string, stdClass>
+ */
+function isNonEmptyMapWithKnownType(array $value): array
+{
+    Assert::isNonEmptyMap($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param array<string, mixed>|null $value
+ */
+function nullOrIsNonEmptyMap(?array $value): ?array
+{
+    Assert::nullOrIsNonEmptyMap($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<array<string, mixed>> $value
+ */
+function allIsNonEmptyMap(iterable $value): iterable
+{
+    Assert::allIsNonEmptyMap($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<array<string, mixed>|null> $value
+ */
+function allNullOrIsNonEmptyMap(iterable $value): iterable
+{
+    Assert::allNullOrIsNonEmptyMap($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-isNotA.php
+++ b/tests/static-analysis/non-return/assert-isNotA.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use DateTime;
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-return object|class-string
+ */
+function isNotA(mixed $value): object|string
+{
+    Assert::isNotA($value, DateTime::class);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param null|object|string $value
+ * @param class-string $class
+ */
+function nullOrIsNotA(mixed $value, $class): object|string|null
+{
+    Assert::nullOrIsNotA($value, $class);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<object|string> $value
+ * @param class-string $class
+ */
+function allIsNotA(mixed $value, $class): iterable
+{
+    Assert::allIsNotA($value, $class);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<object|string|null> $value
+ * @param class-string $class
+ */
+function allNullOrIsNotA(mixed $value, $class): iterable
+{
+    Assert::allNullOrIsNotA($value, $class);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-isNotInstanceOfAny.php
+++ b/tests/static-analysis/non-return/assert-isNotInstanceOfAny.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * 
+ * @param array<class-string> $classes
+ */
+function isNotInstanceOfAny(mixed $value, array $classes): mixed
+{
+    Assert::isNotInstanceOfAny($value, $classes);
+
+    return $value;
+}
+
+/**
+ * 
+ * @param array<class-string> $classes
+ */
+function nullOrIsNotInstanceOfAny(mixed $value, array $classes): mixed
+{
+    Assert::nullOrIsNotInstanceOfAny($value, $classes);
+
+    return $value;
+}
+
+/**
+ * @param iterable<mixed> $value
+ * @param array<class-string> $classes
+ */
+function allIsNotInstanceOfAny(iterable $value, array $classes): iterable
+{
+    Assert::allIsNotInstanceOfAny($value, $classes);
+
+    return $value;
+}
+
+/**
+ * @param iterable<mixed|null> $value
+ * @param array<class-string> $classes
+ */
+function allNullOrIsNotInstanceOfAny(iterable $value, array $classes): iterable
+{
+    Assert::allNullOrIsNotInstanceOfAny($value, $classes);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-isStatic.php
+++ b/tests/static-analysis/non-return/assert-isStatic.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+function isStatic(callable $closure): callable
+{
+    Assert::isStatic($closure);
+
+    return $closure;
+}

--- a/tests/static-analysis/non-return/assert-keyExists.php
+++ b/tests/static-analysis/non-return/assert-keyExists.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @param array-key $key
+ */
+function keyExists(array $array, $key): array
+{
+    Assert::keyExists($array, $key);
+
+    return $array;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param array-key $key
+ */
+function nullOrKeyExists(?array $array, $key): ?array
+{
+    Assert::nullOrKeyExists($array, $key);
+
+    return $array;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<array> $array
+ * @param array-key $key
+ */
+function allKeyExists(iterable $array, $key): iterable
+{
+    Assert::allKeyExists($array, $key);
+
+    return $array;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<array|null> $array
+ * @param array-key $key
+ */
+function allNullOrKeyExists(iterable $array, $key): iterable
+{
+    Assert::allNullOrKeyExists($array, $key);
+
+    return $array;
+}

--- a/tests/static-analysis/non-return/assert-keyNotExists.php
+++ b/tests/static-analysis/non-return/assert-keyNotExists.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @param array-key $key
+ */
+function keyNotExists(array $array, $key): array
+{
+    Assert::keyNotExists($array, $key);
+
+    return $array;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param array-key $key
+ */
+function nullOrKeyNotExists(?array $array, $key): ?array
+{
+    Assert::nullOrKeyNotExists($array, $key);
+
+    return $array;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<array> $array
+ * @param array-key $key
+ */
+function allKeyNotExists(iterable $array, $key): iterable
+{
+    Assert::allKeyNotExists($array, $key);
+
+    return $array;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<array|null> $array
+ * @param array-key $key
+ */
+function allNullOrKeyNotExists(iterable $array, $key): iterable
+{
+    Assert::allNullOrKeyNotExists($array, $key);
+
+    return $array;
+}

--- a/tests/static-analysis/non-return/assert-length.php
+++ b/tests/static-analysis/non-return/assert-length.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function length(string $value, int $length): string
+{
+    Assert::length($value, $length);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrLength(?string $value, int $length): ?string
+{
+    Assert::nullOrLength($value, $length);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string> $value
+ */
+function allLength(iterable $value, int $length): iterable
+{
+    Assert::allLength($value, $length);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ */
+function allNullOrLength(iterable $value, int $length): iterable
+{
+    Assert::allNullOrLength($value, $length);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-lengthBetween.php
+++ b/tests/static-analysis/non-return/assert-lengthBetween.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function lengthBetween(string $value, int $min, int $max): string
+{
+    Assert::lengthBetween($value, $min, $max);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrLengthBetween(?string $value, int $min, int $max): ?string
+{
+    Assert::nullOrLengthBetween($value, $min, $max);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string> $value
+ *
+ * @return iterable<string>
+ */
+function allLengthBetween(iterable $value, int $min, int $max): iterable
+{
+    Assert::allLengthBetween($value, $min, $max);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ *
+ * @return iterable<string|null>
+ */
+function allNullOrLengthBetween(iterable $value, int $min, int $max): iterable
+{
+    Assert::allNullOrLengthBetween($value, $min, $max);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-lessThan.php
+++ b/tests/static-analysis/non-return/assert-lessThan.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ * @param mixed $limit
+ */
+function lessThan(mixed $value, mixed $limit): mixed
+{
+    Assert::lessThan($value, $limit);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ * @param mixed $limit
+ */
+function nullOrLessThan(mixed $value, mixed $limit): mixed
+{
+    Assert::nullOrLessThan($value, $limit);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ * @param mixed $limit
+ */
+function allLessThan(mixed $value, mixed $limit): mixed
+{
+    Assert::allLessThan($value, $limit);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ * @param mixed $limit
+ */
+function allNullOrLessThan(mixed $value, mixed $limit): mixed
+{
+    Assert::allNullOrLessThan($value, $limit);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-lessThanEq.php
+++ b/tests/static-analysis/non-return/assert-lessThanEq.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ * @param mixed $limit
+ */
+function lessThanEq(mixed $value, mixed $limit): mixed
+{
+    Assert::lessThanEq($value, $limit);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ * @param mixed $limit
+ */
+function nullOrLessThanEq(mixed $value, mixed $limit): mixed
+{
+    Assert::nullOrLessThanEq($value, $limit);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ * @param mixed $limit
+ */
+function allLessThanEq(mixed $value, mixed $limit): mixed
+{
+    Assert::allLessThanEq($value, $limit);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ * @param mixed $limit
+ */
+function allNullOrLessThanEq(mixed $value, mixed $limit): mixed
+{
+    Assert::allNullOrLessThanEq($value, $limit);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-lower.php
+++ b/tests/static-analysis/non-return/assert-lower.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @return lowercase-string
+ */
+function lower(string $value): string
+{
+    Assert::lower($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return null|lowercase-string
+ */
+function nullOrLower(?string $value): ?string
+{
+    Assert::nullOrLower($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string> $value
+ */
+function allLower(iterable $value): iterable
+{
+    Assert::allLower($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ */
+function allNullOrLower(iterable $value): iterable
+{
+    Assert::allNullOrLower($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-maxCount.php
+++ b/tests/static-analysis/non-return/assert-maxCount.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Countable;
+use Webmozart\Assert\Assert;
+
+/**
+ * @param Countable|array $array
+ * @param int|float $max
+ */
+function maxCount(mixed $array, $max): Countable|array
+{
+    Assert::maxCount($array, $max);
+
+    return $array;
+}
+
+/**
+ * @param null|Countable|array $array
+ * @param int|float $max
+ */
+function nullOrMaxCount(mixed $array, $max): Countable|array|null
+{
+    Assert::nullOrMaxCount($array, $max);
+
+    return $array;
+}
+
+/**
+ * @param iterable<Countable|array> $array
+ * @param int|float $max
+ */
+function allMaxCount(iterable $array, $max): iterable
+{
+    Assert::allMaxCount($array, $max);
+
+    return $array;
+}
+
+/**
+ * @param iterable<Countable|array|null> $array
+ * @param int|float $max
+ */
+function allNullOrMaxCount(iterable $array, $max): iterable
+{
+    Assert::allNullOrMaxCount($array, $max);
+
+    return $array;
+}

--- a/tests/static-analysis/non-return/assert-maxLength.php
+++ b/tests/static-analysis/non-return/assert-maxLength.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function maxLength(string $value, int $max): string
+{
+    Assert::maxLength($value, $max);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrMaxLength(?string $value, int $max): ?string
+{
+    Assert::nullOrMaxLength($value, $max);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string> $value
+ *
+ * @return iterable<string>
+ */
+function allMaxLength(iterable $value, int $max): iterable
+{
+    Assert::allMaxLength($value, $max);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ *
+ * @return iterable<string|null>
+ */
+function allNullOrMaxLength(iterable $value, int $max): iterable
+{
+    Assert::allMaxLength($value, $max);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-methodExists.php
+++ b/tests/static-analysis/non-return/assert-methodExists.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @param class-string|object $classOrObject
+ * @param mixed $method
+ */
+function methodExists(mixed $classOrObject, $method): string|object
+{
+    Assert::methodExists($classOrObject, $method);
+
+    return $classOrObject;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param null|class-string|object $classOrObject
+ * @param mixed $method
+ */
+function nullOrMethodExists(mixed $classOrObject, $method): string|object|null
+{
+    Assert::nullOrMethodExists($classOrObject, $method);
+
+    return $classOrObject;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<class-string|object> $classOrObject
+ * @param mixed $method
+ */
+function allMethodExists(iterable $classOrObject, $method): iterable
+{
+    Assert::allMethodExists($classOrObject, $method);
+
+    return $classOrObject;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<class-string|object|null> $classOrObject
+ * @param mixed $method
+ */
+function allNullOrMethodExists(iterable $classOrObject, $method): iterable
+{
+    Assert::allNullOrMethodExists($classOrObject, $method);
+
+    return $classOrObject;
+}

--- a/tests/static-analysis/non-return/assert-methodNotExists.php
+++ b/tests/static-analysis/non-return/assert-methodNotExists.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @param class-string|object $classOrObject
+ * @param mixed $method
+ */
+function methodNotExists(mixed $classOrObject, $method): string|object
+{
+    Assert::methodNotExists($classOrObject, $method);
+
+    return $classOrObject;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param null|class-string|object $classOrObject
+ * @param mixed $method
+ */
+function nullOrMethodNotExists(mixed $classOrObject, $method): string|object|null
+{
+    Assert::nullOrMethodNotExists($classOrObject, $method);
+
+    return $classOrObject;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<class-string|object> $classOrObject
+ * @param mixed $method
+ */
+function allMethodNotExists(iterable $classOrObject, $method): iterable
+{
+    Assert::allMethodNotExists($classOrObject, $method);
+
+    return $classOrObject;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<class-string|object|null> $classOrObject
+ * @param mixed $method
+ */
+function allNullOrMethodNotExists(iterable $classOrObject, $method): iterable
+{
+    Assert::allNullOrMethodNotExists($classOrObject, $method);
+
+    return $classOrObject;
+}

--- a/tests/static-analysis/non-return/assert-minCount.php
+++ b/tests/static-analysis/non-return/assert-minCount.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Countable;
+use Webmozart\Assert\Assert;
+
+/**
+ * @param Countable|array $array
+ * @param int|float $min
+ */
+function minCount(mixed $array, $min): Countable|array
+{
+    Assert::minCount($array, $min);
+
+    return $array;
+}
+
+/**
+ * @param null|Countable|array $array
+ * @param int|float $min
+ */
+function nullOrMinCount(mixed $array, $min): Countable|array|null
+{
+    Assert::nullOrMinCount($array, $min);
+
+    return $array;
+}
+
+/**
+ * @param iterable<Countable|array> $array
+ * @param int|float $min
+ *
+ * @return iterable<Countable|array>
+ */
+function allMinCount(mixed $array, $min)
+{
+    Assert::allMinCount($array, $min);
+
+    return $array;
+}
+
+/**
+ * @param iterable<Countable|array|null> $array
+ * @param int|float $min
+ *
+ * @return iterable<Countable|array|null>
+ */
+function allNullOrMinCount(mixed $array, $min)
+{
+    Assert::allNullOrMinCount($array, $min);
+
+    return $array;
+}

--- a/tests/static-analysis/non-return/assert-minLength.php
+++ b/tests/static-analysis/non-return/assert-minLength.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @param int|float $min
+ */
+function minLength(string $value, $min): string
+{
+    Assert::minLength($value, $min);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param int|float $min
+ */
+function nullOrMinLength(?string $value, $min): ?string
+{
+    Assert::nullOrMinLength($value, $min);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string> $value
+ * @param int|float $min
+ */
+function allMinLength(iterable $value, $min): iterable
+{
+    Assert::allMinLength($value, $min);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ * @param int|float $min
+ */
+function allNullOrMinLength(iterable $value, $min): iterable
+{
+    Assert::allNullOrMinLength($value, $min);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-natural.php
+++ b/tests/static-analysis/non-return/assert-natural.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-return positive-int|0
+ */
+function natural(mixed $value): int
+{
+    Assert::natural($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-return positive-int|0|null
+ */
+function nullOrNatural(mixed $value): ?int
+{
+    Assert::nullOrNatural($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return iterable<positive-int|0>
+ */
+function allNatural(mixed $value): iterable
+{
+    Assert::allNatural($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return iterable<positive-int|0|null>
+ */
+function allNullOrNatural(mixed $value): iterable
+{
+    Assert::allNullOrNatural($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-negativeInteger.php
+++ b/tests/static-analysis/non-return/assert-negativeInteger.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-return negative-int
+ */
+function negativeInteger(mixed $value): int
+{
+    Assert::negativeInteger($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-return negative-int|null
+ */
+function nullOrNegativeInteger(mixed $value): ?int
+{
+    Assert::nullOrNegativeInteger($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return iterable<negative-int>
+ */
+function allNegativeInteger(mixed $value): iterable
+{
+    Assert::allNegativeInteger($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return iterable<negative-int|null>
+ */
+function allNullOrNegativeInteger(mixed $value): iterable
+{
+    Assert::allNullOrNegativeInteger($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-notContains.php
+++ b/tests/static-analysis/non-return/assert-notContains.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function notContains(string $value, string $subString): string
+{
+    Assert::notContains($value, $subString);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrNotContains(?string $value, string $subString): ?string
+{
+    Assert::nullOrNotContains($value, $subString);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string> $value
+ */
+function allNotContains(iterable $value, string $subString): iterable
+{
+    Assert::allNotContains($value, $subString);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ */
+function allNullOrNotContains(iterable $value, string $subString): iterable
+{
+    Assert::allNullOrNotContains($value, $subString);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-notEmpty.php
+++ b/tests/static-analysis/non-return/assert-notEmpty.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function notEmptyNullableObject(?object $value): object
+{
+    Assert::notEmpty($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return non-empty-string
+ */
+function notEmptyString(string $value)
+{
+    Assert::notEmpty($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return true
+ */
+function notEmptyBool(bool $value)
+{
+    Assert::notEmpty($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return non-empty-array
+ */
+function notEmptyArray(array $value)
+{
+    Assert::notEmpty($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrNotEmpty(mixed $value): mixed
+{
+    Assert::nullOrNotEmpty($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNotEmpty(mixed $value): mixed
+{
+    Assert::allNotEmpty($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrNotEmpty(mixed $value): mixed
+{
+    Assert::allNullOrNotEmpty($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-notEndsWith.php
+++ b/tests/static-analysis/non-return/assert-notEndsWith.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function notEndsWith(string $value, string $suffix): string
+{
+    Assert::notEndsWith($value, $suffix);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrNotEndsWith(?string $value, string $suffix): ?string
+{
+    Assert::nullOrNotEndsWith($value, $suffix);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string> $value
+ */
+function allNotEndsWith(iterable $value, string $suffix): iterable
+{
+    Assert::allNotEndsWith($value, $suffix);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ */
+function allNullOrNotEndsWith(iterable $value, string $suffix): iterable
+{
+    Assert::allNullOrNotEndsWith($value, $suffix);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-notEq.php
+++ b/tests/static-analysis/non-return/assert-notEq.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+function notEq(mixed $value, mixed $expect): mixed
+{
+    Assert::notEq($value, $expect);
+
+    return $value;
+}
+
+function nullOrNotEq(mixed $value, mixed $expect): mixed
+{
+    Assert::nullOrNotEq($value, $expect);
+
+    return $value;
+}
+
+function allNotEq(mixed $value, mixed $expect): mixed
+{
+    Assert::allNotEq($value, $expect);
+
+    return $value;
+}
+
+function allNullOrNotEq(mixed $value, mixed $expect): mixed
+{
+    Assert::allNullOrNotEq($value, $expect);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-notFalse.php
+++ b/tests/static-analysis/non-return/assert-notFalse.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @return true
+ */
+function notFalseBool(bool $value): bool
+{
+    Assert::notFalse($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param false|string $value
+ */
+function notFalseUnion(mixed $value): string
+{
+    Assert::notFalse($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrNotFalse(mixed $value): mixed
+{
+    Assert::nullOrNotFalse($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<mixed> $value
+ */
+function allNotFalse(iterable $value): iterable
+{
+    Assert::allNotFalse($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<mixed|null> $value
+ */
+function allNullOrNotFalse(iterable $value): iterable
+{
+    Assert::allNullOrNotFalse($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-notInArray.php
+++ b/tests/static-analysis/non-return/assert-notInArray.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function notInArray(mixed $value, array $values): mixed
+{
+    Assert::notInArray($value, $values);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrNotInArray(mixed $value, array $values): mixed
+{
+    Assert::nullOrNotInArray($value, $values);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNotInArray(mixed $value, array $values): mixed
+{
+    Assert::allNotInArray($value, $values);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-notInstanceOf.php
+++ b/tests/static-analysis/non-return/assert-notInstanceOf.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use stdClass;
+use Webmozart\Assert\Assert;
+
+/**
+ * 
+ */
+function notInstanceOf(mixed $value): object
+{
+    Assert::notInstanceOf($value, stdClass::class);
+
+    return $value;
+}
+
+/**
+ * @psalm-template T of object
+ * @param class-string<T> $class
+ */
+function nullOrNotInstanceOf(mixed $value, $class): mixed
+{
+    Assert::nullOrNotInstanceOf($value, $class);
+
+    return $value;
+}
+
+/**
+ * @psalm-template T of object
+ * @param class-string<T> $class
+ */
+function allNotInstanceOf(mixed $value, $class): mixed
+{
+    Assert::allNotInstanceOf($value, $class);
+
+    return $value;
+}
+
+/**
+ * @psalm-template T of object
+ * @param class-string<T> $class
+ */
+function allNullOrNotInstanceOf(mixed $value, $class): mixed
+{
+    Assert::allNullOrNotInstanceOf($value, $class);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-notNegativeInteger.php
+++ b/tests/static-analysis/non-return/assert-notNegativeInteger.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-return non-negative-int
+ */
+function nonNegativeInteger(mixed $value): int
+{
+    Assert::notNegativeInteger($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-return non-negative-int|null
+ */
+function nullOrNonNegativeInteger(mixed $value): ?int
+{
+    Assert::nullOrNotNegativeInteger($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return iterable<non-negative-int>
+ */
+function allNonNegativeInteger(mixed $value): iterable
+{
+    Assert::allNotNegativeInteger($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return iterable<non-negative-int|null>
+ */
+function allNullOrNonNegativeInteger(mixed $value): iterable
+{
+    Assert::allNullOrPositiveInteger($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-notNull.php
+++ b/tests/static-analysis/non-return/assert-notNull.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function notNull(?object $value): object
+{
+    Assert::notNull($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<mixed|null> $value
+ */
+function allNotNull(iterable $value): iterable
+{
+    Assert::allNotNull($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-notOneOf.php
+++ b/tests/static-analysis/non-return/assert-notOneOf.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function notOneOf(mixed $value, array $values): mixed
+{
+    Assert::notOneOf($value, $values);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrNotOneOf(mixed $value, array $values): mixed
+{
+    Assert::nullOrNotOneOf($value, $values);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNotOneOf(mixed $value, array $values): mixed
+{
+    Assert::allNotOneOf($value, $values);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-notRegex.php
+++ b/tests/static-analysis/non-return/assert-notRegex.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function notRegex(string $value, string $pattern): string
+{
+    Assert::notRegex($value, $pattern);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrNotRegex(?string $value, string $pattern): ?string
+{
+    Assert::nullOrNotRegex($value, $pattern);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string> $value
+ */
+function allNotRegex(iterable $value, string $pattern): iterable
+{
+    Assert::allNotRegex($value, $pattern);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ */
+function allNullOrNotRegex(iterable $value, string $pattern): iterable
+{
+    Assert::allNotRegex($value, $pattern);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-notSame.php
+++ b/tests/static-analysis/non-return/assert-notSame.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ * @param mixed $expect
+ */
+function notSame(mixed $value, $expect): mixed
+{
+    Assert::notSame($value, $expect);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ * @param mixed $expect
+ */
+function nullOrNotSame(mixed $value, $expect): mixed
+{
+    Assert::nullOrNotSame($value, $expect);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ * @param mixed $expect
+ */
+function allNotSame(mixed $value, $expect): mixed
+{
+    Assert::allNotSame($value, $expect);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ * @param mixed $expect
+ */
+function allNullOrNotSame(mixed $value, $expect): mixed
+{
+    Assert::allNullOrNotSame($value, $expect);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-notStartsWith.php
+++ b/tests/static-analysis/non-return/assert-notStartsWith.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function notStartsWith(string $value, string $prefix): string
+{
+    Assert::notStartsWith($value, $prefix);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrNotStartsWith(?string $value, string $prefix): ?string
+{
+    Assert::nullOrNotStartsWith($value, $prefix);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string> $value
+ */
+function allNotStartsWith(iterable $value, string $prefix): iterable
+{
+    Assert::allNotStartsWith($value, $prefix);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ */
+function allNullOrNotStartsWith(iterable $value, string $prefix): iterable
+{
+    Assert::allNullOrNotStartsWith($value, $prefix);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-notStatic.php
+++ b/tests/static-analysis/non-return/assert-notStatic.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+function notStatic(callable $closure): callable
+{
+    Assert::notStatic($closure);
+
+    return $closure;
+}

--- a/tests/static-analysis/non-return/assert-notWhitespaceOnly.php
+++ b/tests/static-analysis/non-return/assert-notWhitespaceOnly.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function notWhitespaceOnly(string $value): string
+{
+    Assert::notWhitespaceOnly($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrNotWhitespaceOnly(?string $value): ?string
+{
+    Assert::nullOrNotWhitespaceOnly($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string> $value
+ */
+function allNotWhitespaceOnly(iterable $value): iterable
+{
+    Assert::allNotWhitespaceOnly($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ */
+function allNullOrNotWhitespaceOnly(iterable $value): iterable
+{
+    Assert::allNullOrNotWhitespaceOnly($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-null.php
+++ b/tests/static-analysis/non-return/assert-null.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function null(mixed $value): null
+{
+    Assert::null($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNull(mixed $value): iterable
+{
+    Assert::allNull($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-numeric.php
+++ b/tests/static-analysis/non-return/assert-numeric.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @return numeric
+ */
+function numeric(mixed $value)
+{
+    Assert::numeric($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return null|numeric
+ */
+function nullOrNumeric(mixed $value)
+{
+    Assert::nullOrNumeric($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNumeric(mixed $value): iterable
+{
+    Assert::allNumeric($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrNumeric(mixed $value): iterable
+{
+    Assert::allNullOrNumeric($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-object.php
+++ b/tests/static-analysis/non-return/assert-object.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function object(mixed $value): object
+{
+    Assert::object($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrObject(mixed $value): ?object
+{
+    Assert::nullOrObject($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allObject(mixed $value): iterable
+{
+    Assert::allObject($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrObject(mixed $value): iterable
+{
+    Assert::allNullOrObject($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-objectish.php
+++ b/tests/static-analysis/non-return/assert-objectish.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function objectish(mixed $value): object|string
+{
+    Assert::objectish($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrObjectish(mixed $value): object|string|null
+{
+    Assert::nullOrObjectish($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allObjectish(mixed $value): iterable
+{
+    Assert::allObjectish($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrObjectish(mixed $value): iterable
+{
+    Assert::allNullOrObjectish($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-oneOf.php
+++ b/tests/static-analysis/non-return/assert-oneOf.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function oneOf(mixed $value, array $values): mixed
+{
+    Assert::oneOf($value, $values);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrOneOf(mixed $value, array $values): mixed
+{
+    Assert::nullOrOneOf($value, $values);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allOneOf(mixed $value, array $values): mixed
+{
+    Assert::allOneOf($value, $values);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrOneOf(mixed $value, array $values): mixed
+{
+    Assert::allNullOrOneOf($value, $values);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-positiveInteger.php
+++ b/tests/static-analysis/non-return/assert-positiveInteger.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-return positive-int
+ */
+function positiveInteger(mixed $value): int
+{
+    Assert::positiveInteger($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param 0|1|2 $value
+ *
+ * @psalm-return 1|2
+ */
+function positiveIntegerFiltersOutZero(mixed $value): int
+{
+    Assert::positiveInteger($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-return positive-int|null
+ */
+function nullOrPositiveInteger(mixed $value): ?int
+{
+    Assert::nullOrPositiveInteger($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allPositiveInteger(mixed $value): iterable
+{
+    Assert::allPositiveInteger($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrPositiveInteger(mixed $value): iterable
+{
+    Assert::allPositiveInteger($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-propertyExists.php
+++ b/tests/static-analysis/non-return/assert-propertyExists.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @param class-string|object $classOrObject
+ * @param mixed $property
+ */
+function propertyExists(mixed $classOrObject, $property): string|object
+{
+    Assert::propertyExists($classOrObject, $property);
+
+    return $classOrObject;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param null|class-string|object $classOrObject
+ * @param mixed $property
+ */
+function nullOrPropertyExists(mixed $classOrObject, $property): string|object|null
+{
+    Assert::nullOrPropertyExists($classOrObject, $property);
+
+    return $classOrObject;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<class-string|object> $classOrObject
+ * @param mixed $property
+ */
+function allPropertyExists(iterable $classOrObject, $property): iterable
+{
+    Assert::allPropertyExists($classOrObject, $property);
+
+    return $classOrObject;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<class-string|object|null> $classOrObject
+ * @param mixed $property
+ */
+function allNullOrPropertyExists(iterable $classOrObject, $property): iterable
+{
+    Assert::allNullOrPropertyExists($classOrObject, $property);
+
+    return $classOrObject;
+}

--- a/tests/static-analysis/non-return/assert-propertyNotExists.php
+++ b/tests/static-analysis/non-return/assert-propertyNotExists.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @param class-string|object $classOrObject
+ * @param mixed $property
+ */
+function propertyNotExists(mixed $classOrObject, $property): string|object
+{
+    Assert::propertyNotExists($classOrObject, $property);
+
+    return $classOrObject;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param null|class-string|object $classOrObject
+ * @param mixed $property
+ */
+function nullOrPropertyNotExists(mixed $classOrObject, $property): string|object|null
+{
+    Assert::nullOrPropertyNotExists($classOrObject, $property);
+
+    return $classOrObject;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<class-string|object> $classOrObject
+ * @param mixed $property
+ */
+function allPropertyNotExists(iterable $classOrObject, $property): iterable
+{
+    Assert::allPropertyNotExists($classOrObject, $property);
+
+    return $classOrObject;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<class-string|object|null> $classOrObject
+ * @param mixed $property
+ */
+function allNullOrPropertyNotExists(iterable $classOrObject, $property): iterable
+{
+    Assert::allNullOrPropertyNotExists($classOrObject, $property);
+
+    return $classOrObject;
+}

--- a/tests/static-analysis/non-return/assert-psalm-notRedundant.php
+++ b/tests/static-analysis/non-return/assert-psalm-notRedundant.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @see https://github.com/webmozart/assert/pull/160#issuecomment-564491986
+ * @see https://github.com/vimeo/psalm/commit/4b715cdbffea19a7eab6f72482027d2dd358aab2
+ * @see https://github.com/vimeo/psalm/issues/2456
+ */
+function stringWillNotBeRedundantIfAssertingAndNotUsingEither(mixed $value): string
+{
+    Assert::string($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-psalm-plugin-return-type.php
+++ b/tests/static-analysis/non-return/assert-psalm-plugin-return-type.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @return numeric
+ */
+function returnedNumeric(mixed $value): int|float|string
+{
+    Assert::numeric($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return numeric
+ */
+function returnedIntegerish(mixed $value): int|float|string
+{
+    Assert::integerish($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-psalm-preserveContainerType.php
+++ b/tests/static-analysis/non-return/assert-psalm-preserveContainerType.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use ArrayIterator;
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @param mixed[] $value
+ *
+ * @return string[]
+ */
+function preserveContainerAllArray(mixed $value): iterable
+{
+    Assert::allString($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param ArrayIterator<string, mixed> $value
+ *
+ * @return ArrayIterator<string, string>
+ */
+function preserveContainerAllArrayIterator(mixed $value)
+{
+    Assert::allString($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-psalm-preserveStringType.php
+++ b/tests/static-analysis/non-return/assert-psalm-preserveStringType.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @param non-empty-string $value
+ *
+ * @return non-empty-string
+ */
+function lowerPreservesTypes(string $value): string
+{
+    Assert::lower($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-range.php
+++ b/tests/static-analysis/non-return/assert-range.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ * @param mixed $min
+ * @param mixed $max
+ */
+function range(mixed $value, $min, $max): mixed
+{
+    Assert::range($value, $min, $max);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ * @param mixed $min
+ * @param mixed $max
+ */
+function nullOrRange(mixed $value, $min, $max): mixed
+{
+    Assert::nullOrRange($value, $min, $max);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ * @param mixed $min
+ * @param mixed $max
+ */
+function allRange(mixed $value, $min, $max): mixed
+{
+    Assert::allRange($value, $min, $max);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ * @param mixed $min
+ * @param mixed $max
+ */
+function allNullOrRange(mixed $value, $min, $max): mixed
+{
+    Assert::allNullOrRange($value, $min, $max);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-readable.php
+++ b/tests/static-analysis/non-return/assert-readable.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+function readable(string $value): string
+{
+    Assert::readable($value);
+
+    return $value;
+}
+
+function nullOrReadable(?string $value): ?string
+{
+    Assert::nullOrReadable($value);
+
+    return $value;
+}
+
+/**
+ * @param iterable<string> $value
+ */
+function allReadable(iterable $value): iterable
+{
+    Assert::allReadable($value);
+
+    return $value;
+}
+
+/**
+ * @param iterable<string|null> $value
+ */
+function allNullOrReadable(iterable $value): iterable
+{
+    Assert::allNullOrReadable($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-regex.php
+++ b/tests/static-analysis/non-return/assert-regex.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function regex(string $value, string $pattern): string
+{
+    Assert::regex($value, $pattern);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrRegex(?string $value, string $pattern): ?string
+{
+    Assert::nullOrRegex($value, $pattern);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string> $value
+ */
+function allRegex(iterable $value, string $pattern): iterable
+{
+    Assert::allRegex($value, $pattern);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ */
+function allNullOrRegex(iterable $value, string $pattern): iterable
+{
+    Assert::allRegex($value, $pattern);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-resource.php
+++ b/tests/static-analysis/non-return/assert-resource.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ * @param null|string $type
+ */
+function resource(mixed $value, ?string $type): mixed
+{
+    Assert::resource($value, $type);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ * @param null|string $type
+ */
+function nullOrResource(mixed $value, ?string $type): mixed
+{
+    Assert::nullOrResource($value, $type);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ * @param null|string $type
+ */
+function allResource(mixed $value, $type): iterable
+{
+    Assert::allResource($value, $type);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ * @param null|string $type
+ */
+function allNullOrResource(mixed $value, $type): iterable
+{
+    Assert::allNullOrResource($value, $type);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-same.php
+++ b/tests/static-analysis/non-return/assert-same.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ * @param mixed $expect
+ */
+function same(mixed $value, $expect): mixed
+{
+    Assert::same($value, $expect);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ * @param mixed $expect
+ */
+function nullOrSame(mixed $value, $expect): mixed
+{
+    Assert::nullOrSame($value, $expect);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ * @param mixed $expect
+ */
+function allSame(mixed $value, $expect): mixed
+{
+    Assert::allSame($value, $expect);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ * @param mixed $expect
+ */
+function allNullOrSame(mixed $value, $expect): mixed
+{
+    Assert::allNullOrSame($value, $expect);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-scalar.php
+++ b/tests/static-analysis/non-return/assert-scalar.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function scalar(mixed $value): int|float|string|bool
+{
+    Assert::scalar($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrScalar(mixed $value): int|float|string|bool|null
+{
+    Assert::nullOrScalar($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allScalar(mixed $value): iterable
+{
+    Assert::allScalar($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrScalar(mixed $value): iterable
+{
+    Assert::allNullOrScalar($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-startsWith.php
+++ b/tests/static-analysis/non-return/assert-startsWith.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function startsWith(string $value, string $prefix): string
+{
+    Assert::startsWith($value, $prefix);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrStartsWith(?string $value, string $prefix): ?string
+{
+    Assert::nullOrStartsWith($value, $prefix);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string> $value
+ */
+function allStartsWith(iterable $value, string $prefix): iterable
+{
+    Assert::allStartsWith($value, $prefix);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ */
+function allNullOrStartsWith(iterable $value, string $prefix): iterable
+{
+    Assert::allNullOrStartsWith($value, $prefix);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-startsWithLetter.php
+++ b/tests/static-analysis/non-return/assert-startsWithLetter.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function startsWithLetter(mixed $value, string $prefix): mixed
+{
+    Assert::startsWithLetter($value, $prefix);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrStartsWithLetter(mixed $value, string $prefix): mixed
+{
+    Assert::nullOrStartsWithLetter($value, $prefix);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allStartsWithLetter(mixed $value, string $prefix): mixed
+{
+    Assert::allStartsWithLetter($value, $prefix);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrStartsWithLetter(mixed $value, string $prefix): mixed
+{
+    Assert::allNullOrStartsWithLetter($value, $prefix);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-string.php
+++ b/tests/static-analysis/non-return/assert-string.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function string(mixed $value): string
+{
+    Assert::string($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrString(mixed $value): ?string
+{
+    Assert::nullOrString($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allString(mixed $value): iterable
+{
+    Assert::allString($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrString(mixed $value): iterable
+{
+    Assert::allNullOrString($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-stringNotEmpty.php
+++ b/tests/static-analysis/non-return/assert-stringNotEmpty.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @return non-empty-string
+ */
+function stringNotEmpty(mixed $value): string
+{
+    Assert::stringNotEmpty($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return null|non-empty-string
+ */
+function nullOrStringNotEmpty(mixed $value): ?string
+{
+    Assert::nullOrStringNotEmpty($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allStringNotEmpty(mixed $value): iterable
+{
+    Assert::allStringNotEmpty($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrStringNotEmpty(mixed $value): iterable
+{
+    Assert::allNullOrStringNotEmpty($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-subclassOf.php
+++ b/tests/static-analysis/non-return/assert-subclassOf.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use stdClass;
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @return class-string<stdClass>|stdClass
+ */
+function subclassOf(mixed $value)
+{
+    Assert::subclassOf($value, stdClass::class);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return null|class-string<stdClass>|stdClass
+ */
+function nullOrSubclassOf(mixed $value)
+{
+    Assert::nullOrSubclassOf($value, stdClass::class);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allSubclassOf(mixed $value): iterable
+{
+    Assert::allSubclassOf($value, stdClass::class);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrSubclassOf(mixed $value): iterable
+{
+    Assert::allNullOrSubclassOf($value, stdClass::class);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-throws.php
+++ b/tests/static-analysis/non-return/assert-throws.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Closure;
+use Throwable;
+use Webmozart\Assert\Assert;
+
+/**
+ * @param class-string<Throwable> $class
+ */
+function throws(Closure $value, $class): Closure
+{
+    Assert::throws($value, $class);
+
+    return $value;
+}
+
+/**
+ * @param class-string<Throwable> $class
+ */
+function nullOrThrows(?Closure $value, $class): ?Closure
+{
+    Assert::nullOrThrows($value, $class);
+
+    return $value;
+}
+
+/**
+ * @param iterable<Closure> $value
+ * @param class-string<Throwable> $class
+ */
+function allThrows(iterable $value, $class): iterable
+{
+    Assert::allThrows($value, $class);
+
+    return $value;
+}
+/**
+ * @param iterable<Closure|null> $value
+ * @param class-string<Throwable> $class
+ */
+function allNullOrThrows(iterable $value, $class): iterable
+{
+    Assert::allNullOrThrows($value, $class);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-true.php
+++ b/tests/static-analysis/non-return/assert-true.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @return true
+ */
+function true(mixed $value): bool
+{
+    Assert::true($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return null|true
+ */
+function nullOrTrue(mixed $value): ?bool
+{
+    Assert::nullOrTrue($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allTrue(mixed $value): iterable
+{
+    Assert::allTrue($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrTrue(mixed $value): iterable
+{
+    Assert::allNullOrTrue($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-unicodeLetters.php
+++ b/tests/static-analysis/non-return/assert-unicodeLetters.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function unicodeLetters(mixed $value): mixed
+{
+    Assert::unicodeLetters($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrUnicodeLetters(mixed $value): mixed
+{
+    Assert::nullOrUnicodeLetters($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allUnicodeLetters(mixed $value): mixed
+{
+    Assert::allUnicodeLetters($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrUnicodeLetters(mixed $value): mixed
+{
+    Assert::allNullOrUnicodeLetters($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-uniqueValues.php
+++ b/tests/static-analysis/non-return/assert-uniqueValues.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+function uniqueValues(mixed $values): array
+{
+    Assert::uniqueValues($values);
+
+    return $values;
+}
+
+function nullOrUniqueValues(mixed $values): ?array
+{
+    Assert::nullOrUniqueValues($values);
+
+    return $values;
+}
+
+/**
+ * @return iterable<array>
+ */
+function allUniqueValues(iterable $values): iterable
+{
+    Assert::allUniqueValues($values);
+
+    return $values;
+}
+
+/**
+ * @return iterable<array|null>
+ */
+function allNullOrUniqueValues(iterable $values): iterable
+{
+    Assert::allNullOrUniqueValues($values);
+
+    return $values;
+}

--- a/tests/static-analysis/non-return/assert-upper.php
+++ b/tests/static-analysis/non-return/assert-upper.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function upper(mixed $value): string
+{
+    Assert::upper($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrUpper(?string $value): ?string
+{
+    Assert::nullOrUpper($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string> $value
+ */
+function allUpper(iterable $value): iterable
+{
+    Assert::allUpper($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ */
+function allNullOrUpper(iterable $value): iterable
+{
+    Assert::allNullOrUpper($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-uuid.php
+++ b/tests/static-analysis/non-return/assert-uuid.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ */
+function uuid(string $value): string
+{
+    Assert::uuid($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function nullOrUuid(?string $value): ?string
+{
+    Assert::nullOrUuid($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string> $value
+ */
+function allUuid(iterable $value): iterable
+{
+    Assert::allUuid($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @param iterable<string|null> $value
+ */
+function allNullOrUuid(iterable $value): iterable
+{
+    Assert::allNullOrUuid($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-validArrayKey.php
+++ b/tests/static-analysis/non-return/assert-validArrayKey.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @psalm-pure
+ *
+ * @return array-key
+ */
+function validArrayKey(mixed $value)
+{
+    Assert::validArrayKey($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ *
+ * @return null|array-key
+ */
+function nullOrValidArrayKey(mixed $value)
+{
+    Assert::nullOrValidArrayKey($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allValidArrayKey(mixed $value): iterable
+{
+    Assert::allValidArrayKey($value);
+
+    return $value;
+}
+
+/**
+ * @psalm-pure
+ */
+function allNullOrValidArrayKey(mixed $value): iterable
+{
+    Assert::allNullOrValidArrayKey($value);
+
+    return $value;
+}

--- a/tests/static-analysis/non-return/assert-writable.php
+++ b/tests/static-analysis/non-return/assert-writable.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webmozart\Assert\Tests\StaticAnalysis\NonReturn;
+
+use Webmozart\Assert\Assert;
+
+function writable(string $value): string
+{
+    Assert::writable($value);
+
+    return $value;
+}
+
+function nullOrWritable(?string $value): ?string
+{
+    Assert::nullOrWritable($value);
+
+    return $value;
+}
+
+/**
+ * @param iterable<string> $value
+ */
+function allWritable(iterable $value): iterable
+{
+    Assert::allWritable($value);
+
+    return $value;
+}
+
+/**
+ * @param iterable<string|null> $value
+ */
+function allNullOrWritable(iterable $value): iterable
+{
+    Assert::allNullOrWritable($value);
+
+    return $value;
+}


### PR DESCRIPTION
There should really be a psalm extension for this, I'll likely either contribute it or come up with some way to express the same inside of Psalm itself, as many of the assertions used here cannot be used as standalone types.