### PR TITLE
Fix PHPDoc generics for isInstanceOfAny

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -592,7 +592,8 @@ class Assert
      *
      * @psalm-assert T $value
      *
-     * @param T $value
+     * @param mixed $value
+     * @param iterable<class-string<T>> $classes
      * @param string|callable():string $message
      *
      * @return T

--- a/src/Mixin.php
+++ b/src/Mixin.php
@@ -1398,8 +1398,9 @@ trait Mixin
      * @template T of object
      * @psalm-assert T|null $value
      *
-     * @param T|null                   $value
-     * @param string|callable():string $message
+     * @param mixed                     $value
+     * @param iterable<class-string<T>> $classes
+     * @param string|callable():string  $message
      *
      * @return T|null
      *
@@ -1416,8 +1417,9 @@ trait Mixin
      * @template T of object
      * @psalm-assert iterable<T> $value
      *
-     * @param iterable<T>              $value
-     * @param string|callable():string $message
+     * @param mixed                     $value
+     * @param iterable<class-string<T>> $classes
+     * @param string|callable():string  $message
      *
      * @return iterable<T>
      *
@@ -1438,8 +1440,9 @@ trait Mixin
      * @template T of object
      * @psalm-assert iterable<T|null> $value
      *
-     * @param iterable<T|null>         $value
-     * @param string|callable():string $message
+     * @param mixed                     $value
+     * @param iterable<class-string<T>> $classes
+     * @param string|callable():string  $message
      *
      * @return iterable<T|null>
      *


### PR DESCRIPTION
Originally, the method used `@param T $value`, which already implied the asserted type and therefore did not provide any type narrowing through `@psalm-assert`. By changing the parameter type to `mixed` and typing `$classes` param, static analyzers can now correctly understand and infer the asserted object type.

Original behavior - https://phpstan.org/r/7f96122b-fa81-4578-a4df-04aaa9154cd3
After the fix - https://phpstan.org/r/2cac2398-0028-4e34-9aa1-71250f5cc888